### PR TITLE
Add provider foreign key for feed settings

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.quotes.stream.ccypair_feed_settings.entity;
 
 import com.alligator.market.backend.ccypairs.entity.Pair;
 import com.alligator.market.backend.common.jpa.entity.BaseEntity;
+import com.alligator.market.backend.quotes.stream.providers.list.entity.Provider;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,9 +35,11 @@ public class CcyPairFeedSettingsEntity extends BaseEntity {
             foreignKey = @ForeignKey(name = "fk_feed_settings_pair"))
     private Pair pair;
 
-    /* Имя провайдера котировок */
-    @Column(length = 50, nullable = false)
-    private String provider;
+    /* Провайдер котировок (FK на provider.name) */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "provider", referencedColumnName = "name",
+            foreignKey = @ForeignKey(name = "fk_feed_settings_provider"))
+    private Provider provider;
 
     /* Режим стриминга (PULL/PUSH) */
     @Column(length = 4, nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/mapper/CcyPairFeedSettingsMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/mapper/CcyPairFeedSettingsMapper.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.quotes.stream.ccypair_feed_settings.mapper;
 
 import com.alligator.market.backend.ccypairs.entity.Pair;
 import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.entity.CcyPairFeedSettingsEntity;
+import com.alligator.market.backend.quotes.stream.providers.list.entity.Provider;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,7 +15,7 @@ public class CcyPairFeedSettingsMapper {
     public com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings toDomain(CcyPairFeedSettingsEntity entity) {
         return new com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings(
                 entity.getPair().getPair(),
-                entity.getProvider(),
+                entity.getProvider().getName(),
                 entity.getMode(),
                 entity.getPriority(),
                 entity.getRefreshMs(),
@@ -22,10 +23,13 @@ public class CcyPairFeedSettingsMapper {
         );
     }
 
-    public CcyPairFeedSettingsEntity toEntity(com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings cfg, Pair pair) {
+    public CcyPairFeedSettingsEntity toEntity(
+            com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings cfg,
+            Pair pair,
+            Provider provider) {
         CcyPairFeedSettingsEntity entity = new CcyPairFeedSettingsEntity();
         entity.setPair(pair);
-        entity.setProvider(cfg.provider());
+        entity.setProvider(provider);
         entity.setMode(cfg.mode());
         entity.setPriority(cfg.priority());
         entity.setRefreshMs(cfg.refreshMs());

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/repository/SettingsRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/repository/SettingsRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
  */
 public interface SettingsRepository extends JpaRepository<CcyPairFeedSettingsEntity, Long> {
 
-    Optional<CcyPairFeedSettingsEntity> findByPair_PairAndProvider(String pair, String provider);
+    Optional<CcyPairFeedSettingsEntity> findByPair_PairAndProvider_Name(String pair, String provider);
 
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
@@ -11,6 +11,9 @@ import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.exceptio
 import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.exceptions.SettingsNotFoundException;
 import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.mapper.CcyPairFeedSettingsMapper;
 import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.repository.SettingsRepository;
+import com.alligator.market.backend.quotes.stream.providers.list.entity.Provider;
+import com.alligator.market.backend.quotes.stream.providers.list.exceptions.ProviderNotFoundException;
+import com.alligator.market.backend.quotes.stream.providers.list.repository.ProviderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
@@ -30,6 +33,7 @@ public class SettingsServiceImpl implements SettingsService {
 
     private final SettingsRepository repository;
     private final PairRepository pairRepository;
+    private final ProviderRepository providerRepository;
     private final CcyPairFeedSettingsMapper mapper;
 
     //========================
@@ -38,7 +42,7 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     public String createConfig(SettingsCreateDto dto) {
 
-        repository.findByPair_PairAndProvider(dto.pair(), dto.provider()).ifPresent(c -> {
+        repository.findByPair_PairAndProvider_Name(dto.pair(), dto.provider()).ifPresent(c -> {
             throw new DuplicateSettingsException(dto.pair(), dto.provider());
         });
 
@@ -47,6 +51,9 @@ public class SettingsServiceImpl implements SettingsService {
 
         // Для PUSH-интервал определяет провайдер, поэтому устанавливаем 0.
         int refreshMs = "PUSH".equals(dto.mode()) ? 0 : dto.refreshMs();
+
+        Provider provider = providerRepository.findByName(dto.provider())
+                .orElseThrow(() -> new ProviderNotFoundException(dto.provider()));
 
         CcyPairFeedSettingsEntity entity = mapper.toEntity(
                 new com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings(
@@ -57,12 +64,13 @@ public class SettingsServiceImpl implements SettingsService {
                         refreshMs,
                         dto.enabled()
                 ),
-                pair
+                pair,
+                provider
         );
 
         CcyPairFeedSettingsEntity saved = repository.save(entity);
         log.info("CcyPairFeedSettingsEntity {}:{}:{} saved with id={}", dto.pair(), dto.provider(), dto.mode(), saved.getId());
-        return "%s:%s:%s".formatted(saved.getPair().getPair(), saved.getProvider(), saved.getMode());
+        return "%s:%s:%s".formatted(saved.getPair().getPair(), saved.getProvider().getName(), saved.getMode());
     }
 
     //===================
@@ -71,7 +79,7 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     public void updateConfig(String pair, String provider, SettingsUpdateDto dto) {
 
-        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider(pair, provider)
+        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider_Name(pair, provider)
                 .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
 
         entity.setPriority(dto.priority());
@@ -90,7 +98,7 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     public void deleteConfig(String pair, String provider) {
 
-        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider(pair, provider)
+        CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider_Name(pair, provider)
                 .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
 
         repository.delete(entity);
@@ -104,11 +112,11 @@ public class SettingsServiceImpl implements SettingsService {
     @Transactional(readOnly = true)
     public List<SettingsDto> findAll() {
 
-        List<SettingsDto> result = repository.findAll(Sort.by("pair.pair", "provider", "mode"))
+        List<SettingsDto> result = repository.findAll(Sort.by("pair.pair", "provider.name", "mode"))
                 .stream()
                 .map(cfg -> new SettingsDto(
                         cfg.getPair().getPair(),
-                        cfg.getProvider(),
+                        cfg.getProvider().getName(),
                         cfg.getMode(),
                         cfg.getPriority(),
                         cfg.getRefreshMs(),

--- a/backend/src/main/resources/db/migration/V12__ccypair_feed_settings_provider_fk.sql
+++ b/backend/src/main/resources/db/migration/V12__ccypair_feed_settings_provider_fk.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ccypair_feed_settings
+    ADD CONSTRAINT fk_ccypair_feed_settings_provider FOREIGN KEY (provider) REFERENCES provider (name);


### PR DESCRIPTION
## Summary
- reference quote provider entity from feed settings
- update mapper and service logic
- search settings by provider name
- enforce provider constraint with a new migration

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a8dc4e6c832d91fa924f3059b40a