### PR TITLE
Handle PUSH mode refresh interval

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsCreateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsCreateDto.java
@@ -25,7 +25,7 @@ public record SettingsCreateDto(
 
         @NotNull
         @Min(0)
-        Integer refreshMs,
+        Integer refreshMs, // для PUSH игнорируется
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsDto.java
@@ -25,7 +25,7 @@ public record SettingsDto(
 
         @NotNull
         @Min(0)
-        Integer refreshMs,
+        Integer refreshMs, // для PUSH игнорируется
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsUpdateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/dto/SettingsUpdateDto.java
@@ -15,7 +15,7 @@ public record SettingsUpdateDto(
 
         @NotNull
         @Min(0)
-        Integer refreshMs,
+        Integer refreshMs, // для PUSH игнорируется
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/entity/CcyPairFeedSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/entity/CcyPairFeedSettingsEntity.java
@@ -46,7 +46,7 @@ public class CcyPairFeedSettingsEntity extends BaseEntity {
     @Column(nullable = false)
     private short priority;
 
-    /* Частота обновления, мс */
+    /* Частота обновления, мс (для PUSH всегда 0) */
     @Column(name = "refresh_ms", nullable = false)
     private int refreshMs;
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsServiceImpl.java
@@ -45,13 +45,16 @@ public class SettingsServiceImpl implements SettingsService {
         Pair pair = pairRepository.findByPair(dto.pair())
                 .orElseThrow(() -> new PairNotFoundException(dto.pair()));
 
+        // Для PUSH-интервал определяет провайдер, поэтому устанавливаем 0.
+        int refreshMs = "PUSH".equals(dto.mode()) ? 0 : dto.refreshMs();
+
         CcyPairFeedSettingsEntity entity = mapper.toEntity(
                 new com.alligator.market.domain.model.CcyPairFeedSettings(
                         dto.pair(),
                         dto.provider(),
                         dto.mode(),
                         dto.priority(),
-                        dto.refreshMs(),
+                        refreshMs,
                         dto.enabled()
                 ),
                 pair
@@ -72,7 +75,9 @@ public class SettingsServiceImpl implements SettingsService {
                 .orElseThrow(() -> new SettingsNotFoundException(pair, provider, mode));
 
         entity.setPriority(dto.priority());
-        entity.setRefreshMs(dto.refreshMs());
+        // Если режим PUSH, интервал задаётся провайдером, поэтому сохраняем 0.
+        int refreshMs = "PUSH".equals(entity.getMode()) ? 0 : dto.refreshMs();
+        entity.setRefreshMs(refreshMs);
         entity.setEnabled(dto.enabled());
 
         repository.save(entity);

--- a/backend/src/main/resources/db/migration/V6__refresh_ms_zero_for_push.sql
+++ b/backend/src/main/resources/db/migration/V6__refresh_ms_zero_for_push.sql
@@ -1,0 +1,5 @@
+-- Set refresh_ms to 0 for PUSH mode where it's irrelevant
+UPDATE fx_pair_streaming_cfg
+SET refresh_ms = 0
+WHERE mode = 'PUSH';
+

--- a/domain/src/main/java/com/alligator/market/domain/model/CcyPairFeedSettings.java
+++ b/domain/src/main/java/com/alligator/market/domain/model/CcyPairFeedSettings.java
@@ -7,7 +7,7 @@ public record CcyPairFeedSettings(
         String provider,
         String mode,
         short priority,
-        int refreshMs,
+        int refreshMs, // 0 для PUSH
         boolean enabled
 
 ) {}


### PR DESCRIPTION
## Summary
- keep `refreshMs` 0 for PUSH mode in streaming config service
- document PUSH specifics in DTOs and entity
- migrate existing configs to 0 when mode is PUSH

## Testing
- `sh ./mvnw -q test` *(fails: unable to fetch Maven artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68548b593a9c832dbd1d9bb5a94e820f