### PR TITLE
Fix terminology for streaming configuration

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/config/entity/FxPairStreamingConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/config/entity/FxPairStreamingConfig.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * Entity настроек стрима котировок для заданной валютной пары.
+ * Entity конфигурации стрима котировок для заданной валютной пары.
  */
 @Entity
 @Table(

--- a/backend/src/main/java/com/alligator/market/backend/quotes/config/repository/FxPairStreamingConfigRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/config/repository/FxPairStreamingConfigRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 /**
- * Репозиторий таблицы настроек стрима котировок для заданной валютной пары.
+ * Репозиторий таблицы конфигураций стрима котировок для заданной валютной пары.
  */
 public interface FxPairStreamingConfigRepository extends JpaRepository<FxPairStreamingConfig, Long> {
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/config/service/FxPairStreamingConfigService.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/config/service/FxPairStreamingConfigService.java
@@ -6,7 +6,7 @@ import com.alligator.market.backend.quotes.config.dto.FxPairStreamingConfigUpdat
 
 import java.util.List;
 
-/* Интерфейс сервиса настроек стрима котировок для заданной валютной пары. */
+/* Интерфейс сервиса конфигурации стрима котировок для заданной валютной пары. */
 public interface FxPairStreamingConfigService {
 
     String createConfig(FxPairStreamingConfigCreateDto dto);

--- a/backend/src/main/java/com/alligator/market/backend/quotes/config/service/FxPairStreamingConfigServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/config/service/FxPairStreamingConfigServiceImpl.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-/* Реализация сервиса настроек стрима котировок для заданной валютной пары. */
+/* Реализация сервиса конфигурации стрима котировок для заданной валютной пары. */
 @Service
 @RequiredArgsConstructor
 @Transactional

--- a/backend/src/main/java/com/alligator/market/backend/quotes/config/web/FxPairStreamingConfigController.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/config/web/FxPairStreamingConfigController.java
@@ -16,7 +16,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 import java.util.List;
 
-/* REST-контроллер для управления настройками стрима котировок. */
+/* REST-контроллер для управления конфигурациями стрима котировок. */
 @RestController
 @RequestMapping("/api/v1/streaming-configs")
 @RequiredArgsConstructor
@@ -26,7 +26,7 @@ public class FxPairStreamingConfigController {
     private final FxPairStreamingConfigService service;
 
     //================================================
-    // Создать новую настройку для заданной валютной пары
+    // Создать новую конфигурацию для заданной валютной пары
     //================================================
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid FxPairStreamingConfigCreateDto dto) {
@@ -41,7 +41,7 @@ public class FxPairStreamingConfigController {
     }
 
     //==============================
-    // Обновить настройку по паре и провайдеру
+    // Обновить конфигурацию по паре и провайдеру
     //==============================
     @PutMapping("/{pair}/{provider}")
     public ResponseEntity<ApiResponse<Void>> update(
@@ -53,7 +53,7 @@ public class FxPairStreamingConfigController {
     }
 
     //==============================
-    // Удалить настройку по паре и провайдеру
+    // Удалить конфигурацию по паре и провайдеру
     //==============================
     @DeleteMapping("/{pair}/{provider}")
     public ResponseEntity<ApiResponse<Void>> delete(
@@ -64,7 +64,7 @@ public class FxPairStreamingConfigController {
     }
 
     //===============================
-    // Вернуть все настройки стримов
+    // Вернуть все конфигурации стримов
     //===============================
     @GetMapping
     public ResponseEntity<ApiResponse<List<FxPairStreamingConfigDto>>> getAll() {


### PR DESCRIPTION
## Summary
- fix Russian comments in quotes config package
- use term "конфигурация стрима" consistently across comments

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531ddaf4b8832d82fe317a93060871