### PR TITLE
Fix Confluent serializer dependency

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -101,6 +101,14 @@
         </dependency>
     </dependencies>
 
+    <!-- Репозиторий Confluent содержит Avro сериализаторы -->
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Summary
- add Confluent Maven repository so `kafka-avro-serializer` can be resolved

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6848aeecec0c832d9c117b23e1e5d1d7