### PR TITLE
feat(backend): add TwelveData quote feed adapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/adapters/twelvedata/TwelveDataProperties.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/adapters/twelvedata/TwelveDataProperties.java
@@ -1,0 +1,20 @@
+package com.alligator.market.backend.quotes.stream.adapters.twelvedata;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Настройки для обращения к API TwelveData.
+ */
+@Component
+@ConfigurationProperties(prefix = "twelvedata")
+@Data
+public class TwelveDataProperties {
+
+    /** Базовый URL API. */
+    private String baseUrl;
+
+    /** API-ключ. */
+    private String apikey;
+}

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/adapters/twelvedata/TwelveDataQuoteFeedAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/adapters/twelvedata/TwelveDataQuoteFeedAdapter.java
@@ -1,0 +1,71 @@
+package com.alligator.market.backend.quotes.stream.adapters.twelvedata;
+
+import com.alligator.market.domain.quotes.stream.QuoteTick;
+import com.alligator.market.domain.quotes.stream.exeptions.QuoteUnavailableException;
+import com.alligator.market.domain.quotes.stream.ports.QuoteFeedPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Получение котировок через сервис TwelveData.
+ */
+@Service
+@Slf4j
+public class TwelveDataQuoteFeedAdapter implements QuoteFeedPort {
+
+    private static final String PROVIDER = "TWELVEDATA";
+
+    private final WebClient webClient;
+    private final TwelveDataProperties properties;
+
+    public TwelveDataQuoteFeedAdapter(WebClient.Builder builder, TwelveDataProperties properties) {
+        this.webClient = builder.baseUrl(properties.getBaseUrl()).build();
+        this.properties = properties;
+    }
+
+    //=======================================
+    // Возвратить последнюю котировку по паре
+    //=======================================
+    @Override
+    public QuoteTick fetchQuote(String pairCode) throws QuoteUnavailableException {
+
+        String symbol = pairCode.substring(0, 3) + "/" + pairCode.substring(3);
+
+        try {
+            PriceDto dto = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/price")
+                            .queryParam("symbol", symbol)
+                            .queryParam("apikey", properties.getApikey())
+                            .build())
+                    .retrieve()
+                    .bodyToMono(PriceDto.class)
+                    .block();
+
+            if (dto == null || dto.price() == null) {
+                throw new IllegalStateException("Empty price");
+            }
+            BigDecimal price = new BigDecimal(dto.price());
+
+            return new QuoteTick(
+                    pairCode,
+                    price,
+                    price,
+                    Instant.now(),
+                    PROVIDER
+            );
+
+        } catch (Exception e) {
+            log.error("Cannot fetch quote from TwelveData", e);
+            throw new QuoteUnavailableException("Failed to fetch quote", e);
+        }
+    }
+
+    /* Ответ API с ценой. */
+    private record PriceDto(String price) {
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -29,6 +29,7 @@ logging.level.com.alligator.market=INFO
 # TWELVEDATA API
 # ===============================
 twelvedata.apikey=2b8e2659372340d5b922cd6b8d6d2cb2
+twelvedata.base-url=https://api.twelvedata.com
 # ===============================
 # KAFKA
 # ===============================


### PR DESCRIPTION
## Summary
- implement `TwelveDataQuoteFeedAdapter` with simple `/price` fetching
- add configuration bean `TwelveDataProperties`
- extend application properties with TwelveData base URL

## Testing
- `./backend/mvnw -q test` *(fails: repo access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685664696d94832d916928d4f9848f7b