### PR TITLE
Add currency FK and update pair UI

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/fx/currency/service/CurrencyServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/currency/service/CurrencyServiceImpl.java
@@ -4,8 +4,10 @@ import com.alligator.market.backend.fx.currency.dto.CurrencyDto;
 import com.alligator.market.backend.fx.currency.dto.CurrencyUpdateDto;
 import com.alligator.market.backend.fx.currency.entity.Currency;
 import com.alligator.market.backend.fx.currency.repository.CurrencyRepository;
+import com.alligator.market.backend.fx.pairs.repository.PairRepository;
 import com.alligator.market.backend.fx.currency.service.exceptions.CurrencyNotFoundException;
 import com.alligator.market.backend.fx.currency.service.exceptions.DuplicateCurrencyException;
+import com.alligator.market.backend.fx.currency.service.exceptions.CurrencyUsedInPairsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
@@ -22,6 +24,7 @@ import java.util.List;
 public class CurrencyServiceImpl implements CurrencyService {
 
     private final CurrencyRepository repository;
+    private final PairRepository pairRepository;
 
     //=====================
     // Создать новую валюту
@@ -86,6 +89,10 @@ public class CurrencyServiceImpl implements CurrencyService {
 
         Currency currency = repository.findByCode(code)
                 .orElseThrow(() -> new CurrencyNotFoundException(code));
+
+        if (pairRepository.existsByCode1_CodeOrCode2_Code(code, code)) {
+            throw new CurrencyUsedInPairsException(code);
+        }
 
         repository.delete(currency);
         log.info("Currency {} deleted (id={})", currency.getCode(), currency.getId());

--- a/backend/src/main/java/com/alligator/market/backend/fx/currency/service/exceptions/CurrencyUsedInPairsException.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/currency/service/exceptions/CurrencyUsedInPairsException.java
@@ -1,0 +1,8 @@
+package com.alligator.market.backend.fx.currency.service.exceptions;
+
+/** Нельзя удалить валюту, если она используется в валютных парах. */
+public class CurrencyUsedInPairsException extends RuntimeException {
+    public CurrencyUsedInPairsException(String code) {
+        super("Currency '%s' used in pairs".formatted(code));
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/fx/currency/web/CurrencyRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/currency/web/CurrencyRestExceptionHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.common.web.dto.ApiResponse;
 import com.alligator.market.backend.common.web.util.ResponseEntityFactory;
 import com.alligator.market.backend.fx.currency.service.exceptions.CurrencyNotFoundException;
 import com.alligator.market.backend.fx.currency.service.exceptions.DuplicateCurrencyException;
+import com.alligator.market.backend.fx.currency.service.exceptions.CurrencyUsedInPairsException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -35,6 +36,15 @@ public class CurrencyRestExceptionHandler {
 
         log.warn("CurrencyNotFoundException: {}", ex.getMessage());
         return ResponseEntityFactory.notFound(ex.getMessage());
+    }
+
+    /* Валюта используется в валютных парах. */
+    @ExceptionHandler(CurrencyUsedInPairsException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCurrencyUsed(
+            CurrencyUsedInPairsException ex) {
+
+        log.warn("CurrencyUsedInPairsException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.CONFLICT, ex.getMessage());
     }
 
 }

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/entity/Pair.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/entity/Pair.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.fx.pairs.entity;
 
 import com.alligator.market.backend.common.jpa.entity.BaseEntity;
+import com.alligator.market.backend.fx.currency.entity.Currency;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -27,15 +28,17 @@ public class Pair extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /* ISO-4217 код валюты-1 */
-    @Pattern(regexp = "^[A-Z]{3}$")
-    @Column(length = 3, nullable = false)
-    private String code1;
+    /* ISO-4217 код валюты-1 (FK на currency.code) */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "code1", referencedColumnName = "code",
+            foreignKey = @ForeignKey(name = "fk_pair_code1"))
+    private Currency code1;
 
-    /* ISO-4217 код валюты-2 */
-    @Pattern(regexp = "^[A-Z]{3}$")
-    @Column(length = 3, nullable = false)
-    private String code2;
+    /* ISO-4217 код валюты-2 (FK на currency.code) */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "code2", referencedColumnName = "code",
+            foreignKey = @ForeignKey(name = "fk_pair_code2"))
+    private Currency code2;
 
     /* Валютная пара как code1 + code2 */
     @Pattern(regexp = "^[A-Z]{6}$")

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/repository/PairRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/repository/PairRepository.java
@@ -9,5 +9,7 @@ import java.util.Optional;
 public interface PairRepository extends JpaRepository<Pair, Long> {
 
     Optional<Pair> findByPair(String pair);
+
+    boolean existsByCode1_CodeOrCode2_Code(String code1, String code2);
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/PairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/PairServiceImpl.java
@@ -4,9 +4,12 @@ import com.alligator.market.backend.fx.pairs.dto.PairDto;
 import com.alligator.market.backend.fx.pairs.dto.PairCreateDto;
 import com.alligator.market.backend.fx.pairs.dto.PairUpdateDto;
 import com.alligator.market.backend.fx.pairs.entity.Pair;
+import com.alligator.market.backend.fx.currency.repository.CurrencyRepository;
+import com.alligator.market.backend.fx.currency.entity.Currency;
 import com.alligator.market.backend.fx.pairs.repository.PairRepository;
 import com.alligator.market.backend.fx.pairs.service.exceptions.PairNotFoundException;
 import com.alligator.market.backend.fx.pairs.service.exceptions.DuplicatePairException;
+import com.alligator.market.backend.fx.pairs.service.exceptions.PairCurrencyNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
@@ -23,6 +26,7 @@ import java.util.List;
 public class PairServiceImpl implements PairService {
 
     private final PairRepository repository;
+    private final CurrencyRepository currencyRepository;
 
     //=====================
     // Создать новую пару
@@ -36,9 +40,14 @@ public class PairServiceImpl implements PairService {
             throw new DuplicatePairException(pair);
         });
 
+        Currency c1 = currencyRepository.findByCode(dto.code1())
+                .orElseThrow(() -> new PairCurrencyNotFoundException(dto.code1()));
+        Currency c2 = currencyRepository.findByCode(dto.code2())
+                .orElseThrow(() -> new PairCurrencyNotFoundException(dto.code2()));
+
         Pair entity = new Pair();
-        entity.setCode1(dto.code1());
-        entity.setCode2(dto.code2());
+        entity.setCode1(c1);
+        entity.setCode2(c2);
         entity.setPair(pair);
         entity.setDecimal(dto.decimal());
 
@@ -85,8 +94,8 @@ public class PairServiceImpl implements PairService {
         List<PairDto> result = repository.findAll(Sort.by("pair"))
                 .stream()
                 .map(p -> new PairDto(
-                        p.getCode1(),
-                        p.getCode2(),
+                        p.getCode1().getCode(),
+                        p.getCode2().getCode(),
                         p.getPair(),
                         p.getDecimal()
                 ))

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/exceptions/PairCurrencyNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/service/exceptions/PairCurrencyNotFoundException.java
@@ -1,0 +1,8 @@
+package com.alligator.market.backend.fx.pairs.service.exceptions;
+
+/** Валюта для валютной пары не найдена. */
+public class PairCurrencyNotFoundException extends RuntimeException {
+    public PairCurrencyNotFoundException(String code) {
+        super("Currency '%s' not found".formatted(code));
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/fx/pairs/web/PairRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/pairs/web/PairRestExceptionHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.common.web.dto.ApiResponse;
 import com.alligator.market.backend.common.web.util.ResponseEntityFactory;
 import com.alligator.market.backend.fx.pairs.service.exceptions.PairNotFoundException;
 import com.alligator.market.backend.fx.pairs.service.exceptions.DuplicatePairException;
+import com.alligator.market.backend.fx.pairs.service.exceptions.PairCurrencyNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -35,5 +36,14 @@ public class PairRestExceptionHandler {
 
         log.warn("PairNotFoundException: {}", ex.getMessage());
         return ResponseEntityFactory.notFound(ex.getMessage());
+    }
+
+    /* Одна из валют не найдена. */
+    @ExceptionHandler(PairCurrencyNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCurrencyNotFound(
+            PairCurrencyNotFoundException ex) {
+
+        log.warn("PairCurrencyNotFoundException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 }

--- a/backend/src/main/resources/db/migration/V2__pair_init.sql
+++ b/backend/src/main/resources/db/migration/V2__pair_init.sql
@@ -15,3 +15,9 @@ CREATE TABLE ccypair
 
 ALTER TABLE ccypair
     ADD CONSTRAINT uq_currency_pair UNIQUE (pair);
+
+ALTER TABLE ccypair
+    ADD CONSTRAINT fk_pair_code1 FOREIGN KEY (code1) REFERENCES currency (code);
+
+ALTER TABLE ccypair
+    ADD CONSTRAINT fk_pair_code2 FOREIGN KEY (code2) REFERENCES currency (code);

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
@@ -13,31 +13,25 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Base Currency</mat-label>
-          <input
-            matInput
-            formControlName="code1"
-            maxlength="3"
-          />
+          <mat-select formControlName="code1">
+            <mat-option *ngFor="let c of currencies" [value]="c.code">
+              {{ c.code }}
+            </mat-option>
+          </mat-select>
           <mat-error *ngIf="form.controls['code1'].hasError('required')">
             Is required
-          </mat-error>
-          <mat-error *ngIf="form.controls['code1'].hasError('pattern')">
-            Three letters A-Z
           </mat-error>
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Quote Currency</mat-label>
-          <input
-            matInput
-            formControlName="code2"
-            maxlength="3"
-          />
+          <mat-select formControlName="code2">
+            <mat-option *ngFor="let c of currencies" [value]="c.code">
+              {{ c.code }}
+            </mat-option>
+          </mat-select>
           <mat-error *ngIf="form.controls['code2'].hasError('required')">
             Is required
-          </mat-error>
-          <mat-error *ngIf="form.controls['code2'].hasError('pattern')">
-            Three letters A-Z
           </mat-error>
         </mat-form-field>
 

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
@@ -4,6 +4,7 @@ import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import {MatTableDataSource, MatTableModule} from '@angular/material/table';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
@@ -12,6 +13,8 @@ import {PairDto} from '../../models/pair.model';
 import {PairCreateDto} from '../../models/pair-create.model';
 import {PairService} from '../../services/pair.service';
 import {PairUpdateDto} from '../../models/pair-update.model';
+import {CurrencyService} from '../../../currency/services/currency.service';
+import {CurrencyDto} from '../../../currency/models/currency.model';
 
 @Component({
   selector: 'app-pair-admin',
@@ -22,6 +25,7 @@ import {PairUpdateDto} from '../../models/pair-update.model';
     MatTableModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSelectModule,
     MatIconModule,
     MatButtonModule,
     MatSnackBarModule,
@@ -46,27 +50,23 @@ export class PairAdminComponent implements OnInit {
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
   editPair: string | null = null; // код пары для редактирования
+  currencies: CurrencyDto[] = [];
 
   constructor(
     private readonly service: PairService,
     private readonly fb: FormBuilder,
-    private readonly snack: MatSnackBar
+    private readonly snack: MatSnackBar,
+    private readonly currencyService: CurrencyService
   ) {
     this.form = this.fb.group({
       code1: [
         '',
-        [
-          Validators.required,
-          Validators.pattern(/^[A-Z]{3}$/)
-        ]
+        [Validators.required]
       ],
 
       code2: [
         '',
-        [
-          Validators.required,
-          Validators.pattern(/^[A-Z]{3}$/)
-        ]
+        [Validators.required]
       ],
 
       decimal: [
@@ -87,6 +87,10 @@ export class PairAdminComponent implements OnInit {
   /* загрузка списка при открытии страницы */
   ngOnInit(): void {
     this.refresh();
+    this.currencyService.list().subscribe({
+      next: c => this.currencies = c,
+      error: err => this.snack.open(err.message ?? 'Load currencies failed', 'Close')
+    });
   }
 
   /* нажата кнопка Add */


### PR DESCRIPTION
## Summary
- link pairs to currencies via foreign keys
- add service checks for currency usage
- create new business exceptions and handlers
- adjust DB migration for foreign keys
- update frontend form to select existing currencies

## Testing
- `./mvnw -q test` *(fails: mvnw cannot download dependencies)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dfb2c4e00832d8a0aad2646b65047