### PR TITLE
Add provider selection to ccypair feed settings

### DIFF
--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
@@ -24,7 +24,9 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Provider</mat-label>
-          <input matInput formControlName="provider" maxlength="50" />
+          <mat-select formControlName="provider">
+            <mat-option *ngFor="let p of providers" [value]="p.name">{{ p.name }}</mat-option>
+          </mat-select>
           <mat-error *ngIf="form.controls['provider'].hasError('required')">
             Is required
           </mat-error>
@@ -33,8 +35,7 @@
         <mat-form-field appearance="outline">
           <mat-label>Mode</mat-label>
           <mat-select formControlName="mode">
-            <mat-option value="PULL">PULL</mat-option>
-            <mat-option value="PUSH">PUSH</mat-option>
+            <mat-option *ngFor="let m of availableModes" [value]="m">{{ m }}</mat-option>
           </mat-select>
           <mat-error *ngIf="form.controls['mode'].hasError('required')">
             Is required

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
@@ -16,6 +16,8 @@ import {SettingsUpdateDto} from '../../models/settings-update.model';
 import {SettingsService} from '../../services/settings.service';
 import {PairDto} from '../../../../../pairs/models/pair.model';
 import {PairService} from '../../../../../pairs/services/pair.service';
+import {ProviderDto} from '../../../../../providers/models/provider.model';
+import {ProviderService} from '../../../../../providers/services/provider.service';
 import {RouterLink} from '@angular/router';
 
 @Component({
@@ -57,10 +59,13 @@ export class SettingsAdminComponent implements OnInit {
   editProvider: string | null = null;
   editMode: string | null = null;
   pairs: PairDto[] = [];
+  providers: { name: string, modes: string[] }[] = [];
+  availableModes: string[] = ['PULL', 'PUSH'];
 
   constructor(
     private readonly service: SettingsService,
     private readonly pairService: PairService,
+    private readonly providerService: ProviderService,
     private readonly fb: FormBuilder,
     private readonly snack: MatSnackBar
   ) {
@@ -77,6 +82,10 @@ export class SettingsAdminComponent implements OnInit {
     this.form.controls['mode'].valueChanges
       .subscribe(m => this.updateRefreshCtrl(m));
 
+    // реакция на выбор провайдера
+    this.form.controls['provider'].valueChanges
+      .subscribe(p => this.updateModeCtrl(p));
+
     // начальное состояние поля периода
     this.updateRefreshCtrl(this.form.controls['mode'].value);
   }
@@ -89,6 +98,20 @@ export class SettingsAdminComponent implements OnInit {
     this.pairService.list().subscribe({
       next: p => this.pairs = p,
       error: err => this.snack.open(err.message ?? 'Load pairs failed', 'Close')
+    });
+    this.providerService.list().subscribe({
+      next: list => {
+        const map = new Map<string, string[]>();
+        list.forEach(pr => {
+          const arr = map.get(pr.name) ?? [];
+          if (!arr.includes(pr.mode)) { arr.push(pr.mode); }
+          map.set(pr.name, arr);
+        });
+        this.providers = Array.from(map.entries())
+          .map(([name, modes]) => ({ name, modes }));
+        this.updateModeCtrl(this.form.controls['provider'].value);
+      },
+      error: err => this.snack.open(err.message ?? 'Load providers failed', 'Close')
     });
   }
 
@@ -105,6 +128,7 @@ export class SettingsAdminComponent implements OnInit {
         this.refresh();
         this.form.reset({ mode: 'PULL', priority: 1, refreshMs: 1000, enabled: true, pair: '', provider: '' });
         this.form.controls['refreshMs'].enable();
+        this.updateModeCtrl(this.form.controls['provider'].value);
         this.updateRefreshCtrl(this.form.controls['mode'].value);
         this.locked = false;
       },
@@ -129,6 +153,7 @@ export class SettingsAdminComponent implements OnInit {
       refreshMs: c.refreshMs,
       enabled: c.enabled
     });
+    this.updateModeCtrl(c.provider);
     this.updateRefreshCtrl(c.mode);
     this.form.controls['pair'].disable();
     this.form.controls['provider'].disable();
@@ -171,8 +196,31 @@ export class SettingsAdminComponent implements OnInit {
     this.form.controls['provider'].enable();
     this.form.controls['mode'].enable();
     this.form.controls['refreshMs'].enable();
+    this.updateModeCtrl(this.form.controls['provider'].value);
     this.updateRefreshCtrl(this.form.controls['mode'].value);
     this.locked = false;
+  }
+
+  /**
+   * Обновляем состояние поля режима в зависимости от провайдера
+   */
+  private updateModeCtrl(provider: string): void {
+    const modeCtrl = this.form.controls['mode'];
+    const item = this.providers.find(p => p.name === provider);
+    if (!item) { this.availableModes = ['PULL', 'PUSH']; modeCtrl.enable(); return; }
+
+    this.availableModes = item.modes;
+
+    if (item.modes.length === 1) {
+      modeCtrl.setValue(item.modes[0]);
+      modeCtrl.disable();
+    } else {
+      modeCtrl.enable();
+      if (!item.modes.includes(modeCtrl.value)) {
+        modeCtrl.setValue(item.modes[0]);
+      }
+    }
+    this.updateRefreshCtrl(modeCtrl.value);
   }
 
   /**


### PR DESCRIPTION
## Summary
- fetch providers and modes for stream settings
- set available mode list according to selected provider
- update view with provider drop-down

## Testing
- `./mvnw -q test` *(fails: network access blocked)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857da0b8acc832da023a39ff10e8533