### PR TITLE
Add FX pair administration components

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,6 +6,11 @@ export const routes: Routes = [
     loadChildren: () =>
       import('./fx/currency/currency.module').then(m => m.CurrencyModule)
   },
+  {
+    path: 'pairs',
+    loadChildren: () =>
+      import('./fx/pair/pair.module').then(m => m.PairModule)
+  },
   { path: '', redirectTo: 'currencies', pathMatch: 'full' },
   { path: '**', redirectTo: 'currencies' }
 ];

--- a/frontend/src/app/fx/pair/models/pair-update.model.ts
+++ b/frontend/src/app/fx/pair/models/pair-update.model.ts
@@ -1,0 +1,4 @@
+/** DTO для обновления валютной пары аналогичный backend */
+export interface PairUpdateDto {
+  decimal: number;
+}

--- a/frontend/src/app/fx/pair/models/pair.model.ts
+++ b/frontend/src/app/fx/pair/models/pair.model.ts
@@ -1,0 +1,7 @@
+/** DTO для валютной пары аналогичный backend */
+export interface PairDto {
+  code1: string;
+  code2: string;
+  pair: string;
+  decimal: number;
+}

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
@@ -1,0 +1,137 @@
+<div class="center-box">
+
+  <h1 class="mat-headline-4">Pair administration</h1>
+
+  <!-- карточка с формой добавления -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Pair Toolbar</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <form [formGroup]="form" class="toolbar">
+
+        <mat-form-field appearance="outline">
+          <mat-label>Pair</mat-label>
+          <input
+            matInput
+            formControlName="pair"
+            maxlength="6"
+          />
+          <mat-error *ngIf="this.form.controls['pair'].hasError('required')">
+            Is required
+          </mat-error>
+          <mat-error *ngIf="this.form.controls['pair'].hasError('pattern')">
+            Six letters A-Z
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Code 1</mat-label>
+          <input
+            matInput
+            formControlName="code1"
+            maxlength="3"
+          />
+          <mat-error *ngIf="form.controls['code1'].hasError('required')">
+            Is required
+          </mat-error>
+          <mat-error *ngIf="form.controls['code1'].hasError('pattern')">
+            Three letters A-Z
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Code 2</mat-label>
+          <input
+            matInput
+            formControlName="code2"
+            maxlength="3"
+          />
+          <mat-error *ngIf="form.controls['code2'].hasError('required')">
+            Is required
+          </mat-error>
+          <mat-error *ngIf="form.controls['code2'].hasError('pattern')">
+            Three letters A-Z
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Decimal</mat-label>
+          <input
+            matInput
+            type="number"
+            formControlName="decimal"
+          />
+          <mat-error *ngIf="form.controls['decimal'].hasError('required')">
+            Is required
+          </mat-error>
+          <mat-error *ngIf="form.controls['decimal'].hasError('min')
+               || form.controls['decimal'].hasError('max')">
+            0 – 10 allowed
+          </mat-error>
+        </mat-form-field>
+
+        <ng-container *ngIf="!editing; else editButtons">
+          <button mat-raised-button
+                  type="button"
+                  (click)="onAdd()" [disabled]="form.invalid || locked"> Add
+          </button>
+        </ng-container>
+        <ng-template #editButtons>
+          <button mat-raised-button color="primary"
+                  type="button"
+                  (click)="onSave()" [disabled]="form.invalid || locked"> Save
+          </button>
+          <button mat-raised-button type="button" (click)="cancelEdit()">Cancel</button>
+        </ng-template>
+      </form>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- карточка со списком пар -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Pair List</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
+
+        <ng-container matColumnDef="pair">
+          <th mat-header-cell *matHeaderCellDef> Pair</th>
+          <td mat-cell *matCellDef="let p"> {{ p.pair }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="code1">
+          <th mat-header-cell *matHeaderCellDef> Code 1</th>
+          <td mat-cell *matCellDef="let p"> {{ p.code1 }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="code2">
+          <th mat-header-cell *matHeaderCellDef> Code 2</th>
+          <td mat-cell *matCellDef="let p"> {{ p.code2 }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="decimal">
+          <th mat-header-cell *matHeaderCellDef> Decimal</th>
+          <td mat-cell *matCellDef="let p"> {{ p.decimal }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let p">
+            <button mat-icon-button color="primary" (click)="onEdit(p)">
+              <mat-icon>edit</mat-icon>
+            </button>
+            <button mat-icon-button color="warn" (click)="onDelete(p.pair)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+      </table>
+    </mat-card-content>
+  </mat-card>
+
+</div>

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.scss
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.scss
@@ -1,0 +1,17 @@
+/* центрируем контент и даём одинаковый зазор между карточками */
+.center-box {
+  max-width: 960px;
+  margin: 32px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 0 16px;
+}
+
+/* выстроить поля и кнопку в одну линию, с равными промежутками и переносом на новую строку */
+.toolbar {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 16px;
+  align-items: flex-end;
+}

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.spec.ts
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PairAdminComponent } from './pair-admin.component';
+
+describe('PairAdminComponent', () => {
+  let component: PairAdminComponent;
+  let fixture: ComponentFixture<PairAdminComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PairAdminComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PairAdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
@@ -1,0 +1,200 @@
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatTableDataSource, MatTableModule} from '@angular/material/table';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatCardModule} from '@angular/material/card';
+import {PairDto} from '../../models/pair.model';
+import {PairService} from '../../services/pair.service';
+import {PairUpdateDto} from '../../models/pair-update.model';
+
+@Component({
+  selector: 'app-pair-admin',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    MatCardModule
+  ],
+  templateUrl: './pair-admin.component.html',
+  styleUrl: './pair-admin.component.scss'
+})
+export class PairAdminComponent implements OnInit {
+
+  //=================
+  // Табличные данные
+  //=================
+  displayed: string[] = ['pair', 'code1', 'code2', 'decimal', 'actions'];
+  dataSource  = new MatTableDataSource<PairDto>([]);
+
+  //==============================
+  // Форма добавления валютной пары
+  //==============================
+  form: FormGroup;
+
+  locked = false; // флаг блокировки кнопки Add
+  editing = false; // режим редактирования
+  editPair: string | null = null; // код пары для редактирования
+
+  constructor(
+    private readonly service: PairService,
+    private readonly fb: FormBuilder,
+    private readonly snack: MatSnackBar
+  ) {
+    this.form = this.fb.group({
+      pair: [
+        '',
+        [
+          Validators.required,
+          Validators.pattern(/^[A-Z]{6}$/)
+        ]
+      ],
+
+      code1: [
+        '',
+        [
+          Validators.required,
+          Validators.pattern(/^[A-Z]{3}$/)
+        ]
+      ],
+
+      code2: [
+        '',
+        [
+          Validators.required,
+          Validators.pattern(/^[A-Z]{3}$/)
+        ]
+      ],
+
+      decimal: [
+        2,
+        [
+          Validators.required,
+          Validators.min(0),
+          Validators.max(10)
+        ]
+      ]
+    });
+  }
+
+  //=======================
+  // Активность на странице
+  //=======================
+
+  /* загрузка списка при открытии страницы */
+  ngOnInit(): void {
+    this.refresh();
+  }
+
+  /* нажата кнопка Add */
+  onAdd(): void {
+    if (this.form.invalid || this.locked) { return; }
+
+    this.locked = true; // блокируем кнопку
+
+    const dto: PairDto = this.form.value;
+
+    this.service.add(dto).subscribe({
+      next: pair => {
+        // Если все ОК
+        this.snack.open(
+          `Pair '${pair}' added`, 'OK', { duration: 2500 }
+        );
+        this.refresh();
+        this.form.reset({ decimal: 2 });
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Add failed';
+        const ref =
+          this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => this.locked = false);
+      }
+    });
+  }
+
+  /* клик по иконке Edit */
+  onEdit(p: PairDto): void {
+    this.editing = true;
+    this.editPair = p.pair;
+    this.form.setValue({
+      pair: p.pair,
+      code1: p.code1,
+      code2: p.code2,
+      decimal: p.decimal
+    });
+    this.form.controls['pair'].disable();
+    this.form.controls['code1'].disable();
+    this.form.controls['code2'].disable();
+  }
+
+  /* нажата кнопка Save */
+  onSave(): void {
+    if (this.form.invalid || this.locked || !this.editPair) { return; }
+
+    this.locked = true;
+
+    const dto: PairUpdateDto = {
+      decimal: this.form.controls['decimal'].value
+    } as PairUpdateDto;
+
+    this.service.update(this.editPair, dto).subscribe({
+      next: () => {
+        this.snack.open(`Pair '${this.editPair}' updated`, 'OK', { duration: 2500 });
+        this.refresh();
+        this.cancelEdit();
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Update failed';
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => this.locked = false);
+      }
+    });
+  }
+
+  /* нажата кнопка Cancel */
+  cancelEdit(): void {
+    this.editing = false;
+    this.editPair = null;
+    this.form.reset({ pair: '', code1: '', code2: '', decimal: 2 });
+    this.form.controls['pair'].enable();
+    this.form.controls['code1'].enable();
+    this.form.controls['code2'].enable();
+    this.locked = false;
+  }
+
+  /* клик по иконке Delete */
+  onDelete(pair: string): void {
+    this.service.delete(pair).subscribe({
+      next: () => {
+        this.snack.open(`Pair '${pair}' deleted`, 'OK', { duration: 2500 });
+        this.refresh();
+      },
+      error: err =>
+        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close')
+    });
+  }
+
+  //========================
+  // Вспомогательные утилиты
+  //========================
+  /* утилита: перезагрузить список */
+  private refresh(): void {
+    this.service.list().subscribe({
+      next: list => this.dataSource.data = list,
+      error: err => this.snack.open(err.message ?? 'Load failed', 'Close')
+    });
+  }
+
+}

--- a/frontend/src/app/fx/pair/pair-routing.module.ts
+++ b/frontend/src/app/fx/pair/pair-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/pair-admin/pair-admin.component')
+        .then(c => c.PairAdminComponent)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PairRoutingModule { }

--- a/frontend/src/app/fx/pair/pair.module.ts
+++ b/frontend/src/app/fx/pair/pair.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { PairRoutingModule } from './pair-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    PairRoutingModule,
+  ]
+})
+export class PairModule { }

--- a/frontend/src/app/fx/pair/services/pair.service.spec.ts
+++ b/frontend/src/app/fx/pair/services/pair.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PairService } from './pair.service';
+
+describe('PairService', () => {
+  let service: PairService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PairService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/fx/pair/services/pair.service.ts
+++ b/frontend/src/app/fx/pair/services/pair.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/api-response.model';
+import { PairDto } from '../models/pair.model';
+import { PairUpdateDto } from '../models/pair-update.model';
+
+/* Сервис для взаимодействия с API по работе с валютными парами */
+@Injectable({
+  providedIn: 'root'
+})
+export class PairService {
+
+  constructor(private http: HttpClient) { }
+
+  /* Базовый URL (через proxy уйдёт на Spring) */
+  private readonly baseUrl = '/api/v1/pairs';
+
+  /* Получить список всех валютных пар */
+  list(): Observable<PairDto[]> {
+    return this.http
+      .get<ApiResponse<PairDto[]>>(this.baseUrl)
+      .pipe(map(res => res.data));
+  }
+
+  /* Добавить валютную пару, backend вернёт её pair */
+  add(dto: PairDto): Observable<string> {
+    return this.http
+      .post<ApiResponse<string>>(this.baseUrl, dto)
+      .pipe(map(res => res.data));
+  }
+
+  /* Удалить валютную пару по коду pair */
+  delete(pair: string): Observable<void> {
+    return this.http
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}`)
+      .pipe(map(res => res.data));
+  }
+
+  /* Обновить валютную пару по коду pair */
+  update(pair: string, dto: PairUpdateDto): Observable<void> {
+    return this.http
+      .put<ApiResponse<void>>(`${this.baseUrl}/${pair}`, dto)
+      .pipe(map(res => res.data));
+  }
+}


### PR DESCRIPTION
## Summary
- implement Pair feature similar to Currency
- create `PairService`, DTO models, lazy module and routing
- build standalone `PairAdminComponent` with html and styles
- register pair module in app routes

## Testing
- `npm --prefix frontend test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbd958570832db9a1067781fd2d42