### PR TITLE
Auto generate pair

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/dto/PairCreateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/dto/PairCreateDto.java
@@ -2,8 +2,8 @@ package com.alligator.market.backend.fx.pairs.dto;
 
 import jakarta.validation.constraints.*;
 
-/* DTO для представления валютной пары. */
-public record PairDto(
+/* DTO для создания валютной пары. */
+public record PairCreateDto(
 
         @NotBlank
         @Pattern(regexp = "^[A-Z]{3}$")
@@ -12,10 +12,6 @@ public record PairDto(
         @NotBlank
         @Pattern(regexp = "^[A-Z]{3}$")
         String code2,
-
-        @NotBlank
-        @Pattern(regexp = "^[A-Z]{6}$")
-        String pair,
 
         @NotNull
         @Min(0) @Max(10)

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/PairService.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/PairService.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.fx.pairs.service;
 
 import com.alligator.market.backend.fx.pairs.dto.PairDto;
+import com.alligator.market.backend.fx.pairs.dto.PairCreateDto;
 import com.alligator.market.backend.fx.pairs.dto.PairUpdateDto;
 
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.List;
 /* Интерфейс сервиса для операций с валютными парами. */
 public interface PairService {
 
-    String createPair(PairDto dto);
+    String createPair(PairCreateDto dto);
 
     void updatePair(String pair, PairUpdateDto dto);
 

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/PairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/PairServiceImpl.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.fx.pairs.service;
 
 import com.alligator.market.backend.fx.pairs.dto.PairDto;
+import com.alligator.market.backend.fx.pairs.dto.PairCreateDto;
 import com.alligator.market.backend.fx.pairs.dto.PairUpdateDto;
 import com.alligator.market.backend.fx.pairs.entity.Pair;
 import com.alligator.market.backend.fx.pairs.repository.PairRepository;
@@ -27,16 +28,18 @@ public class PairServiceImpl implements PairService {
     // Создать новую пару
     //=====================
     @Override
-    public String createPair(PairDto dto) {
+    public String createPair(PairCreateDto dto) {
 
-        repository.findByPair(dto.pair()).ifPresent(p -> {
-            throw new DuplicatePairException(dto.pair());
+        String pair = dto.code1() + dto.code2();
+
+        repository.findByPair(pair).ifPresent(p -> {
+            throw new DuplicatePairException(pair);
         });
 
         Pair entity = new Pair();
         entity.setCode1(dto.code1());
         entity.setCode2(dto.code2());
-        entity.setPair(dto.pair());
+        entity.setPair(pair);
         entity.setDecimal(dto.decimal());
 
         Pair saved = repository.save(entity);

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/web/PairController.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/web/PairController.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.fx.pairs.web;
 import com.alligator.market.backend.common.web.dto.ApiResponse;
 import com.alligator.market.backend.common.web.util.ResponseEntityFactory;
 import com.alligator.market.backend.fx.pairs.dto.PairDto;
+import com.alligator.market.backend.fx.pairs.dto.PairCreateDto;
 import com.alligator.market.backend.fx.pairs.dto.PairUpdateDto;
 import com.alligator.market.backend.fx.pairs.service.PairService;
 import jakarta.validation.Valid;
@@ -28,7 +29,7 @@ public class PairController {
     // Создать новую пару
     //=====================
     @PostMapping
-    public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid PairDto dto) {
+    public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid PairCreateDto dto) {
 
         String pair = service.createPair(dto);
         URI location = ServletUriComponentsBuilder

--- a/frontend/src/app/fx/pair/models/pair-create.model.ts
+++ b/frontend/src/app/fx/pair/models/pair-create.model.ts
@@ -1,0 +1,6 @@
+/** DTO для создания валютной пары аналогичный backend */
+export interface PairCreateDto {
+  code1: string;
+  code2: string;
+  decimal: number;
+}

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
@@ -10,20 +10,6 @@
     <mat-card-content>
       <form [formGroup]="form" class="toolbar">
 
-        <mat-form-field appearance="outline">
-          <mat-label>Pair</mat-label>
-          <input
-            matInput
-            formControlName="pair"
-            maxlength="6"
-          />
-          <mat-error *ngIf="this.form.controls['pair'].hasError('required')">
-            Is required
-          </mat-error>
-          <mat-error *ngIf="this.form.controls['pair'].hasError('pattern')">
-            Six letters A-Z
-          </mat-error>
-        </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Code 1</mat-label>

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
@@ -9,6 +9,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatCardModule} from '@angular/material/card';
 import {PairDto} from '../../models/pair.model';
+import {PairCreateDto} from '../../models/pair-create.model';
 import {PairService} from '../../services/pair.service';
 import {PairUpdateDto} from '../../models/pair-update.model';
 
@@ -52,14 +53,6 @@ export class PairAdminComponent implements OnInit {
     private readonly snack: MatSnackBar
   ) {
     this.form = this.fb.group({
-      pair: [
-        '',
-        [
-          Validators.required,
-          Validators.pattern(/^[A-Z]{6}$/)
-        ]
-      ],
-
       code1: [
         '',
         [
@@ -102,7 +95,7 @@ export class PairAdminComponent implements OnInit {
 
     this.locked = true; // блокируем кнопку
 
-    const dto: PairDto = this.form.value;
+    const dto: PairCreateDto = this.form.value;
 
     this.service.add(dto).subscribe({
       next: pair => {
@@ -128,12 +121,10 @@ export class PairAdminComponent implements OnInit {
     this.editing = true;
     this.editPair = p.pair;
     this.form.setValue({
-      pair: p.pair,
       code1: p.code1,
       code2: p.code2,
       decimal: p.decimal
     });
-    this.form.controls['pair'].disable();
     this.form.controls['code1'].disable();
     this.form.controls['code2'].disable();
   }
@@ -167,8 +158,7 @@ export class PairAdminComponent implements OnInit {
   cancelEdit(): void {
     this.editing = false;
     this.editPair = null;
-    this.form.reset({ pair: '', code1: '', code2: '', decimal: 2 });
-    this.form.controls['pair'].enable();
+    this.form.reset({ code1: '', code2: '', decimal: 2 });
     this.form.controls['code1'].enable();
     this.form.controls['code2'].enable();
     this.locked = false;

--- a/frontend/src/app/fx/pair/services/pair.service.ts
+++ b/frontend/src/app/fx/pair/services/pair.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiResponse } from '../../../shared/api-response.model';
 import { PairDto } from '../models/pair.model';
+import { PairCreateDto } from '../models/pair-create.model';
 import { PairUpdateDto } from '../models/pair-update.model';
 
 /* Сервис для взаимодействия с API по работе с валютными парами */
@@ -24,7 +25,7 @@ export class PairService {
   }
 
   /* Добавить валютную пару, backend вернёт её pair */
-  add(dto: PairDto): Observable<string> {
+  add(dto: PairCreateDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
       .pipe(map(res => res.data));


### PR DESCRIPTION
## Summary
- add PairCreateDto to backend
- compute currency pair in service implementation
- update PairService and controller
- adjust Angular frontend to set only codes and decimal
- remove pair input from toolbar

## Testing
- `sh ./backend/mvnw -q -f backend/pom.xml test` *(fails: wget failed to fetch maven)*
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cc53d0dc8832d92e96f2dbc3cfe1c