### PR TITLE
Fix toolbar sticky class for admin pages

### DIFF
--- a/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.html
+++ b/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.html
@@ -3,7 +3,7 @@
   <h1 class="mat-headline-4">Currencies Administration</h1>
 
   <!-- карточка с формой добавления -->
-  <mat-card>
+  <mat-card class="toolbar-card">
     <mat-card-header>
       <mat-card-title>Currency Toolbar</mat-card-title>
     </mat-card-header>

--- a/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.scss
+++ b/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.scss
@@ -15,3 +15,11 @@
   gap: 16px;
   align-items: flex-end;
 }
+
+/* фиксация toolbar при прокрутке */
+.toolbar-card {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #fff;
+}

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
@@ -3,7 +3,7 @@
   <h1 class="mat-headline-4">Currency Pairs Administration</h1>
 
   <!-- карточка с формой добавления -->
-  <mat-card>
+  <mat-card class="toolbar-card">
     <mat-card-header>
       <mat-card-title>Currency Pair Toolbar</mat-card-title>
     </mat-card-header>

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.scss
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.scss
@@ -15,3 +15,11 @@
   gap: 16px;
   align-items: flex-end;
 }
+
+/* фиксация toolbar при прокрутке */
+.toolbar-card {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #fff;
+}


### PR DESCRIPTION
## Summary
- keep toolbar on screen by adding `toolbar-card` class
- add sticky styles in currency and pair admin SCSS

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683df86ca284832daf302c0376583a61