### PR TITLE
Fix backend references to CcyPairFeedSettings

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/mapper/CcyPairFeedSettingsMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/mapper/CcyPairFeedSettingsMapper.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class CcyPairFeedSettingsMapper {
 
-    public com.alligator.market.domain.model.CcyPairFeedSettings toDomain(CcyPairFeedSettingsEntity entity) {
-        return new com.alligator.market.domain.model.CcyPairFeedSettings(
+    public com.alligator.market.domain.quote.stream.settings.CcyPairFeedSettings toDomain(CcyPairFeedSettingsEntity entity) {
+        return new com.alligator.market.domain.quote.stream.settings.CcyPairFeedSettings(
                 entity.getPair().getPair(),
                 entity.getProvider(),
                 entity.getMode(),
@@ -22,7 +22,7 @@ public class CcyPairFeedSettingsMapper {
         );
     }
 
-    public CcyPairFeedSettingsEntity toEntity(com.alligator.market.domain.model.CcyPairFeedSettings cfg, Pair pair) {
+    public CcyPairFeedSettingsEntity toEntity(com.alligator.market.domain.quote.stream.settings.CcyPairFeedSettings cfg, Pair pair) {
         CcyPairFeedSettingsEntity entity = new CcyPairFeedSettingsEntity();
         entity.setPair(pair);
         entity.setProvider(cfg.provider());

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/settings/service/SettingsServiceImpl.java
@@ -49,7 +49,7 @@ public class SettingsServiceImpl implements SettingsService {
         int refreshMs = "PUSH".equals(dto.mode()) ? 0 : dto.refreshMs();
 
         CcyPairFeedSettingsEntity entity = mapper.toEntity(
-                new com.alligator.market.domain.model.CcyPairFeedSettings(
+                new com.alligator.market.domain.quote.stream.settings.CcyPairFeedSettings(
                         dto.pair(),
                         dto.provider(),
                         dto.mode(),


### PR DESCRIPTION
## Summary
- update `CcyPairFeedSettingsMapper` with new domain package
- update `SettingsServiceImpl` to use the moved record

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68565db47720832da2802c72bc7545ea