### PR TITLE
Implement quotes streaming feature

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/fx/quote/web/QuoteController.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/quote/web/QuoteController.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.fx.quote.web;
+
+import com.alligator.core.fx.dto.CurrencyQuoteDto;
+import com.alligator.core.fx.model.CurrencyQuote;
+import com.alligator.core.fx.port.ExternalPriceFeed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+/* Контроллер выдачи котировок через SSE. */
+@RestController
+@RequestMapping("/api/v1/quotes")
+@RequiredArgsConstructor
+public class QuoteController {
+
+    private final ExternalPriceFeed feed;
+
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<CurrencyQuoteDto> stream() {
+        return feed.streamAll().map(this::toDto);
+    }
+
+    private CurrencyQuoteDto toDto(CurrencyQuote q) {
+        return new CurrencyQuoteDto(q.pairId(), q.bid(), q.ask(), q.ts());
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -25,3 +25,7 @@ spring.jpa.hibernate.ddl-auto=update
 logging.level.root=INFO
 # Application logging level
 logging.level.com.alligator.market=INFO
+# ===============================
+# TWELVEDATA API
+# ===============================
+twelvedata.apikey=demo

--- a/core/src/main/java/com/alligator/core/fx/dto/CurrencyQuoteDto.java
+++ b/core/src/main/java/com/alligator/core/fx/dto/CurrencyQuoteDto.java
@@ -1,0 +1,12 @@
+package com.alligator.core.fx.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/* DTO котировки для отправки на клиент. */
+public record CurrencyQuoteDto(
+        Long pairId,
+        BigDecimal bid,
+        BigDecimal ask,
+        Instant ts
+) {}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,6 +3,7 @@
   <button mat-button routerLink="/">Home</button>
   <button mat-button routerLink="/currencies">Currencies</button>
   <button mat-button routerLink="/pairs">Currency Pairs</button>
+  <button mat-button routerLink="/quotes">Quotes</button>
 </mat-toolbar>
 
 <router-outlet></router-outlet>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,11 @@ export const routes: Routes = [
       import('./fx/pair/pair.module').then(m => m.PairModule)
   },
   {
+    path: 'quotes',
+    loadChildren: () =>
+      import('./quotes/quotes.module').then(m => m.QuotesModule)
+  },
+  {
     path: '',
     loadComponent: () =>
       import('./home/home.component').then(c => c.HomeComponent)

--- a/frontend/src/app/quotes/models/quote.model.ts
+++ b/frontend/src/app/quotes/models/quote.model.ts
@@ -1,0 +1,7 @@
+/** DTO котировки аналогичный backend */
+export interface CurrencyQuoteDto {
+  pairId: number;
+  bid: string;
+  ask: string;
+  ts: string;
+}

--- a/frontend/src/app/quotes/pages/quotes/quotes.component.html
+++ b/frontend/src/app/quotes/pages/quotes/quotes.component.html
@@ -1,0 +1,21 @@
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+  <ng-container matColumnDef="pairId">
+    <th mat-header-cell *matHeaderCellDef>Pair ID</th>
+    <td mat-cell *matCellDef="let q">{{q.pairId}}</td>
+  </ng-container>
+  <ng-container matColumnDef="bid">
+    <th mat-header-cell *matHeaderCellDef>Bid</th>
+    <td mat-cell *matCellDef="let q">{{q.bid}}</td>
+  </ng-container>
+  <ng-container matColumnDef="ask">
+    <th mat-header-cell *matHeaderCellDef>Ask</th>
+    <td mat-cell *matCellDef="let q">{{q.ask}}</td>
+  </ng-container>
+  <ng-container matColumnDef="ts">
+    <th mat-header-cell *matHeaderCellDef>Time</th>
+    <td mat-cell *matCellDef="let q">{{q.ts}}</td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+</table>

--- a/frontend/src/app/quotes/pages/quotes/quotes.component.scss
+++ b/frontend/src/app/quotes/pages/quotes/quotes.component.scss
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  padding: 16px;
+}

--- a/frontend/src/app/quotes/pages/quotes/quotes.component.ts
+++ b/frontend/src/app/quotes/pages/quotes/quotes.component.ts
@@ -1,0 +1,29 @@
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatTableDataSource, MatTableModule} from '@angular/material/table';
+import {QuoteService} from '../../services/quote.service';
+import {CurrencyQuoteDto} from '../../models/quote.model';
+
+@Component({
+  selector: 'app-quotes',
+  standalone: true,
+  imports: [CommonModule, MatTableModule],
+  templateUrl: './quotes.component.html',
+  styleUrl: './quotes.component.scss'
+})
+export class QuotesComponent implements OnInit {
+
+  displayed: string[] = ['pairId', 'bid', 'ask', 'ts'];
+  dataSource = new MatTableDataSource<CurrencyQuoteDto>([]);
+
+  constructor(private service: QuoteService) {}
+
+  ngOnInit(): void {
+    this.service.stream().subscribe({
+      next: q => {
+        const data = [q, ...this.dataSource.data].slice(0, 50);
+        this.dataSource.data = data;
+      }
+    });
+  }
+}

--- a/frontend/src/app/quotes/quotes-routing.module.ts
+++ b/frontend/src/app/quotes/quotes-routing.module.ts
@@ -1,0 +1,17 @@
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/quotes/quotes.component')
+        .then(c => c.QuotesComponent)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class QuotesRoutingModule {}

--- a/frontend/src/app/quotes/quotes.module.ts
+++ b/frontend/src/app/quotes/quotes.module.ts
@@ -1,0 +1,12 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {QuotesRoutingModule} from './quotes-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    QuotesRoutingModule,
+  ]
+})
+export class QuotesModule { }

--- a/frontend/src/app/quotes/services/quote.service.ts
+++ b/frontend/src/app/quotes/services/quote.service.ts
@@ -1,0 +1,21 @@
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+import {CurrencyQuoteDto} from '../models/quote.model';
+
+/* Сервис подписки на поток котировок через SSE */
+@Injectable({ providedIn: 'root' })
+export class QuoteService {
+
+  /* Подписаться на поток SSE */
+  stream(): Observable<CurrencyQuoteDto> {
+    return new Observable<CurrencyQuoteDto>(subscriber => {
+      const es = new EventSource('/api/v1/quotes/stream');
+      es.onmessage = ev => subscriber.next(JSON.parse(ev.data));
+      es.onerror = err => {
+        subscriber.error(err);
+        es.close();
+      };
+      return () => es.close();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add CurrencyQuoteDto in core for client quotes
- expose SSE stream in QuoteController
- provide TwelveData API key property
- frontend: create quotes module with service and component
- update routes and navigation with Quotes link

## Testing
- `sh backend/mvnw -f core/pom.xml -q test` *(fails: Failed to fetch)*
- `sh backend/mvnw -q test` *(fails: Failed to fetch)*
- `npm test --prefix frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455f9fc150832dba9adc88c6826d27