### PR TITLE
Fix mode value for stream settings

### DIFF
--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
@@ -120,7 +120,8 @@ export class SettingsAdminComponent implements OnInit {
 
     this.locked = true;
 
-    const dto: SettingsCreateDto = this.form.value;
+    // getRawValue() позволяет получить значения выключенных контролов (mode)
+    const dto: SettingsCreateDto = this.form.getRawValue() as SettingsCreateDto;
 
     this.service.add(dto).subscribe({
       next: id => {


### PR DESCRIPTION
## Summary
- fix mode form submission by using `getRawValue()` when adding streaming settings

## Testing
- `./mvnw -q test` *(fails: network access blocked)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857de5a6d9c832d82bb385749f7c8e1