### PR TITLE
Fix provider mode handling in frontend

### DIFF
--- a/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.html
+++ b/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.html
@@ -92,7 +92,7 @@
             <button mat-icon-button color="primary" (click)="onEdit(p)">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button color="warn" (click)="onDelete(p.name)">
+            <button mat-icon-button color="warn" (click)="onDelete(p.name, p.mode)">
               <mat-icon>delete</mat-icon>
             </button>
           </td>

--- a/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.ts
+++ b/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.ts
@@ -50,6 +50,7 @@ export class ProviderAdminComponent implements OnInit {
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
   editName: string | null = null; // имя провайдера для редактирования
+  editMode: string | null = null; // текущий режим провайдера для редактирования
 
   constructor(
     private readonly service: ProviderService,
@@ -97,7 +98,7 @@ export class ProviderAdminComponent implements OnInit {
     this.service.add(dto).subscribe({
       next: name => {
         this.snack.open(
-          `Provider '${name}' added`, 'OK', { duration: 2500 }
+          `Provider '${name}' with mode '${dto.mode}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();
         this.form.reset({ mode: 'PULL' });
@@ -114,6 +115,7 @@ export class ProviderAdminComponent implements OnInit {
   onEdit(p: ProviderDto): void {
     this.editing = true;
     this.editName = p.name;
+    this.editMode = p.mode;
     this.form.setValue({
       name: p.name,
       baseUrl: p.baseUrl,
@@ -124,7 +126,7 @@ export class ProviderAdminComponent implements OnInit {
   }
 
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editName) { return; }
+    if (this.form.invalid || this.locked || !this.editName || !this.editMode) { return; }
 
     this.locked = true;
 
@@ -134,9 +136,9 @@ export class ProviderAdminComponent implements OnInit {
       apiKey: this.form.controls['apiKey'].value
     } as ProviderUpdateDto;
 
-    this.service.update(this.editName, dto).subscribe({
+    this.service.update(this.editName, this.editMode, dto).subscribe({
       next: () => {
-        this.snack.open(`Provider '${this.editName}' updated`, 'OK', { duration: 2500 });
+        this.snack.open(`Provider '${this.editName}' updated to mode '${dto.mode}'`, 'OK', { duration: 2500 });
         this.refresh();
         this.cancelEdit();
         this.locked = false;
@@ -152,15 +154,16 @@ export class ProviderAdminComponent implements OnInit {
   cancelEdit(): void {
     this.editing = false;
     this.editName = null;
+    this.editMode = null;
     this.form.reset({ name: '', baseUrl: '', mode: 'PULL', apiKey: '' });
     this.form.controls['name'].enable();
     this.locked = false;
   }
 
-  onDelete(name: string): void {
-    this.service.delete(name).subscribe({
+  onDelete(name: string, mode: string): void {
+    this.service.delete(name, mode).subscribe({
       next: () => {
-        this.snack.open(`Provider '${name}' deleted`, 'OK', { duration: 2500 });
+        this.snack.open(`Provider '${name}' with mode '${mode}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
       error: err =>

--- a/frontend/src/app/features/providers/services/provider.service.ts
+++ b/frontend/src/app/features/providers/services/provider.service.ts
@@ -31,17 +31,17 @@ export class ProviderService {
       .pipe(map(res => res.data));
   }
 
-  /* Удалить провайдера по имени */
-  delete(name: string): Observable<void> {
+  /* Удалить провайдера по имени и режиму */
+  delete(name: string, mode: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${name}`)
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${name}/${mode}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить провайдера по имени */
-  update(name: string, dto: ProviderUpdateDto): Observable<void> {
+  /* Обновить провайдера по имени и режиму */
+  update(name: string, mode: string, dto: ProviderUpdateDto): Observable<void> {
     return this.http
-      .put<ApiResponse<void>>(`${this.baseUrl}/${name}`, dto)
+      .put<ApiResponse<void>>(`${this.baseUrl}/${name}/${mode}`, dto)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- update frontend provider service to target `{name}/{mode}` endpoint
- handle provider mode in provider admin component
- adjust UI messages

## Testing
- `npm test` *(fails: ng not found)*
- `mvn -q -pl backend test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d69c1610832d975347c0227e9e8b