### PR TITLE
Synchronize frontend naming with backend

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,7 +3,7 @@
   <button mat-button routerLink="/">Home</button>
   <button mat-button routerLink="/currencies">Currencies</button>
   <button mat-button routerLink="/pairs">Currency Pairs</button>
-  <button mat-button routerLink="/stream-configs">Stream Configuration</button>
+  <button mat-button routerLink="/stream-configs">Stream Settings</button>
 </mat-toolbar>
 
 <router-outlet></router-outlet>

--- a/frontend/src/app/features/quotes/stream/settings/models/settings-create.model.ts
+++ b/frontend/src/app/features/quotes/stream/settings/models/settings-create.model.ts
@@ -1,5 +1,5 @@
-/** DTO создания конфигурации стрима аналогичный backend */
-export interface StreamConfigCreateDto {
+/** DTO создания настроек потока котировок аналогичный backend */
+export interface SettingsCreateDto {
   pair: string;
   provider: string;
   priority: number;

--- a/frontend/src/app/features/quotes/stream/settings/models/settings-update.model.ts
+++ b/frontend/src/app/features/quotes/stream/settings/models/settings-update.model.ts
@@ -1,5 +1,5 @@
-/** DTO обновления конфигурации стрима аналогичный backend */
-export interface StreamConfigUpdateDto {
+/** DTO обновления настроек потока котировок аналогичный backend */
+export interface SettingsUpdateDto {
   priority: number;
   refreshMs: number;
   enabled: boolean;

--- a/frontend/src/app/features/quotes/stream/settings/models/settings.model.ts
+++ b/frontend/src/app/features/quotes/stream/settings/models/settings.model.ts
@@ -1,5 +1,5 @@
-/** DTO конфигурации стрима аналогичный backend */
-export interface StreamConfigDto {
+/** DTO настроек потока котировок аналогичный backend */
+export interface SettingsDto {
   pair: string;
   provider: string;
   priority: number;

--- a/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.html
+++ b/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.html
@@ -1,11 +1,11 @@
 <div class="center-box">
 
-  <h1 class="mat-headline-4">Quotes Stream Configuration</h1>
+  <h1 class="mat-headline-4">Quotes Stream Settings</h1>
 
   <!-- карточка с формой -->
   <mat-card class="toolbar-card">
     <mat-card-header>
-      <mat-card-title>Stream Configuration Toolbar</mat-card-title>
+      <mat-card-title>Stream Settings Toolbar</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <form [formGroup]="form" class="toolbar">
@@ -62,7 +62,7 @@
   <!-- карточка со списком -->
   <mat-card>
     <mat-card-header>
-      <mat-card-title>Stream Configuration List</mat-card-title>
+      <mat-card-title>Stream Settings List</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">

--- a/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.spec.ts
+++ b/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StreamConfigAdminComponent } from './settings-admin.component';
+import { SettingsAdminComponent } from './settings-admin.component';
 
-describe('StreamConfigAdminComponent', () => {
-  let component: StreamConfigAdminComponent;
-  let fixture: ComponentFixture<StreamConfigAdminComponent>;
+describe('SettingsAdminComponent', () => {
+  let component: SettingsAdminComponent;
+  let fixture: ComponentFixture<SettingsAdminComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [StreamConfigAdminComponent]
+      imports: [SettingsAdminComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(StreamConfigAdminComponent);
+    fixture = TestBed.createComponent(SettingsAdminComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.ts
@@ -10,16 +10,16 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
-import {StreamConfigDto} from '../../models/settings.model';
-import {StreamConfigCreateDto} from '../../models/settings-create.model';
-import {StreamConfigUpdateDto} from '../../models/settings-update.model';
+import {SettingsDto} from '../../models/settings.model';
+import {SettingsCreateDto} from '../../models/settings-create.model';
+import {SettingsUpdateDto} from '../../models/settings-update.model';
 import {SettingsService} from '../../services/settings.service';
 import {PairDto} from '../../../../../pairs/models/pair.model';
 import {PairService} from '../../../../../pairs/services/pair.service';
 import {RouterLink} from '@angular/router';
 
 @Component({
-  selector: 'app-stream-config-admin',
+  selector: 'app-settings-admin',
   standalone: true,
   imports: [
     CommonModule,
@@ -38,17 +38,17 @@ import {RouterLink} from '@angular/router';
   templateUrl: './settings-admin.component.html',
   styleUrl: './settings-admin.component.scss'
 })
-export class StreamConfigAdminComponent implements OnInit {
+export class SettingsAdminComponent implements OnInit {
 
   //=================
   // Табличные данные
   //=================
   displayed: string[] = ['pair', 'provider', 'priority', 'refreshMs', 'enabled', 'actions'];
-  dataSource = new MatTableDataSource<StreamConfigDto>([]);
+  dataSource = new MatTableDataSource<SettingsDto>([]);
 
-  //==============================
-  // Форма добавления конфигурации
-  //==============================
+  //========================
+  // Форма добавления настроек
+  //========================
   form: FormGroup;
 
   locked = false; // блокировка кнопки
@@ -88,11 +88,11 @@ export class StreamConfigAdminComponent implements OnInit {
 
     this.locked = true;
 
-    const dto: StreamConfigCreateDto = this.form.value;
+    const dto: SettingsCreateDto = this.form.value;
 
     this.service.add(dto).subscribe({
       next: id => {
-        this.snack.open(`Config '${id}' added`, 'OK', { duration: 2500 });
+        this.snack.open(`Settings '${id}' added`, 'OK', { duration: 2500 });
         this.refresh();
         this.form.reset({ priority: 1, refreshMs: 1000, enabled: true });
         this.locked = false;
@@ -105,7 +105,7 @@ export class StreamConfigAdminComponent implements OnInit {
     });
   }
 
-  onEdit(c: StreamConfigDto): void {
+  onEdit(c: SettingsDto): void {
     this.editing = true;
     this.editPair = c.pair;
     this.editProvider = c.provider;
@@ -125,15 +125,15 @@ export class StreamConfigAdminComponent implements OnInit {
 
     this.locked = true;
 
-    const dto: StreamConfigUpdateDto = {
+    const dto: SettingsUpdateDto = {
       priority: this.form.controls['priority'].value,
       refreshMs: this.form.controls['refreshMs'].value,
       enabled: this.form.controls['enabled'].value
-    } as StreamConfigUpdateDto;
+    } as SettingsUpdateDto;
 
     this.service.update(this.editPair, this.editProvider, dto).subscribe({
       next: () => {
-        this.snack.open(`Config '${this.editPair}:${this.editProvider}' updated`, 'OK', { duration: 2500 });
+        this.snack.open(`Settings '${this.editPair}:${this.editProvider}' updated`, 'OK', { duration: 2500 });
         this.refresh();
         this.cancelEdit();
         this.locked = false;
@@ -159,7 +159,7 @@ export class StreamConfigAdminComponent implements OnInit {
   onDelete(pair: string, provider: string): void {
     this.service.delete(pair, provider).subscribe({
       next: () => {
-        this.snack.open(`Config '${pair}:${provider}' deleted`, 'OK', { duration: 2500 });
+        this.snack.open(`Settings '${pair}:${provider}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
       error: err => this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close')

--- a/frontend/src/app/features/quotes/stream/settings/services/settings.service.ts
+++ b/frontend/src/app/features/quotes/stream/settings/services/settings.service.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiResponse } from '../../../../../shared/api-response.model';
-import { StreamConfigDto } from '../models/settings.model';
-import { StreamConfigCreateDto } from '../models/settings-create.model';
-import { StreamConfigUpdateDto } from '../models/settings-update.model';
+import { SettingsDto } from '../models/settings.model';
+import { SettingsCreateDto } from '../models/settings-create.model';
+import { SettingsUpdateDto } from '../models/settings-update.model';
 
 /* Сервис взаимодействия с API конфигураций стрима */
 @Injectable({
@@ -17,29 +17,29 @@ export class SettingsService {
   /* Базовый URL API */
   private readonly baseUrl = '/api/v1/streaming-configs';
 
-  /* Получить список всех конфигураций */
-  list(): Observable<StreamConfigDto[]> {
+  /* Получить список всех настроек */
+  list(): Observable<SettingsDto[]> {
     return this.http
-      .get<ApiResponse<StreamConfigDto[]>>(this.baseUrl)
+      .get<ApiResponse<SettingsDto[]>>(this.baseUrl)
       .pipe(map(res => res.data));
   }
 
-  /* Создать конфигурацию, backend вернёт её id */
-  add(dto: StreamConfigCreateDto): Observable<string> {
+  /* Создать настройки, backend вернёт их id */
+  add(dto: SettingsCreateDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
       .pipe(map(res => res.data));
   }
 
-  /* Удалить конфигурацию по паре и провайдеру */
+  /* Удалить настройки по паре и провайдеру */
   delete(pair: string, provider: string): Observable<void> {
     return this.http
       .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить конфигурацию по паре и провайдеру */
-  update(pair: string, provider: string, dto: StreamConfigUpdateDto): Observable<void> {
+  /* Обновить настройки по паре и провайдеру */
+  update(pair: string, provider: string, dto: SettingsUpdateDto): Observable<void> {
     return this.http
       .put<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`, dto)
       .pipe(map(res => res.data));

--- a/frontend/src/app/features/quotes/stream/settings/settings-routing.module.ts
+++ b/frontend/src/app/features/quotes/stream/settings/settings-routing.module.ts
@@ -6,7 +6,7 @@ const routes: Routes = [
     path: '',
     loadComponent: () =>
       import('./pages/settings-admin/settings-admin.component')
-        .then(c => c.StreamConfigAdminComponent)
+        .then(c => c.SettingsAdminComponent)
   }
 ];
 


### PR DESCRIPTION
## Summary
- rename stream-config models to settings
- update stream settings admin component
- adjust service and routing
- tweak navigation labels

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68546df95194832db701416171d31fd4