### PR TITLE
Rename streaming config table

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/entity/CcyPairFeedSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/entity/CcyPairFeedSettingsEntity.java
@@ -13,9 +13,9 @@ import lombok.Setter;
  */
 @Entity
 @Table(
-        name = "fx_pair_streaming_cfg",
+        name = "ccypair_feed_settings",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_fx_pair_streaming_cfg_pair_provider_mode", columnNames = {"pair_id", "provider", "mode"})
+                @UniqueConstraint(name = "uq_ccypair_feed_settings_pair_provider_mode", columnNames = {"pair_id", "provider", "mode"})
         }
 )
 @Getter
@@ -31,7 +31,7 @@ public class CcyPairFeedSettingsEntity extends BaseEntity {
     /* Валютная пара (FK на ccypair.id) */
     @ManyToOne(optional = false)
     @JoinColumn(name = "pair_id", referencedColumnName = "id",
-            foreignKey = @ForeignKey(name = "fk_stream_cfg_pair"))
+            foreignKey = @ForeignKey(name = "fk_feed_settings_pair"))
     private Pair pair;
 
     /* Имя провайдера котировок */

--- a/backend/src/main/resources/db/migration/V7__rename_fx_pair_streaming_cfg_to_ccypair_feed_settings.sql
+++ b/backend/src/main/resources/db/migration/V7__rename_fx_pair_streaming_cfg_to_ccypair_feed_settings.sql
@@ -1,0 +1,5 @@
+ALTER TABLE fx_pair_streaming_cfg RENAME TO ccypair_feed_settings;
+
+ALTER TABLE ccypair_feed_settings RENAME CONSTRAINT pk_fx_pair_streaming_cfg TO pk_ccypair_feed_settings;
+ALTER TABLE ccypair_feed_settings RENAME CONSTRAINT fk_stream_cfg_pair TO fk_feed_settings_pair;
+ALTER TABLE ccypair_feed_settings RENAME CONSTRAINT uq_fx_pair_streaming_cfg_pair_provider_mode TO uq_ccypair_feed_settings_pair_provider_mode;


### PR DESCRIPTION
## Summary
- rename the `fx_pair_streaming_cfg` table to `ccypair_feed_settings`
- update entity mapping and FK name
- add Flyway migration to rename the table and constraints

## Testing
- `sh ./mvnw -q test` *(fails: network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6854911de968832d8cccff0871df44ee