### PR TITLE
Ensure provider uniqueness by name and mode

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/entity/Provider.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/entity/Provider.java
@@ -13,7 +13,10 @@ import lombok.Setter;
 @Table(
         name = "provider",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_provider_name", columnNames = "name")
+                @UniqueConstraint(
+                        name = "uq_provider_name_mode",
+                        columnNames = {"name", "mode"}
+                )
         }
 )
 @Getter

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/exceptions/DuplicateProviderException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/exceptions/DuplicateProviderException.java
@@ -4,7 +4,7 @@ package com.alligator.market.backend.quotes.stream.prodiders.list.exceptions;
  * Очевидно из названия.
  */
 public class DuplicateProviderException extends RuntimeException {
-    public DuplicateProviderException(String name) {
-        super("Provider '%s' already exists".formatted(name));
+    public DuplicateProviderException(String name, String mode) {
+        super("Provider '%s' with mode '%s' already exists".formatted(name, mode));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/exceptions/ProviderNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/exceptions/ProviderNotFoundException.java
@@ -6,7 +6,7 @@ import jakarta.persistence.EntityNotFoundException;
  * Очевидно из названия.
  */
 public class ProviderNotFoundException extends EntityNotFoundException {
-    public ProviderNotFoundException(String name) {
-        super("Provider '%s' not found".formatted(name));
+    public ProviderNotFoundException(String name, String mode) {
+        super("Provider '%s' with mode '%s' not found".formatted(name, mode));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/repository/ProviderRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/repository/ProviderRepository.java
@@ -12,4 +12,6 @@ public interface ProviderRepository extends JpaRepository<Provider, Long> {
 
     Optional<Provider> findByName(String name);
 
+    Optional<Provider> findByNameAndMode(String name, String mode);
+
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/service/ProviderService.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/service/ProviderService.java
@@ -13,9 +13,9 @@ public interface ProviderService {
 
     String createProvider(ProviderCreateDto dto);
 
-    void updateProvider(String name, ProviderUpdateDto dto);
+    void updateProvider(String name, String mode, ProviderUpdateDto dto);
 
-    void deleteProvider(String name);
+    void deleteProvider(String name, String mode);
 
     List<ProviderDto> findAll();
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/service/ProviderServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/service/ProviderServiceImpl.java
@@ -32,8 +32,8 @@ public class ProviderServiceImpl implements ProviderService {
     @Override
     public String createProvider(ProviderCreateDto dto) {
 
-        repository.findByName(dto.name()).ifPresent(p -> {
-            throw new DuplicateProviderException(dto.name());
+        repository.findByNameAndMode(dto.name(), dto.mode()).ifPresent(p -> {
+            throw new DuplicateProviderException(dto.name(), dto.mode());
         });
 
         Provider entity = new Provider();
@@ -43,7 +43,7 @@ public class ProviderServiceImpl implements ProviderService {
         entity.setApiKey(dto.apiKey());
 
         Provider saved = repository.save(entity);
-        log.info("Provider {} saved with id={}", saved.getName(), saved.getId());
+        log.info("Provider {}:{} saved with id={}", saved.getName(), saved.getMode(), saved.getId());
         return saved.getName();
     }
 
@@ -51,30 +51,36 @@ public class ProviderServiceImpl implements ProviderService {
     // Обновить провайдера
     //====================
     @Override
-    public void updateProvider(String name, ProviderUpdateDto dto) {
+    public void updateProvider(String name, String mode, ProviderUpdateDto dto) {
 
-        Provider provider = repository.findByName(name)
-                .orElseThrow(() -> new ProviderNotFoundException(name));
+        Provider provider = repository.findByNameAndMode(name, mode)
+                .orElseThrow(() -> new ProviderNotFoundException(name, mode));
+
+        if (!mode.equals(dto.mode())) {
+            repository.findByNameAndMode(name, dto.mode()).ifPresent(p -> {
+                throw new DuplicateProviderException(name, dto.mode());
+            });
+        }
 
         provider.setBaseUrl(dto.baseUrl());
         provider.setMode(dto.mode());
         provider.setApiKey(dto.apiKey());
 
         repository.save(provider);
-        log.info("Provider {} updated (id={})", provider.getName(), provider.getId());
+        log.info("Provider {}:{} updated (id={})", provider.getName(), provider.getMode(), provider.getId());
     }
 
     //===================
     // Удалить провайдера
     //===================
     @Override
-    public void deleteProvider(String name) {
+    public void deleteProvider(String name, String mode) {
 
-        Provider provider = repository.findByName(name)
-                .orElseThrow(() -> new ProviderNotFoundException(name));
+        Provider provider = repository.findByNameAndMode(name, mode)
+                .orElseThrow(() -> new ProviderNotFoundException(name, mode));
 
         repository.delete(provider);
-        log.info("Provider {} deleted (id={})", provider.getName(), provider.getId());
+        log.info("Provider {}:{} deleted (id={})", provider.getName(), provider.getMode(), provider.getId());
     }
 
     //=========================

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/web/ProviderController.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/prodiders/list/web/ProviderController.java
@@ -36,8 +36,8 @@ public class ProviderController {
         String name = service.createProvider(dto);
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
-                .path("/{name}")
-                .buildAndExpand(name)
+                .path("/{name}/{mode}")
+                .buildAndExpand(name, dto.mode())
                 .toUri();
         return ResponseEntityFactory.created(location, name);
     }
@@ -45,21 +45,24 @@ public class ProviderController {
     //====================
     // Обновить провайдера
     //====================
-    @PutMapping("/{name}")
+    @PutMapping("/{name}/{mode}")
     public ResponseEntity<ApiResponse<Void>> update(
             @PathVariable String name,
+            @PathVariable String mode,
             @RequestBody @Valid ProviderUpdateDto dto) {
-        service.updateProvider(name, dto);
+        service.updateProvider(name, mode, dto);
         return ResponseEntityFactory.ok(null);
     }
 
     //===================
     // Удалить провайдера
     //===================
-    @DeleteMapping("/{name}")
-    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String name) {
+    @DeleteMapping("/{name}/{mode}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @PathVariable String name,
+            @PathVariable String mode) {
 
-        service.deleteProvider(name);
+        service.deleteProvider(name, mode);
         return ResponseEntityFactory.ok(null);
     }
 

--- a/backend/src/main/resources/db/migration/V9__provider_unique_name_mode.sql
+++ b/backend/src/main/resources/db/migration/V9__provider_unique_name_mode.sql
@@ -1,0 +1,5 @@
+ALTER TABLE provider
+    DROP CONSTRAINT uq_provider_name;
+
+ALTER TABLE provider
+    ADD CONSTRAINT uq_provider_name_mode UNIQUE (name, mode);


### PR DESCRIPTION
## Summary
- enforce unique constraint for provider by `name` and `mode`
- update repository and service logic to use the composite key
- adjust controller endpoints
- add Flyway migration for new unique constraint

## Testing
- `./mvnw test` *(fails: Failed to fetch maven due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6857d4c264f0832db03d0f8dd4e997c9