### PR TITLE
Add mode support to frontend

### DIFF
--- a/frontend/src/app/features/quotes/stream/settings/models/settings-create.model.ts
+++ b/frontend/src/app/features/quotes/stream/settings/models/settings-create.model.ts
@@ -2,6 +2,8 @@
 export interface SettingsCreateDto {
   pair: string;
   provider: string;
+  /** Режим получения котировок */
+  mode: string;
   priority: number;
   refreshMs: number;
   enabled: boolean;

--- a/frontend/src/app/features/quotes/stream/settings/models/settings.model.ts
+++ b/frontend/src/app/features/quotes/stream/settings/models/settings.model.ts
@@ -2,6 +2,8 @@
 export interface SettingsDto {
   pair: string;
   provider: string;
+  /** Режим получения котировок */
+  mode: string;
   priority: number;
   refreshMs: number;
   enabled: boolean;

--- a/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.html
+++ b/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.html
@@ -31,6 +31,17 @@
         </mat-form-field>
 
         <mat-form-field appearance="outline">
+          <mat-label>Mode</mat-label>
+          <mat-select formControlName="mode">
+            <mat-option value="PULL">PULL</mat-option>
+            <mat-option value="PUSH">PUSH</mat-option>
+          </mat-select>
+          <mat-error *ngIf="form.controls['mode'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
           <mat-label>Priority</mat-label>
           <input matInput type="number" formControlName="priority" />
           <mat-error *ngIf="form.controls['priority'].hasError('required')">
@@ -77,6 +88,11 @@
           <td mat-cell *matCellDef="let c">{{ c.provider }}</td>
         </ng-container>
 
+        <ng-container matColumnDef="mode">
+          <th mat-header-cell *matHeaderCellDef>Mode</th>
+          <td mat-cell *matCellDef="let c">{{ c.mode }}</td>
+        </ng-container>
+
         <ng-container matColumnDef="priority">
           <th mat-header-cell *matHeaderCellDef>Priority</th>
           <td mat-cell *matCellDef="let c">{{ c.priority }}</td>
@@ -98,7 +114,7 @@
             <button mat-icon-button color="primary" (click)="onEdit(c)">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button color="warn" (click)="onDelete(c.pair, c.provider)">
+            <button mat-icon-button color="warn" (click)="onDelete(c.pair, c.provider, c.mode)">
               <mat-icon>delete</mat-icon>
             </button>
           </td>

--- a/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/settings/pages/settings-admin/settings-admin.component.ts
@@ -43,7 +43,7 @@ export class SettingsAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['pair', 'provider', 'priority', 'refreshMs', 'enabled', 'actions'];
+  displayed: string[] = ['pair', 'provider', 'mode', 'priority', 'refreshMs', 'enabled', 'actions'];
   dataSource = new MatTableDataSource<SettingsDto>([]);
 
   //========================
@@ -55,6 +55,7 @@ export class SettingsAdminComponent implements OnInit {
   editing = false;
   editPair: string | null = null;
   editProvider: string | null = null;
+  editMode: string | null = null;
   pairs: PairDto[] = [];
 
   constructor(
@@ -66,6 +67,7 @@ export class SettingsAdminComponent implements OnInit {
     this.form = this.fb.group({
       pair: ['', [Validators.required]],
       provider: ['', [Validators.required, Validators.maxLength(50)]],
+      mode: ['PULL', [Validators.required]],
       priority: [1, [Validators.required, Validators.min(0), Validators.max(32767)]],
       refreshMs: [1000, [Validators.required, Validators.min(0)]],
       enabled: [true]
@@ -94,7 +96,7 @@ export class SettingsAdminComponent implements OnInit {
       next: id => {
         this.snack.open(`Settings '${id}' added`, 'OK', { duration: 2500 });
         this.refresh();
-        this.form.reset({ priority: 1, refreshMs: 1000, enabled: true });
+        this.form.reset({ mode: 'PULL', priority: 1, refreshMs: 1000, enabled: true, pair: '', provider: '' });
         this.locked = false;
       },
       error: err => {
@@ -109,19 +111,22 @@ export class SettingsAdminComponent implements OnInit {
     this.editing = true;
     this.editPair = c.pair;
     this.editProvider = c.provider;
+    this.editMode = c.mode;
     this.form.setValue({
       pair: c.pair,
       provider: c.provider,
+      mode: c.mode,
       priority: c.priority,
       refreshMs: c.refreshMs,
       enabled: c.enabled
     });
     this.form.controls['pair'].disable();
     this.form.controls['provider'].disable();
+    this.form.controls['mode'].disable();
   }
 
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editPair || !this.editProvider) { return; }
+    if (this.form.invalid || this.locked || !this.editPair || !this.editProvider || !this.editMode) { return; }
 
     this.locked = true;
 
@@ -131,7 +136,7 @@ export class SettingsAdminComponent implements OnInit {
       enabled: this.form.controls['enabled'].value
     } as SettingsUpdateDto;
 
-    this.service.update(this.editPair, this.editProvider, dto).subscribe({
+    this.service.update(this.editPair, this.editProvider, this.editMode, dto).subscribe({
       next: () => {
         this.snack.open(`Settings '${this.editPair}:${this.editProvider}' updated`, 'OK', { duration: 2500 });
         this.refresh();
@@ -150,14 +155,16 @@ export class SettingsAdminComponent implements OnInit {
     this.editing = false;
     this.editPair = null;
     this.editProvider = null;
-    this.form.reset({ pair: '', provider: '', priority: 1, refreshMs: 1000, enabled: true });
+    this.editMode = null;
+    this.form.reset({ pair: '', provider: '', mode: 'PULL', priority: 1, refreshMs: 1000, enabled: true });
     this.form.controls['pair'].enable();
     this.form.controls['provider'].enable();
+    this.form.controls['mode'].enable();
     this.locked = false;
   }
 
-  onDelete(pair: string, provider: string): void {
-    this.service.delete(pair, provider).subscribe({
+  onDelete(pair: string, provider: string, mode: string): void {
+    this.service.delete(pair, provider, mode).subscribe({
       next: () => {
         this.snack.open(`Settings '${pair}:${provider}' deleted`, 'OK', { duration: 2500 });
         this.refresh();

--- a/frontend/src/app/features/quotes/stream/settings/services/settings.service.ts
+++ b/frontend/src/app/features/quotes/stream/settings/services/settings.service.ts
@@ -31,17 +31,17 @@ export class SettingsService {
       .pipe(map(res => res.data));
   }
 
-  /* Удалить настройки по паре и провайдеру */
-  delete(pair: string, provider: string): Observable<void> {
+  /* Удалить настройки по паре, провайдеру и режиму */
+  delete(pair: string, provider: string, mode: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`)
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}/${mode}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить настройки по паре и провайдеру */
-  update(pair: string, provider: string, dto: SettingsUpdateDto): Observable<void> {
+  /* Обновить настройки по паре, провайдеру и режиму */
+  update(pair: string, provider: string, mode: string, dto: SettingsUpdateDto): Observable<void> {
     return this.http
-      .put<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`, dto)
+      .put<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}/${mode}`, dto)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- add mode field to streaming settings models
- update Angular forms, table and service to handle mode

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547bc601a4832d8e1ce29711432b48