### PR TITLE
Handle missing price from TwelveData feed

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/fx/quote/collector/twelvedata/TwelveDataFeedAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/quote/collector/twelvedata/TwelveDataFeedAdapter.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.fx.quote.collector.twelvedata;
 
 import com.alligator.core.fx.model.CurrencyQuote;
 import com.alligator.core.fx.port.ExternalPriceFeed;
+import com.alligator.market.backend.fx.quote.exceptions.MissingPriceException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -47,12 +48,17 @@ public class TwelveDataFeedAdapter implements ExternalPriceFeed {
                         .build())
                 .retrieve()
                 .bodyToMono(PriceDto.class)
-                .map(dto -> new CurrencyQuote(
-                        pairId,
-                        new BigDecimal(dto.price()),       // bid = ask = price
-                        new BigDecimal(dto.price()),       // bid = ask = price
-                        (short) 2,                         // priority (secondary)
-                        Instant.now()))
+                .map(dto -> {
+                    if (dto.price() == null) {
+                        throw new MissingPriceException(symbol);
+                    }
+                    return new CurrencyQuote(
+                            pairId,
+                            new BigDecimal(dto.price()),       // bid = ask = price
+                            new BigDecimal(dto.price()),       // bid = ask = price
+                            (short) 2,                         // priority (secondary)
+                            Instant.now());
+                })
                 .flux();
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/fx/quote/exceptions/MissingPriceException.java
+++ b/backend/src/main/java/com/alligator/market/backend/fx/quote/exceptions/MissingPriceException.java
@@ -1,0 +1,8 @@
+package com.alligator.market.backend.fx.quote.exceptions;
+
+/* Отсутствует цена в ответе провайдера котировок. */
+public class MissingPriceException extends RuntimeException {
+    public MissingPriceException(String symbol) {
+        super("Price missing for symbol '%s'".formatted(symbol));
+    }
+}


### PR DESCRIPTION
## Summary
- add `MissingPriceException` for null prices
- validate price in `TwelveDataFeedAdapter`

## Testing
- `sh ../backend/mvnw -q test -f pom.xml` *(fails: Failed to fetch Maven)*
- `sh ./mvnw -q test` *(fails: Failed to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6845ba89a6bc832d943c37a9901eecf0