### PR TITLE
Add home button on pages

### DIFF
--- a/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.html
+++ b/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.html
@@ -2,6 +2,11 @@
 
   <h1 class="mat-headline-4">Currencies Administration</h1>
 
+  <!-- кнопка возврата на домашнюю страницу -->
+  <nav class="links">
+    <a mat-raised-button routerLink="/">Home</a>
+  </nav>
+
   <!-- карточка с формой добавления -->
   <mat-card class="toolbar-card">
     <mat-card-header>

--- a/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.scss
+++ b/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.scss
@@ -23,3 +23,9 @@
   z-index: 10;
   background: #fff;
 }
+
+/* выравниваем кнопку возврата по центру */
+.links {
+  display: flex;
+  justify-content: center;
+}

--- a/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/fx/currency/pages/currency-admin/currency-admin.component.ts
@@ -11,6 +11,7 @@ import {CurrencyDto} from '../../models/currency.model';
 import {CurrencyService} from '../../services/currency.service';
 import {MatCardModule} from "@angular/material/card";
 import {CurrencyUpdateDto} from "../../models/currency-update.model";
+import {RouterLink} from '@angular/router';
 
 @Component({
   selector: 'app-currency-admin',
@@ -24,7 +25,8 @@ import {CurrencyUpdateDto} from "../../models/currency-update.model";
     MatIconModule,
     MatButtonModule,
     MatSnackBarModule,
-    MatCardModule
+    MatCardModule,
+    RouterLink
   ],
   templateUrl: './currency-admin.component.html',
   styleUrl: './currency-admin.component.scss'

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.html
@@ -2,6 +2,11 @@
 
   <h1 class="mat-headline-4">Currency Pairs Administration</h1>
 
+  <!-- кнопка возврата на домашнюю страницу -->
+  <nav class="links">
+    <a mat-raised-button routerLink="/">Home</a>
+  </nav>
+
   <!-- карточка с формой добавления -->
   <mat-card class="toolbar-card">
     <mat-card-header>

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.scss
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.scss
@@ -23,3 +23,9 @@
   z-index: 10;
   background: #fff;
 }
+
+/* выравниваем кнопку возврата по центру */
+.links {
+  display: flex;
+  justify-content: center;
+}

--- a/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
+++ b/frontend/src/app/fx/pair/pages/pair-admin/pair-admin.component.ts
@@ -15,6 +15,7 @@ import {PairService} from '../../services/pair.service';
 import {PairUpdateDto} from '../../models/pair-update.model';
 import {CurrencyService} from '../../../currency/services/currency.service';
 import {CurrencyDto} from '../../../currency/models/currency.model';
+import {RouterLink} from '@angular/router';
 
 @Component({
   selector: 'app-pair-admin',
@@ -29,7 +30,8 @@ import {CurrencyDto} from '../../../currency/models/currency.model';
     MatIconModule,
     MatButtonModule,
     MatSnackBarModule,
-    MatCardModule
+    MatCardModule,
+    RouterLink
   ],
   templateUrl: './pair-admin.component.html',
   styleUrl: './pair-admin.component.scss'


### PR DESCRIPTION
## Summary
- add return-to-home button on currency admin page
- add return-to-home button on pair admin page

## Testing
- `npm run build` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683e0e91a870832dbfdd157567c07af2