### PR TITLE
Rename FxPairStreamingConfig model

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/config/mapper/FxPairStreamingConfigMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/config/mapper/FxPairStreamingConfigMapper.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class FxPairStreamingConfigMapper {
 
-    public com.alligator.market.domain.model.FxPairStreamingConfig toDomain(FxPairStreamingConfig entity) {
-        return new com.alligator.market.domain.model.FxPairStreamingConfig(
+    public com.alligator.market.domain.model.CcyPairFeedSettings toDomain(FxPairStreamingConfig entity) {
+        return new com.alligator.market.domain.model.CcyPairFeedSettings(
                 entity.getPair().getPair(),
                 entity.getProvider(),
                 entity.getPriority(),
@@ -21,7 +21,7 @@ public class FxPairStreamingConfigMapper {
         );
     }
 
-    public FxPairStreamingConfig toEntity(com.alligator.market.domain.model.FxPairStreamingConfig cfg, Pair pair) {
+    public FxPairStreamingConfig toEntity(com.alligator.market.domain.model.CcyPairFeedSettings cfg, Pair pair) {
         FxPairStreamingConfig entity = new FxPairStreamingConfig();
         entity.setPair(pair);
         entity.setProvider(cfg.provider());

--- a/backend/src/main/java/com/alligator/market/backend/quotes/config/service/FxPairStreamingConfigServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/config/service/FxPairStreamingConfigServiceImpl.java
@@ -46,7 +46,7 @@ public class FxPairStreamingConfigServiceImpl implements FxPairStreamingConfigSe
                 .orElseThrow(() -> new PairNotFoundException(dto.pair()));
 
         FxPairStreamingConfig entity = mapper.toEntity(
-                new com.alligator.market.domain.model.FxPairStreamingConfig(
+                new com.alligator.market.domain.model.CcyPairFeedSettings(
                         dto.pair(),
                         dto.provider(),
                         dto.priority(),

--- a/domain/src/main/java/com/alligator/market/domain/model/CcyPairFeedSettings.java
+++ b/domain/src/main/java/com/alligator/market/domain/model/CcyPairFeedSettings.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.model;
 
-/** Конфигурация стрима котировок для заданной валютной пары. */
-public record FxPairStreamingConfig(
+/** Настройки источника котировок для заданной валютной пары. */
+public record CcyPairFeedSettings(
 
         String pair,
         String provider,


### PR DESCRIPTION
## Summary
- rename `FxPairStreamingConfig` record to `CcyPairFeedSettings`
- update mapper and service references

## Testing
- `mvnw test` *(fails: repository access requires the internet)*

------
https://chatgpt.com/codex/tasks/task_e_68544d1601b4832d9ae3c4d2e28c3e31