### PR TITLE
Add mode to streaming settings

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsCreateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsCreateDto.java
@@ -15,6 +15,10 @@ public record SettingsCreateDto(
         @Size(max = 50)
         String provider,
 
+        @NotBlank
+        @Pattern(regexp = "^(PULL|PUSH)$")
+        String mode,
+
         @NotNull
         @Min(0) @Max(32767)
         Short priority,

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsDto.java
@@ -15,6 +15,10 @@ public record SettingsDto(
         @Size(max = 50)
         String provider,
 
+        @NotBlank
+        @Pattern(regexp = "^(PULL|PUSH)$")
+        String mode,
+
         @NotNull
         @Min(0) @Max(32767)
         Short priority,

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/entity/CcyPairFeedSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/entity/CcyPairFeedSettingsEntity.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 @Table(
         name = "fx_pair_streaming_cfg",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_fx_pair_streaming_cfg_pair_provider", columnNames = {"pair_id", "provider"})
+                @UniqueConstraint(name = "uq_fx_pair_streaming_cfg_pair_provider_mode", columnNames = {"pair_id", "provider", "mode"})
         }
 )
 @Getter
@@ -37,6 +37,10 @@ public class CcyPairFeedSettingsEntity extends BaseEntity {
     /* Имя провайдера котировок */
     @Column(length = 50, nullable = false)
     private String provider;
+
+    /* Режим стриминга (PULL/PUSH) */
+    @Column(length = 4, nullable = false)
+    private String mode;
 
     /* Приоритет провайдера для пары */
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/exceptions/DuplicateSettingsException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/exceptions/DuplicateSettingsException.java
@@ -1,10 +1,10 @@
 package com.alligator.market.backend.quotes.stream.settings.exceptions;
 
 /**
- * Исключение при попытке создать повторную запись для той же валютный пары и провайдера.
+ * Исключение при попытке создать повторную запись для той же валютной пары, провайдера и режима.
  */
 public class DuplicateSettingsException extends RuntimeException {
-    public DuplicateSettingsException(String pair, String provider) {
-        super("Streaming config for pair '%s' and provider '%s' already exists".formatted(pair, provider));
+    public DuplicateSettingsException(String pair, String provider, String mode) {
+        super("Streaming config for pair '%s', provider '%s' and mode '%s' already exists".formatted(pair, provider, mode));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/exceptions/SettingsNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/exceptions/SettingsNotFoundException.java
@@ -9,4 +9,8 @@ public class SettingsNotFoundException extends EntityNotFoundException {
     public SettingsNotFoundException(String pair, String provider) {
         super("Streaming config for pair '%s' and provider '%s' not found".formatted(pair, provider));
     }
+
+    public SettingsNotFoundException(String pair, String provider, String mode) {
+        super("Streaming config for pair '%s', provider '%s' and mode '%s' not found".formatted(pair, provider, mode));
+    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/mapper/CcyPairFeedSettingsMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/mapper/CcyPairFeedSettingsMapper.java
@@ -15,6 +15,7 @@ public class CcyPairFeedSettingsMapper {
         return new com.alligator.market.domain.model.CcyPairFeedSettings(
                 entity.getPair().getPair(),
                 entity.getProvider(),
+                entity.getMode(),
                 entity.getPriority(),
                 entity.getRefreshMs(),
                 entity.isEnabled()
@@ -25,6 +26,7 @@ public class CcyPairFeedSettingsMapper {
         CcyPairFeedSettingsEntity entity = new CcyPairFeedSettingsEntity();
         entity.setPair(pair);
         entity.setProvider(cfg.provider());
+        entity.setMode(cfg.mode());
         entity.setPriority(cfg.priority());
         entity.setRefreshMs(cfg.refreshMs());
         entity.setEnabled(cfg.enabled());

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/repository/SettingsRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/repository/SettingsRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
  */
 public interface SettingsRepository extends JpaRepository<CcyPairFeedSettingsEntity, Long> {
 
-    Optional<CcyPairFeedSettingsEntity> findByPair_PairAndProvider(String pair, String provider);
+    Optional<CcyPairFeedSettingsEntity> findByPair_PairAndProviderAndMode(String pair, String provider, String mode);
 
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsService.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsService.java
@@ -13,9 +13,9 @@ public interface SettingsService {
 
     String createConfig(SettingsCreateDto dto);
 
-    void updateConfig(String pair, String provider, SettingsUpdateDto dto);
+    void updateConfig(String pair, String provider, String mode, SettingsUpdateDto dto);
 
-    void deleteConfig(String pair, String provider);
+    void deleteConfig(String pair, String provider, String mode);
 
     List<SettingsDto> findAll();
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsServiceImpl.java
@@ -38,8 +38,8 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     public String createConfig(SettingsCreateDto dto) {
 
-        repository.findByPair_PairAndProvider(dto.pair(), dto.provider()).ifPresent(c -> {
-            throw new DuplicateSettingsException(dto.pair(), dto.provider());
+        repository.findByPair_PairAndProviderAndMode(dto.pair(), dto.provider(), dto.mode()).ifPresent(c -> {
+            throw new DuplicateSettingsException(dto.pair(), dto.provider(), dto.mode());
         });
 
         Pair pair = pairRepository.findByPair(dto.pair())
@@ -49,6 +49,7 @@ public class SettingsServiceImpl implements SettingsService {
                 new com.alligator.market.domain.model.CcyPairFeedSettings(
                         dto.pair(),
                         dto.provider(),
+                        dto.mode(),
                         dto.priority(),
                         dto.refreshMs(),
                         dto.enabled()
@@ -57,38 +58,38 @@ public class SettingsServiceImpl implements SettingsService {
         );
 
         CcyPairFeedSettingsEntity saved = repository.save(entity);
-        log.info("CcyPairFeedSettingsEntity {}:{} saved with id={}", dto.pair(), dto.provider(), saved.getId());
-        return "%s:%s".formatted(saved.getPair().getPair(), saved.getProvider());
+        log.info("CcyPairFeedSettingsEntity {}:{}:{} saved with id={}", dto.pair(), dto.provider(), dto.mode(), saved.getId());
+        return "%s:%s:%s".formatted(saved.getPair().getPair(), saved.getProvider(), saved.getMode());
     }
 
     //===================
     // Обновить настройки
     //===================
     @Override
-    public void updateConfig(String pair, String provider, SettingsUpdateDto dto) {
+    public void updateConfig(String pair, String provider, String mode, SettingsUpdateDto dto) {
 
-        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider(pair, provider)
-                .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
+        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProviderAndMode(pair, provider, mode)
+                .orElseThrow(() -> new SettingsNotFoundException(pair, provider, mode));
 
         entity.setPriority(dto.priority());
         entity.setRefreshMs(dto.refreshMs());
         entity.setEnabled(dto.enabled());
 
         repository.save(entity);
-        log.info("CcyPairFeedSettingsEntity {}:{} updated (id={})", pair, provider, entity.getId());
+        log.info("CcyPairFeedSettingsEntity {}:{}:{} updated (id={})", pair, provider, mode, entity.getId());
     }
 
     //==================
     // Удалить настройки
     //==================
     @Override
-    public void deleteConfig(String pair, String provider) {
+    public void deleteConfig(String pair, String provider, String mode) {
 
-        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider(pair, provider)
-                .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
+        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProviderAndMode(pair, provider, mode)
+                .orElseThrow(() -> new SettingsNotFoundException(pair, provider, mode));
 
         repository.delete(entity);
-        log.info("CcyPairFeedSettingsEntity {}:{} deleted (id={})", pair, provider, entity.getId());
+        log.info("CcyPairFeedSettingsEntity {}:{}:{} deleted (id={})", pair, provider, mode, entity.getId());
     }
 
     //======================
@@ -98,11 +99,12 @@ public class SettingsServiceImpl implements SettingsService {
     @Transactional(readOnly = true)
     public List<SettingsDto> findAll() {
 
-        List<SettingsDto> result = repository.findAll(Sort.by("pair.pair", "provider"))
+        List<SettingsDto> result = repository.findAll(Sort.by("pair.pair", "provider", "mode"))
                 .stream()
                 .map(cfg -> new SettingsDto(
                         cfg.getPair().getPair(),
                         cfg.getProvider(),
+                        cfg.getMode(),
                         cfg.getPriority(),
                         cfg.getRefreshMs(),
                         cfg.isEnabled()

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/web/FxPairStreamingConfigController.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/web/FxPairStreamingConfigController.java
@@ -36,8 +36,8 @@ public class FxPairStreamingConfigController {
         String id = service.createConfig(dto);
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
-                .path("/{pair}/{provider}")
-                .buildAndExpand(dto.pair(), dto.provider())
+                .path("/{pair}/{provider}/{mode}")
+                .buildAndExpand(dto.pair(), dto.provider(), dto.mode())
                 .toUri();
         return ResponseEntityFactory.created(location, id);
     }
@@ -45,23 +45,25 @@ public class FxPairStreamingConfigController {
     //===================
     // Обновить настройки
     //===================
-    @PutMapping("/{pair}/{provider}")
+    @PutMapping("/{pair}/{provider}/{mode}")
     public ResponseEntity<ApiResponse<Void>> update(
             @PathVariable String pair,
             @PathVariable String provider,
+            @PathVariable String mode,
             @RequestBody @Valid SettingsUpdateDto dto) {
-        service.updateConfig(pair, provider, dto);
+        service.updateConfig(pair, provider, mode, dto);
         return ResponseEntityFactory.ok(null);
     }
 
     //==================
     // Удалить настройки
     //==================
-    @DeleteMapping("/{pair}/{provider}")
+    @DeleteMapping("/{pair}/{provider}/{mode}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable String pair,
-            @PathVariable String provider) {
-        service.deleteConfig(pair, provider);
+            @PathVariable String provider,
+            @PathVariable String mode) {
+        service.deleteConfig(pair, provider, mode);
         return ResponseEntityFactory.ok(null);
     }
 

--- a/backend/src/main/resources/db/migration/V5__fx_pair_streaming_cfg_add_mode.sql
+++ b/backend/src/main/resources/db/migration/V5__fx_pair_streaming_cfg_add_mode.sql
@@ -1,0 +1,8 @@
+ALTER TABLE fx_pair_streaming_cfg
+    ADD COLUMN mode VARCHAR(4) NOT NULL DEFAULT 'PULL';
+
+ALTER TABLE fx_pair_streaming_cfg
+    DROP CONSTRAINT uq_fx_pair_streaming_cfg_pair_provider;
+
+ALTER TABLE fx_pair_streaming_cfg
+    ADD CONSTRAINT uq_fx_pair_streaming_cfg_pair_provider_mode UNIQUE (pair_id, provider, mode);

--- a/domain/src/main/java/com/alligator/market/domain/model/CcyPairFeedSettings.java
+++ b/domain/src/main/java/com/alligator/market/domain/model/CcyPairFeedSettings.java
@@ -5,6 +5,7 @@ public record CcyPairFeedSettings(
 
         String pair,
         String provider,
+        String mode,
         short priority,
         int refreshMs,
         boolean enabled


### PR DESCRIPTION
## Summary
- support streaming `mode` (PULL/PUSH)
- update DTOs, entity and mapper
- update service layer and controller for new parameter
- add Flyway migration for `mode`

## Testing
- `mvn test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6854729097ec832d8aee08934afe3447