### PR TITLE
Update ccypair feed settings uniqueness

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 @Table(
         name = "ccypair_feed_settings",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_ccypair_feed_settings_pair_provider_mode", columnNames = {"pair_id", "provider", "mode"})
+                @UniqueConstraint(name = "uq_ccypair_feed_settings_pair_provider", columnNames = {"pair_id", "provider"})
         }
 )
 @Getter

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/exceptions/DuplicateSettingsException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/exceptions/DuplicateSettingsException.java
@@ -4,7 +4,7 @@ package com.alligator.market.backend.quotes.stream.ccypair_feed_settings.excepti
  * Исключение при попытке создать повторную запись для той же валютной пары, провайдера и режима.
  */
 public class DuplicateSettingsException extends RuntimeException {
-    public DuplicateSettingsException(String pair, String provider, String mode) {
-        super("Streaming settings for pair '%s', provider '%s' and mode '%s' already exists".formatted(pair, provider, mode));
+    public DuplicateSettingsException(String pair, String provider) {
+        super("Streaming settings for pair '%s' and provider '%s' already exists".formatted(pair, provider));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/exceptions/SettingsNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/exceptions/SettingsNotFoundException.java
@@ -6,7 +6,7 @@ import jakarta.persistence.EntityNotFoundException;
  * Очевидно из названия.
  */
 public class SettingsNotFoundException extends EntityNotFoundException {
-    public SettingsNotFoundException(String pair, String provider, String mode) {
-        super("Streaming settings for pair '%s', provider '%s' and mode '%s' not found".formatted(pair, provider, mode));
+    public SettingsNotFoundException(String pair, String provider) {
+        super("Streaming settings for pair '%s' and provider '%s' not found".formatted(pair, provider));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/repository/SettingsRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/repository/SettingsRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
  */
 public interface SettingsRepository extends JpaRepository<CcyPairFeedSettingsEntity, Long> {
 
-    Optional<CcyPairFeedSettingsEntity> findByPair_PairAndProviderAndMode(String pair, String provider, String mode);
+    Optional<CcyPairFeedSettingsEntity> findByPair_PairAndProvider(String pair, String provider);
 
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsService.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsService.java
@@ -13,9 +13,9 @@ public interface SettingsService {
 
     String createConfig(SettingsCreateDto dto);
 
-    void updateConfig(String pair, String provider, String mode, SettingsUpdateDto dto);
+    void updateConfig(String pair, String provider, SettingsUpdateDto dto);
 
-    void deleteConfig(String pair, String provider, String mode);
+    void deleteConfig(String pair, String provider);
 
     List<SettingsDto> findAll();
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
@@ -38,8 +38,8 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     public String createConfig(SettingsCreateDto dto) {
 
-        repository.findByPair_PairAndProviderAndMode(dto.pair(), dto.provider(), dto.mode()).ifPresent(c -> {
-            throw new DuplicateSettingsException(dto.pair(), dto.provider(), dto.mode());
+        repository.findByPair_PairAndProvider(dto.pair(), dto.provider()).ifPresent(c -> {
+            throw new DuplicateSettingsException(dto.pair(), dto.provider());
         });
 
         Pair pair = pairRepository.findByPair(dto.pair())
@@ -69,10 +69,10 @@ public class SettingsServiceImpl implements SettingsService {
     // Обновить настройки
     //===================
     @Override
-    public void updateConfig(String pair, String provider, String mode, SettingsUpdateDto dto) {
+    public void updateConfig(String pair, String provider, SettingsUpdateDto dto) {
 
-        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProviderAndMode(pair, provider, mode)
-                .orElseThrow(() -> new SettingsNotFoundException(pair, provider, mode));
+        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider(pair, provider)
+                .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
 
         entity.setPriority(dto.priority());
         // Если режим PUSH, интервал задаётся провайдером, поэтому сохраняем 0.
@@ -81,20 +81,20 @@ public class SettingsServiceImpl implements SettingsService {
         entity.setEnabled(dto.enabled());
 
         repository.save(entity);
-        log.info("CcyPairFeedSettingsEntity {}:{}:{} updated (id={})", pair, provider, mode, entity.getId());
+        log.info("CcyPairFeedSettingsEntity {}:{} updated (id={})", pair, provider, entity.getId());
     }
 
     //==================
     // Удалить настройки
     //==================
     @Override
-    public void deleteConfig(String pair, String provider, String mode) {
+    public void deleteConfig(String pair, String provider) {
 
-        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProviderAndMode(pair, provider, mode)
-                .orElseThrow(() -> new SettingsNotFoundException(pair, provider, mode));
+        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider(pair, provider)
+                .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
 
         repository.delete(entity);
-        log.info("CcyPairFeedSettingsEntity {}:{}:{} deleted (id={})", pair, provider, mode, entity.getId());
+        log.info("CcyPairFeedSettingsEntity {}:{} deleted (id={})", pair, provider, entity.getId());
     }
 
     //======================

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/web/FxPairStreamingConfigController.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/web/FxPairStreamingConfigController.java
@@ -36,8 +36,8 @@ public class FxPairStreamingConfigController {
         String id = service.createConfig(dto);
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
-                .path("/{pair}/{provider}/{mode}")
-                .buildAndExpand(dto.pair(), dto.provider(), dto.mode())
+                .path("/{pair}/{provider}")
+                .buildAndExpand(dto.pair(), dto.provider())
                 .toUri();
         return ResponseEntityFactory.created(location, id);
     }
@@ -45,25 +45,23 @@ public class FxPairStreamingConfigController {
     //===================
     // Обновить настройки
     //===================
-    @PutMapping("/{pair}/{provider}/{mode}")
+    @PutMapping("/{pair}/{provider}")
     public ResponseEntity<ApiResponse<Void>> update(
             @PathVariable String pair,
             @PathVariable String provider,
-            @PathVariable String mode,
             @RequestBody @Valid SettingsUpdateDto dto) {
-        service.updateConfig(pair, provider, mode, dto);
+        service.updateConfig(pair, provider, dto);
         return ResponseEntityFactory.ok(null);
     }
 
     //==================
     // Удалить настройки
     //==================
-    @DeleteMapping("/{pair}/{provider}/{mode}")
+    @DeleteMapping("/{pair}/{provider}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable String pair,
-            @PathVariable String provider,
-            @PathVariable String mode) {
-        service.deleteConfig(pair, provider, mode);
+            @PathVariable String provider) {
+        service.deleteConfig(pair, provider);
         return ResponseEntityFactory.ok(null);
     }
 

--- a/backend/src/main/resources/db/migration/V11__ccypair_feed_settings_unique_pair_provider.sql
+++ b/backend/src/main/resources/db/migration/V11__ccypair_feed_settings_unique_pair_provider.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ccypair_feed_settings
+    DROP CONSTRAINT IF EXISTS uq_ccypair_feed_settings_pair_provider_mode;
+
+ALTER TABLE ccypair_feed_settings
+    ADD CONSTRAINT uq_ccypair_feed_settings_pair_provider UNIQUE (pair_id, provider);

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
@@ -115,7 +115,7 @@
             <button mat-icon-button color="primary" (click)="onEdit(c)">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button color="warn" (click)="onDelete(c.pair, c.provider, c.mode)">
+            <button mat-icon-button color="warn" (click)="onDelete(c.pair, c.provider)">
               <mat-icon>delete</mat-icon>
             </button>
           </td>

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
@@ -57,7 +57,6 @@ export class SettingsAdminComponent implements OnInit {
   editing = false;
   editPair: string | null = null;
   editProvider: string | null = null;
-  editMode: string | null = null;
   pairs: PairDto[] = [];
   providers: { name: string, modes: string[] }[] = [];
   availableModes: string[] = ['PULL', 'PUSH'];
@@ -145,7 +144,6 @@ export class SettingsAdminComponent implements OnInit {
     this.editing = true;
     this.editPair = c.pair;
     this.editProvider = c.provider;
-    this.editMode = c.mode;
     this.form.setValue({
       pair: c.pair,
       provider: c.provider,
@@ -162,7 +160,7 @@ export class SettingsAdminComponent implements OnInit {
   }
 
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editPair || !this.editProvider || !this.editMode) { return; }
+    if (this.form.invalid || this.locked || !this.editPair || !this.editProvider) { return; }
 
     this.locked = true;
 
@@ -172,7 +170,7 @@ export class SettingsAdminComponent implements OnInit {
       enabled: this.form.controls['enabled'].value
     } as SettingsUpdateDto;
 
-    this.service.update(this.editPair, this.editProvider, this.editMode, dto).subscribe({
+    this.service.update(this.editPair, this.editProvider, dto).subscribe({
       next: () => {
         this.snack.open(`Settings '${this.editPair}:${this.editProvider}' updated`, 'OK', { duration: 2500 });
         this.refresh();
@@ -191,7 +189,6 @@ export class SettingsAdminComponent implements OnInit {
     this.editing = false;
     this.editPair = null;
     this.editProvider = null;
-    this.editMode = null;
     this.form.reset({ pair: '', provider: '', mode: 'PULL', priority: 1, refreshMs: 1000, enabled: true });
     this.form.controls['pair'].enable();
     this.form.controls['provider'].enable();
@@ -240,8 +237,8 @@ export class SettingsAdminComponent implements OnInit {
     }
   }
 
-  onDelete(pair: string, provider: string, mode: string): void {
-    this.service.delete(pair, provider, mode).subscribe({
+  onDelete(pair: string, provider: string): void {
+    this.service.delete(pair, provider).subscribe({
       next: () => {
         this.snack.open(`Settings '${pair}:${provider}' deleted`, 'OK', { duration: 2500 });
         this.refresh();

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/services/settings.service.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/services/settings.service.ts
@@ -31,17 +31,17 @@ export class SettingsService {
       .pipe(map(res => res.data));
   }
 
-  /* Удалить настройки по паре, провайдеру и режиму */
-  delete(pair: string, provider: string, mode: string): Observable<void> {
+  /* Удалить настройки по паре и провайдеру */
+  delete(pair: string, provider: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}/${mode}`)
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить настройки по паре, провайдеру и режиму */
-  update(pair: string, provider: string, mode: string, dto: SettingsUpdateDto): Observable<void> {
+  /* Обновить настройки по паре и провайдеру */
+  update(pair: string, provider: string, dto: SettingsUpdateDto): Observable<void> {
     return this.http
-      .put<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}/${mode}`, dto)
+      .put<ApiResponse<void>>(`${this.baseUrl}/${pair}/${provider}`, dto)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- drop mode column from ccypair feed settings unique constraint
- refactor backend service/controller/repository to use pair+provider
- adjust frontend stream settings admin page and service
- add migration to update DB schema

## Testing
- `./mvnw -q test` *(fails: Failed to fetch ...)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a5e5e4d4832da49a2680acc903e1