### PR TITLE
Move FX links to nav bar

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,6 +1,8 @@
 <!-- верхняя панель навигации -->
 <mat-toolbar color="primary">
   <button mat-button routerLink="/">Home</button>
+  <button mat-button routerLink="/currencies">Currencies</button>
+  <button mat-button routerLink="/pairs">Currency Pairs</button>
 </mat-toolbar>
 
 <router-outlet></router-outlet>

--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -1,7 +1,3 @@
 <div class="center-box">
   <h1 class="mat-headline-3">AlligatorFX-markets</h1>
-  <nav class="links">
-    <a routerLink="/currencies">Currencies</a>
-    <a routerLink="/pairs">Currency Pairs</a>
-  </nav>
 </div>

--- a/frontend/src/app/home/home.component.scss
+++ b/frontend/src/app/home/home.component.scss
@@ -8,8 +8,3 @@
   text-align: center;
 }
 
-.links {
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-}


### PR DESCRIPTION
## Summary
- show `Currencies` and `Currency Pairs` buttons in the nav bar
- clean up home page markup and styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e18239da0832d9198b9642a6076c1