### PR TITLE
Update provider uniqueness

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/entity/Provider.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/entity/Provider.java
@@ -14,8 +14,8 @@ import lombok.Setter;
         name = "provider",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "uq_provider_name_mode",
-                        columnNames = {"name", "mode"}
+                        name = "uq_provider_name",
+                        columnNames = {"name"}
                 )
         }
 )

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/exceptions/DuplicateProviderException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/exceptions/DuplicateProviderException.java
@@ -4,7 +4,7 @@ package com.alligator.market.backend.quotes.stream.providers.list.exceptions;
  * Очевидно из названия.
  */
 public class DuplicateProviderException extends RuntimeException {
-    public DuplicateProviderException(String name, String mode) {
-        super("Provider '%s' with mode '%s' already exists".formatted(name, mode));
+    public DuplicateProviderException(String name) {
+        super("Provider '%s' already exists".formatted(name));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/exceptions/ProviderNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/exceptions/ProviderNotFoundException.java
@@ -6,7 +6,7 @@ import jakarta.persistence.EntityNotFoundException;
  * Очевидно из названия.
  */
 public class ProviderNotFoundException extends EntityNotFoundException {
-    public ProviderNotFoundException(String name, String mode) {
-        super("Provider '%s' with mode '%s' not found".formatted(name, mode));
+    public ProviderNotFoundException(String name) {
+        super("Provider '%s' not found".formatted(name));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/repository/ProviderRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/repository/ProviderRepository.java
@@ -12,6 +12,4 @@ public interface ProviderRepository extends JpaRepository<Provider, Long> {
 
     Optional<Provider> findByName(String name);
 
-    Optional<Provider> findByNameAndMode(String name, String mode);
-
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/service/ProviderService.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/service/ProviderService.java
@@ -13,9 +13,9 @@ public interface ProviderService {
 
     String createProvider(ProviderCreateDto dto);
 
-    void updateProvider(String name, String mode, ProviderUpdateDto dto);
+    void updateProvider(String name, ProviderUpdateDto dto);
 
-    void deleteProvider(String name, String mode);
+    void deleteProvider(String name);
 
     List<ProviderDto> findAll();
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/service/ProviderServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/service/ProviderServiceImpl.java
@@ -32,8 +32,8 @@ public class ProviderServiceImpl implements ProviderService {
     @Override
     public String createProvider(ProviderCreateDto dto) {
 
-        repository.findByNameAndMode(dto.name(), dto.mode()).ifPresent(p -> {
-            throw new DuplicateProviderException(dto.name(), dto.mode());
+        repository.findByName(dto.name()).ifPresent(p -> {
+            throw new DuplicateProviderException(dto.name());
         });
 
         Provider entity = new Provider();
@@ -51,36 +51,30 @@ public class ProviderServiceImpl implements ProviderService {
     // Обновить провайдера
     //====================
     @Override
-    public void updateProvider(String name, String mode, ProviderUpdateDto dto) {
+    public void updateProvider(String name, ProviderUpdateDto dto) {
 
-        Provider provider = repository.findByNameAndMode(name, mode)
-                .orElseThrow(() -> new ProviderNotFoundException(name, mode));
-
-        if (!mode.equals(dto.mode())) {
-            repository.findByNameAndMode(name, dto.mode()).ifPresent(p -> {
-                throw new DuplicateProviderException(name, dto.mode());
-            });
-        }
+        Provider provider = repository.findByName(name)
+                .orElseThrow(() -> new ProviderNotFoundException(name));
 
         provider.setBaseUrl(dto.baseUrl());
         provider.setMode(dto.mode());
         provider.setApiKey(dto.apiKey());
 
         repository.save(provider);
-        log.info("Provider {}:{} updated (id={})", provider.getName(), provider.getMode(), provider.getId());
+        log.info("Provider {} updated (id={})", provider.getName(), provider.getId());
     }
 
     //===================
     // Удалить провайдера
     //===================
     @Override
-    public void deleteProvider(String name, String mode) {
+    public void deleteProvider(String name) {
 
-        Provider provider = repository.findByNameAndMode(name, mode)
-                .orElseThrow(() -> new ProviderNotFoundException(name, mode));
+        Provider provider = repository.findByName(name)
+                .orElseThrow(() -> new ProviderNotFoundException(name));
 
         repository.delete(provider);
-        log.info("Provider {}:{} deleted (id={})", provider.getName(), provider.getMode(), provider.getId());
+        log.info("Provider {} deleted (id={})", provider.getName(), provider.getId());
     }
 
     //=========================

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/web/ProviderController.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/web/ProviderController.java
@@ -36,8 +36,8 @@ public class ProviderController {
         String name = service.createProvider(dto);
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
-                .path("/{name}/{mode}")
-                .buildAndExpand(name, dto.mode())
+                .path("/{name}")
+                .buildAndExpand(name)
                 .toUri();
         return ResponseEntityFactory.created(location, name);
     }
@@ -45,24 +45,22 @@ public class ProviderController {
     //====================
     // Обновить провайдера
     //====================
-    @PutMapping("/{name}/{mode}")
+    @PutMapping("/{name}")
     public ResponseEntity<ApiResponse<Void>> update(
             @PathVariable String name,
-            @PathVariable String mode,
             @RequestBody @Valid ProviderUpdateDto dto) {
-        service.updateProvider(name, mode, dto);
+        service.updateProvider(name, dto);
         return ResponseEntityFactory.ok(null);
     }
 
     //===================
     // Удалить провайдера
     //===================
-    @DeleteMapping("/{name}/{mode}")
+    @DeleteMapping("/{name}")
     public ResponseEntity<ApiResponse<Void>> delete(
-            @PathVariable String name,
-            @PathVariable String mode) {
+            @PathVariable String name) {
 
-        service.deleteProvider(name, mode);
+        service.deleteProvider(name);
         return ResponseEntityFactory.ok(null);
     }
 

--- a/backend/src/main/resources/db/migration/V10__provider_unique_name.sql
+++ b/backend/src/main/resources/db/migration/V10__provider_unique_name.sql
@@ -1,0 +1,5 @@
+ALTER TABLE provider
+    DROP CONSTRAINT IF EXISTS uq_provider_name_mode;
+
+ALTER TABLE provider
+    ADD CONSTRAINT uq_provider_name UNIQUE (name);

--- a/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.ts
+++ b/frontend/src/app/features/providers/pages/provider-admin/provider-admin.component.ts
@@ -50,7 +50,6 @@ export class ProviderAdminComponent implements OnInit {
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
   editName: string | null = null; // имя провайдера для редактирования
-  editMode: string | null = null; // текущий режим провайдера для редактирования
 
   constructor(
     private readonly service: ProviderService,
@@ -115,7 +114,6 @@ export class ProviderAdminComponent implements OnInit {
   onEdit(p: ProviderDto): void {
     this.editing = true;
     this.editName = p.name;
-    this.editMode = p.mode;
     this.form.setValue({
       name: p.name,
       baseUrl: p.baseUrl,
@@ -126,7 +124,7 @@ export class ProviderAdminComponent implements OnInit {
   }
 
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editName || !this.editMode) { return; }
+    if (this.form.invalid || this.locked || !this.editName) { return; }
 
     this.locked = true;
 
@@ -136,7 +134,7 @@ export class ProviderAdminComponent implements OnInit {
       apiKey: this.form.controls['apiKey'].value
     } as ProviderUpdateDto;
 
-    this.service.update(this.editName, this.editMode, dto).subscribe({
+    this.service.update(this.editName, dto).subscribe({
       next: () => {
         this.snack.open(`Provider '${this.editName}' updated to mode '${dto.mode}'`, 'OK', { duration: 2500 });
         this.refresh();
@@ -154,14 +152,13 @@ export class ProviderAdminComponent implements OnInit {
   cancelEdit(): void {
     this.editing = false;
     this.editName = null;
-    this.editMode = null;
     this.form.reset({ name: '', baseUrl: '', mode: 'PULL', apiKey: '' });
     this.form.controls['name'].enable();
     this.locked = false;
   }
 
   onDelete(name: string, mode: string): void {
-    this.service.delete(name, mode).subscribe({
+    this.service.delete(name).subscribe({
       next: () => {
         this.snack.open(`Provider '${name}' with mode '${mode}' deleted`, 'OK', { duration: 2500 });
         this.refresh();

--- a/frontend/src/app/features/providers/services/provider.service.ts
+++ b/frontend/src/app/features/providers/services/provider.service.ts
@@ -31,17 +31,17 @@ export class ProviderService {
       .pipe(map(res => res.data));
   }
 
-  /* Удалить провайдера по имени и режиму */
-  delete(name: string, mode: string): Observable<void> {
+  /* Удалить провайдера по имени */
+  delete(name: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${name}/${mode}`)
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${name}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить провайдера по имени и режиму */
-  update(name: string, mode: string, dto: ProviderUpdateDto): Observable<void> {
+  /* Обновить провайдера по имени */
+  update(name: string, dto: ProviderUpdateDto): Observable<void> {
     return this.http
-      .put<ApiResponse<void>>(`${this.baseUrl}/${name}/${mode}`, dto)
+      .put<ApiResponse<void>>(`${this.baseUrl}/${name}`, dto)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- change DB schema: provider is unique only by name
- adjust entity constraint and repository
- simplify provider service API
- update REST controller and frontend service
- adjust provider admin component

## Testing
- `sh backend/mvnw -q test` *(fails: Maven not installed)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599bb282f0832d8cc083d32664ec1c