### PR TITLE
Add Providers admin page

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,6 +3,7 @@
   <button mat-button routerLink="/">Home</button>
   <button mat-button routerLink="/currencies">Currencies</button>
   <button mat-button routerLink="/pairs">Currency Pairs</button>
+  <button mat-button routerLink="/providers">Providers</button>
   <button mat-button routerLink="/stream-configs">Stream Settings</button>
 </mat-toolbar>
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,11 @@ export const routes: Routes = [
       import('./features/pairs/pair.module').then(m => m.PairModule)
   },
   {
+    path: 'providers',
+    loadChildren: () =>
+      import('./features/providers/provider.module').then(m => m.ProviderModule)
+  },
+  {
     path: 'stream-configs',
     loadChildren: () =>
       import('./features/quotes/stream/ccypair_feed_settings/settings.module').then(m => m.SettingsModule)

--- a/frontend/src/app/features/providers/models/provider-create.model.ts
+++ b/frontend/src/app/features/providers/models/provider-create.model.ts
@@ -1,0 +1,7 @@
+/** DTO для создания провайдера аналогичный backend */
+export interface ProviderCreateDto {
+  name: string;
+  baseUrl: string;
+  mode: string;
+  apiKey: string;
+}

--- a/frontend/src/app/features/providers/models/provider-update.model.ts
+++ b/frontend/src/app/features/providers/models/provider-update.model.ts
@@ -1,0 +1,6 @@
+/** DTO для обновления провайдера аналогичный backend */
+export interface ProviderUpdateDto {
+  baseUrl: string;
+  mode: string;
+  apiKey: string;
+}

--- a/frontend/src/app/features/providers/models/provider.model.ts
+++ b/frontend/src/app/features/providers/models/provider.model.ts
@@ -1,0 +1,7 @@
+/** DTO для провайдера аналогичный backend */
+export interface ProviderDto {
+  name: string;
+  baseUrl: string;
+  mode: string;
+  apiKey: string;
+}

--- a/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.html
+++ b/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.html
@@ -1,0 +1,107 @@
+<div class="center-box">
+
+  <h1 class="mat-headline-4">Providers Administration</h1>
+
+  <!-- карточка с формой добавления -->
+  <mat-card class="toolbar-card">
+    <mat-card-header>
+      <mat-card-title>Provider Toolbar</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <form [formGroup]="form" class="toolbar">
+
+        <mat-form-field appearance="outline">
+          <mat-label>Name</mat-label>
+          <input matInput formControlName="name" maxlength="50" />
+          <mat-error *ngIf="form.controls['name'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Base URL</mat-label>
+          <input matInput formControlName="baseUrl" maxlength="255" />
+          <mat-error *ngIf="form.controls['baseUrl'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Mode</mat-label>
+          <mat-select formControlName="mode">
+            <mat-option value="PULL">PULL</mat-option>
+            <mat-option value="PUSH">PUSH</mat-option>
+          </mat-select>
+          <mat-error *ngIf="form.controls['mode'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>API Key</mat-label>
+          <input matInput formControlName="apiKey" maxlength="255" />
+          <mat-error *ngIf="form.controls['apiKey'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <ng-container *ngIf="!editing; else editButtons">
+          <button mat-raised-button type="button" (click)="onAdd()" [disabled]="form.invalid || locked"> Add
+          </button>
+        </ng-container>
+        <ng-template #editButtons>
+          <button mat-raised-button color="primary" type="button" (click)="onSave()" [disabled]="form.invalid || locked"> Save
+          </button>
+          <button mat-raised-button type="button" (click)="cancelEdit()">Cancel</button>
+        </ng-template>
+      </form>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- карточка со списком -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Provider List</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let p">{{ p.name }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="baseUrl">
+          <th mat-header-cell *matHeaderCellDef>Base URL</th>
+          <td mat-cell *matCellDef="let p">{{ p.baseUrl }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="mode">
+          <th mat-header-cell *matHeaderCellDef>Mode</th>
+          <td mat-cell *matCellDef="let p">{{ p.mode }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="apiKey">
+          <th mat-header-cell *matHeaderCellDef>API Key</th>
+          <td mat-cell *matCellDef="let p">{{ p.apiKey }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let p">
+            <button mat-icon-button color="primary" (click)="onEdit(p)">
+              <mat-icon>edit</mat-icon>
+            </button>
+            <button mat-icon-button color="warn" (click)="onDelete(p.name)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+      </table>
+    </mat-card-content>
+  </mat-card>
+
+</div>

--- a/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.scss
+++ b/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.scss
@@ -1,0 +1,25 @@
+/* центрируем контент и даём одинаковый зазор между карточками */
+.center-box {
+  max-width: 960px;
+  margin: 32px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 0 16px;
+}
+
+/* выстроить поля и кнопку в одну линию, с равными промежутками и переносом на новую строку */
+.toolbar {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 16px;
+  align-items: center;
+}
+
+/* фиксация toolbar при прокрутке */
+.toolbar-card {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #fff;
+}

--- a/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.ts
+++ b/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.ts
@@ -1,0 +1,177 @@
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatTableDataSource, MatTableModule} from '@angular/material/table';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatCardModule} from "@angular/material/card";
+import {ProviderDto} from '../../models/provider.model';
+import {ProviderCreateDto} from '../../models/provider-create.model';
+import {ProviderUpdateDto} from '../../models/provider-update.model';
+import {ProviderService} from '../../services/provider.service';
+import {RouterLink} from '@angular/router';
+
+@Component({
+  selector: 'app-provider-admin',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    MatCardModule,
+    RouterLink
+  ],
+  templateUrl: './provider-admin.component.html',
+  styleUrl: './provider-admin.component.scss'
+})
+export class ProviderAdminComponent implements OnInit {
+
+  //=================
+  // Табличные данные
+  //=================
+  displayed: string[] = ['name', 'baseUrl', 'mode', 'apiKey', 'actions'];
+  dataSource  = new MatTableDataSource<ProviderDto>([]);
+
+  //============================
+  // Форма добавления провайдера
+  //============================
+  form: FormGroup;
+
+  locked = false; // флаг блокировки кнопки Add
+  editing = false; // режим редактирования
+  editName: string | null = null; // имя провайдера для редактирования
+
+  constructor(
+    private readonly service: ProviderService,
+    private readonly fb: FormBuilder,
+    private readonly snack: MatSnackBar
+  ) {
+    this.form = this.fb.group({
+      name: [
+        '',
+        [Validators.required, Validators.maxLength(50)]
+      ],
+
+      baseUrl: [
+        '',
+        [Validators.required, Validators.maxLength(255)]
+      ],
+
+      mode: [
+        'PULL',
+        [Validators.required]
+      ],
+
+      apiKey: [
+        '',
+        [Validators.required, Validators.maxLength(255)]
+      ]
+    });
+  }
+
+  //=======================
+  // Активность на странице
+  //=======================
+
+  ngOnInit(): void {
+    this.refresh();
+  }
+
+  onAdd(): void {
+    if (this.form.invalid || this.locked) { return; }
+
+    this.locked = true;
+
+    const dto: ProviderCreateDto = this.form.value;
+
+    this.service.add(dto).subscribe({
+      next: name => {
+        this.snack.open(
+          `Provider '${name}' added`, 'OK', { duration: 2500 }
+        );
+        this.refresh();
+        this.form.reset({ mode: 'PULL' });
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Add failed';
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => this.locked = false);
+      }
+    });
+  }
+
+  onEdit(p: ProviderDto): void {
+    this.editing = true;
+    this.editName = p.name;
+    this.form.setValue({
+      name: p.name,
+      baseUrl: p.baseUrl,
+      mode: p.mode,
+      apiKey: p.apiKey
+    });
+    this.form.controls['name'].disable();
+  }
+
+  onSave(): void {
+    if (this.form.invalid || this.locked || !this.editName) { return; }
+
+    this.locked = true;
+
+    const dto: ProviderUpdateDto = {
+      baseUrl: this.form.controls['baseUrl'].value,
+      mode: this.form.controls['mode'].value,
+      apiKey: this.form.controls['apiKey'].value
+    } as ProviderUpdateDto;
+
+    this.service.update(this.editName, dto).subscribe({
+      next: () => {
+        this.snack.open(`Provider '${this.editName}' updated`, 'OK', { duration: 2500 });
+        this.refresh();
+        this.cancelEdit();
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Update failed';
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => this.locked = false);
+      }
+    });
+  }
+
+  cancelEdit(): void {
+    this.editing = false;
+    this.editName = null;
+    this.form.reset({ name: '', baseUrl: '', mode: 'PULL', apiKey: '' });
+    this.form.controls['name'].enable();
+    this.locked = false;
+  }
+
+  onDelete(name: string): void {
+    this.service.delete(name).subscribe({
+      next: () => {
+        this.snack.open(`Provider '${name}' deleted`, 'OK', { duration: 2500 });
+        this.refresh();
+      },
+      error: err =>
+        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close')
+    });
+  }
+
+  private refresh(): void {
+    this.service.list().subscribe({
+      next: list => this.dataSource.data = list,
+      error: err => this.snack.open(err.message ?? 'Load failed', 'Close')
+    });
+  }
+}

--- a/frontend/src/app/features/providers/provider-routing.module.ts
+++ b/frontend/src/app/features/providers/provider-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/provider-admin/provider-admin.component')
+        .then(c => c.ProviderAdminComponent)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ProviderRoutingModule { }

--- a/frontend/src/app/features/providers/provider.module.ts
+++ b/frontend/src/app/features/providers/provider.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ProviderRoutingModule } from './provider-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    ProviderRoutingModule,
+  ]
+})
+export class ProviderModule { }

--- a/frontend/src/app/features/providers/services/provider.service.spec.ts
+++ b/frontend/src/app/features/providers/services/provider.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProviderService } from './provider.service';
+
+describe('ProviderService', () => {
+  let service: ProviderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ProviderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/features/providers/services/provider.service.ts
+++ b/frontend/src/app/features/providers/services/provider.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/api-response.model';
+import { ProviderDto } from '../models/provider.model';
+import { ProviderCreateDto } from '../models/provider-create.model';
+import { ProviderUpdateDto } from '../models/provider-update.model';
+
+/* Сервис для взаимодействия с API по работе с провайдерами */
+@Injectable({
+  providedIn: 'root'
+})
+export class ProviderService {
+
+  constructor(private http: HttpClient) { }
+
+  /* Базовый URL (через proxy уйдёт на Spring) */
+  private readonly baseUrl = '/api/v1/providers';
+
+  /* Получить список всех провайдеров */
+  list(): Observable<ProviderDto[]> {
+    return this.http
+      .get<ApiResponse<ProviderDto[]>>(this.baseUrl)
+      .pipe(map(res => res.data));
+  }
+
+  /* Добавить провайдера, backend вернёт его name */
+  add(dto: ProviderCreateDto): Observable<string> {
+    return this.http
+      .post<ApiResponse<string>>(this.baseUrl, dto)
+      .pipe(map(res => res.data));
+  }
+
+  /* Удалить провайдера по имени */
+  delete(name: string): Observable<void> {
+    return this.http
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${name}`)
+      .pipe(map(res => res.data));
+  }
+
+  /* Обновить провайдера по имени */
+  update(name: string, dto: ProviderUpdateDto): Observable<void> {
+    return this.http
+      .put<ApiResponse<void>>(`${this.baseUrl}/${name}`, dto)
+      .pipe(map(res => res.data));
+  }
+}


### PR DESCRIPTION
## Summary
- implement Providers feature with CRUD admin page
- expose provider service and models
- register route and navigation link

## Testing
- `npm test --silent --yes` *(fails: ng not found)*
- `./mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857cfca0d90832da05003d9ed92bfbb