### PR TITLE
feat: persist kafka logs

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,1 +1,2 @@
 postgres-data/
+kafka-data/

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    # Сохраняем логи партиций на хосте
+    volumes:
+      - ./kafka-data:/var/lib/kafka/data
     ports:
       - "9092:9092"
 #=============================


### PR DESCRIPTION
## Summary
- make Kafka data persistent in docker-compose
- ignore kafka-data directory

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a4da8448832da97bd3c24f217988