### PR TITLE
Add stream configuration page

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,6 +3,7 @@
   <button mat-button routerLink="/">Home</button>
   <button mat-button routerLink="/currencies">Currencies</button>
   <button mat-button routerLink="/pairs">Currency Pairs</button>
+  <button mat-button routerLink="/stream-configs">Stream Configuration</button>
 </mat-toolbar>
 
 <router-outlet></router-outlet>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,11 @@ export const routes: Routes = [
       import('./fx/pair/pair.module').then(m => m.PairModule)
   },
   {
+    path: 'stream-configs',
+    loadChildren: () =>
+      import('./fx/stream-config/stream-config.module').then(m => m.StreamConfigModule)
+  },
+  {
     path: '',
     loadComponent: () =>
       import('./home/home.component').then(c => c.HomeComponent)

--- a/frontend/src/app/fx/stream-config/models/stream-config-create.model.ts
+++ b/frontend/src/app/fx/stream-config/models/stream-config-create.model.ts
@@ -1,0 +1,8 @@
+/** DTO создания конфигурации стрима аналогичный backend */
+export interface StreamConfigCreateDto {
+  pair: string;
+  provider: string;
+  priority: number;
+  refreshMs: number;
+  enabled: boolean;
+}

--- a/frontend/src/app/fx/stream-config/models/stream-config-update.model.ts
+++ b/frontend/src/app/fx/stream-config/models/stream-config-update.model.ts
@@ -1,0 +1,6 @@
+/** DTO обновления конфигурации стрима аналогичный backend */
+export interface StreamConfigUpdateDto {
+  priority: number;
+  refreshMs: number;
+  enabled: boolean;
+}

--- a/frontend/src/app/fx/stream-config/models/stream-config.model.ts
+++ b/frontend/src/app/fx/stream-config/models/stream-config.model.ts
@@ -1,0 +1,8 @@
+/** DTO конфигурации стрима аналогичный backend */
+export interface StreamConfigDto {
+  pair: string;
+  provider: string;
+  priority: number;
+  refreshMs: number;
+  enabled: boolean;
+}

--- a/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.html
+++ b/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.html
@@ -1,0 +1,113 @@
+<div class="center-box">
+
+  <h1 class="mat-headline-4">Stream Configuration</h1>
+
+  <!-- карточка с формой -->
+  <mat-card class="toolbar-card">
+    <mat-card-header>
+      <mat-card-title>Stream Config Toolbar</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <form [formGroup]="form" class="toolbar">
+
+        <mat-form-field appearance="outline">
+          <mat-label>Pair</mat-label>
+          <mat-select formControlName="pair">
+            <mat-option *ngFor="let p of pairs" [value]="p.pair">
+              {{ p.pair }}
+            </mat-option>
+          </mat-select>
+          <mat-error *ngIf="form.controls['pair'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Provider</mat-label>
+          <input matInput formControlName="provider" maxlength="50" />
+          <mat-error *ngIf="form.controls['provider'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Priority</mat-label>
+          <input matInput type="number" formControlName="priority" />
+          <mat-error *ngIf="form.controls['priority'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Refresh, ms</mat-label>
+          <input matInput type="number" formControlName="refreshMs" />
+          <mat-error *ngIf="form.controls['refreshMs'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-checkbox formControlName="enabled">Enabled</mat-checkbox>
+
+        <ng-container *ngIf="!editing; else editButtons">
+          <button mat-raised-button type="button" (click)="onAdd()" [disabled]="form.invalid || locked">Add</button>
+        </ng-container>
+        <ng-template #editButtons>
+          <button mat-raised-button color="primary" type="button" (click)="onSave()" [disabled]="form.invalid || locked">Save</button>
+          <button mat-raised-button type="button" (click)="cancelEdit()">Cancel</button>
+        </ng-template>
+      </form>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- карточка со списком -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Stream Config List</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
+
+        <ng-container matColumnDef="pair">
+          <th mat-header-cell *matHeaderCellDef>Pair</th>
+          <td mat-cell *matCellDef="let c">{{ c.pair }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="provider">
+          <th mat-header-cell *matHeaderCellDef>Provider</th>
+          <td mat-cell *matCellDef="let c">{{ c.provider }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="priority">
+          <th mat-header-cell *matHeaderCellDef>Priority</th>
+          <td mat-cell *matCellDef="let c">{{ c.priority }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="refreshMs">
+          <th mat-header-cell *matHeaderCellDef>Refresh, ms</th>
+          <td mat-cell *matCellDef="let c">{{ c.refreshMs }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="enabled">
+          <th mat-header-cell *matHeaderCellDef>Enabled</th>
+          <td mat-cell *matCellDef="let c">{{ c.enabled }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let c">
+            <button mat-icon-button color="primary" (click)="onEdit(c)">
+              <mat-icon>edit</mat-icon>
+            </button>
+            <button mat-icon-button color="warn" (click)="onDelete(c.pair, c.provider)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+      </table>
+    </mat-card-content>
+  </mat-card>
+
+</div>

--- a/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.scss
+++ b/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.scss
@@ -1,0 +1,26 @@
+/* центрируем контент и даём одинаковый зазор между карточками */
+.center-box {
+  max-width: 960px;
+  margin: 32px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 0 16px;
+}
+
+/* выстроить поля и кнопку в одну линию, с равными промежутками и переносом на новую строку */
+.toolbar {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 16px;
+  align-items: center;
+}
+
+/* фиксация toolbar при прокрутке */
+.toolbar-card {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #fff;
+}
+

--- a/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.spec.ts
+++ b/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StreamConfigAdminComponent } from './stream-config-admin.component';
+
+describe('StreamConfigAdminComponent', () => {
+  let component: StreamConfigAdminComponent;
+  let fixture: ComponentFixture<StreamConfigAdminComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StreamConfigAdminComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(StreamConfigAdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.ts
+++ b/frontend/src/app/fx/stream-config/pages/stream-config-admin/stream-config-admin.component.ts
@@ -1,0 +1,175 @@
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatTableDataSource, MatTableModule} from '@angular/material/table';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {StreamConfigDto} from '../../models/stream-config.model';
+import {StreamConfigCreateDto} from '../../models/stream-config-create.model';
+import {StreamConfigUpdateDto} from '../../models/stream-config-update.model';
+import {StreamConfigService} from '../../services/stream-config.service';
+import {PairDto} from '../../../pair/models/pair.model';
+import {PairService} from '../../../pair/services/pair.service';
+import {RouterLink} from '@angular/router';
+
+@Component({
+  selector: 'app-stream-config-admin',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    MatCardModule,
+    MatCheckboxModule,
+    RouterLink
+  ],
+  templateUrl: './stream-config-admin.component.html',
+  styleUrl: './stream-config-admin.component.scss'
+})
+export class StreamConfigAdminComponent implements OnInit {
+
+  //=================
+  // Табличные данные
+  //=================
+  displayed: string[] = ['pair', 'provider', 'priority', 'refreshMs', 'enabled', 'actions'];
+  dataSource = new MatTableDataSource<StreamConfigDto>([]);
+
+  //===============================
+  // Форма добавления конфигурации
+  //===============================
+  form: FormGroup;
+
+  locked = false; // блокировка кнопки
+  editing = false;
+  editPair: string | null = null;
+  editProvider: string | null = null;
+  pairs: PairDto[] = [];
+
+  constructor(
+    private readonly service: StreamConfigService,
+    private readonly pairService: PairService,
+    private readonly fb: FormBuilder,
+    private readonly snack: MatSnackBar
+  ) {
+    this.form = this.fb.group({
+      pair: ['', [Validators.required]],
+      provider: ['', [Validators.required, Validators.maxLength(50)]],
+      priority: [0, [Validators.required, Validators.min(0), Validators.max(32767)]],
+      refreshMs: [1000, [Validators.required, Validators.min(0)]],
+      enabled: [true]
+    });
+  }
+
+  //=======================
+  // Активность на странице
+  //=======================
+  ngOnInit(): void {
+    this.refresh();
+    this.pairService.list().subscribe({
+      next: p => this.pairs = p,
+      error: err => this.snack.open(err.message ?? 'Load pairs failed', 'Close')
+    });
+  }
+
+  onAdd(): void {
+    if (this.form.invalid || this.locked) { return; }
+
+    this.locked = true;
+
+    const dto: StreamConfigCreateDto = this.form.value;
+
+    this.service.add(dto).subscribe({
+      next: id => {
+        this.snack.open(`Config '${id}' added`, 'OK', { duration: 2500 });
+        this.refresh();
+        this.form.reset({ priority: 0, refreshMs: 1000, enabled: true });
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Add failed';
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => this.locked = false);
+      }
+    });
+  }
+
+  onEdit(c: StreamConfigDto): void {
+    this.editing = true;
+    this.editPair = c.pair;
+    this.editProvider = c.provider;
+    this.form.setValue({
+      pair: c.pair,
+      provider: c.provider,
+      priority: c.priority,
+      refreshMs: c.refreshMs,
+      enabled: c.enabled
+    });
+    this.form.controls['pair'].disable();
+    this.form.controls['provider'].disable();
+  }
+
+  onSave(): void {
+    if (this.form.invalid || this.locked || !this.editPair || !this.editProvider) { return; }
+
+    this.locked = true;
+
+    const dto: StreamConfigUpdateDto = {
+      priority: this.form.controls['priority'].value,
+      refreshMs: this.form.controls['refreshMs'].value,
+      enabled: this.form.controls['enabled'].value
+    } as StreamConfigUpdateDto;
+
+    this.service.update(this.editPair, this.editProvider, dto).subscribe({
+      next: () => {
+        this.snack.open(`Config '${this.editPair}:${this.editProvider}' updated`, 'OK', { duration: 2500 });
+        this.refresh();
+        this.cancelEdit();
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Update failed';
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => this.locked = false);
+      }
+    });
+  }
+
+  cancelEdit(): void {
+    this.editing = false;
+    this.editPair = null;
+    this.editProvider = null;
+    this.form.reset({ pair: '', provider: '', priority: 0, refreshMs: 1000, enabled: true });
+    this.form.controls['pair'].enable();
+    this.form.controls['provider'].enable();
+    this.locked = false;
+  }
+
+  onDelete(pair: string, provider: string): void {
+    this.service.delete(pair, provider).subscribe({
+      next: () => {
+        this.snack.open(`Config '${pair}:${provider}' deleted`, 'OK', { duration: 2500 });
+        this.refresh();
+      },
+      error: err => this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close')
+    });
+  }
+
+  private refresh(): void {
+    this.service.list().subscribe({
+      next: list => this.dataSource.data = list,
+      error: err => this.snack.open(err.message ?? 'Load failed', 'Close')
+    });
+  }
+}

--- a/frontend/src/app/fx/stream-config/services/stream-config.service.spec.ts
+++ b/frontend/src/app/fx/stream-config/services/stream-config.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StreamConfigService } from './stream-config.service';
+
+describe('StreamConfigService', () => {
+  let service: StreamConfigService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(StreamConfigService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/fx/stream-config/services/stream-config.service.ts
+++ b/frontend/src/app/fx/stream-config/services/stream-config.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/api-response.model';
+import { StreamConfigDto } from '../models/stream-config.model';
+import { StreamConfigCreateDto } from '../models/stream-config-create.model';
+import { StreamConfigUpdateDto } from '../models/stream-config-update.model';
+
+/* Сервис взаимодействия с API конфигураций стрима */
+@Injectable({
+  providedIn: 'root'
+})
+export class StreamConfigService {
+
+  constructor(private http: HttpClient) { }
+
+  /* Базовый URL API */
+  private readonly baseUrl = '/api/v1/streaming-configs';
+
+  /* Получить список всех конфигураций */
+  list(): Observable<StreamConfigDto[]> {
+    return this.http
+      .get<ApiResponse<StreamConfigDto[]>>(this.baseUrl)
+      .pipe(map(res => res.data));
+  }
+
+  /* Создать конфигурацию, backend вернёт её id */
+  add(dto: StreamConfigCreateDto): Observable<string> {
+    return this.http
+      .post<ApiResponse<string>>(this.baseUrl, dto)
+      .pipe(map(res => res.data));
+  }
+
+  /* Удалить конфигурацию по паре и провайдеру */
+  delete(pair: string, provider: string): Observable<void> {
+    return this.http
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`)
+      .pipe(map(res => res.data));
+  }
+
+  /* Обновить конфигурацию по паре и провайдеру */
+  update(pair: string, provider: string, dto: StreamConfigUpdateDto): Observable<void> {
+    return this.http
+      .put<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`, dto)
+      .pipe(map(res => res.data));
+  }
+}

--- a/frontend/src/app/fx/stream-config/stream-config-routing.module.ts
+++ b/frontend/src/app/fx/stream-config/stream-config-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/stream-config-admin/stream-config-admin.component')
+        .then(c => c.StreamConfigAdminComponent)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class StreamConfigRoutingModule { }

--- a/frontend/src/app/fx/stream-config/stream-config.module.ts
+++ b/frontend/src/app/fx/stream-config/stream-config.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { StreamConfigRoutingModule } from './stream-config-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    StreamConfigRoutingModule,
+  ]
+})
+export class StreamConfigModule { }


### PR DESCRIPTION
## Summary
- add navigation tab for stream config
- implement Stream Config page with table and toolbar for CRUD
- add Angular service and DTO models
- wire up routing and module

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685329258a6c832da1e9b45ac1718d85