### PR TITLE
Fix QuoteTick avro schema

### DIFF
--- a/domain/src/main/avro/QuoteTick.avsc
+++ b/domain/src/main/avro/QuoteTick.avsc
@@ -1,7 +1,7 @@
 {
-  "namespace": "com.alligator.market.domain.model",
+  "namespace": "com.alligator.market.domain.quotes.stream",
   "type": "record",
-  "name": "FxPriceTick",
+  "name": "QuoteTick",
   "fields": [
     { "name": "pair", "type": "string" },
     { "name": "bid", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },


### PR DESCRIPTION
## Summary
- исправлено avro-описание `QuoteTick` для соответствия доменной модели

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856982a2ed4832d926f3d1b8ab27bfc