### PR TITLE
Add check for used providers

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/repository/SettingsRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/repository/SettingsRepository.java
@@ -12,4 +12,7 @@ public interface SettingsRepository extends JpaRepository<CcyPairFeedSettingsEnt
 
     Optional<CcyPairFeedSettingsEntity> findByPair_PairAndProvider_Name(String pair, String provider);
 
+    /* Проверяет, используются ли настройки для указанного провайдера */
+    boolean existsByProvider_Name(String provider);
+
 }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/exceptions/ProviderUsedInSettingsException.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/exceptions/ProviderUsedInSettingsException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.backend.quotes.stream.providers.list.exceptions;
+
+/**
+ * Нельзя удалить провайдера, если он используется в настройках потоков котировок.
+ */
+public class ProviderUsedInSettingsException extends RuntimeException {
+    public ProviderUsedInSettingsException(String name) {
+        super("Provider '%s' used in feed settings".formatted(name));
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/service/ProviderServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/service/ProviderServiceImpl.java
@@ -4,8 +4,10 @@ import com.alligator.market.backend.quotes.stream.providers.list.dto.ProviderCre
 import com.alligator.market.backend.quotes.stream.providers.list.dto.ProviderDto;
 import com.alligator.market.backend.quotes.stream.providers.list.dto.ProviderUpdateDto;
 import com.alligator.market.backend.quotes.stream.providers.list.entity.Provider;
+import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.repository.SettingsRepository;
 import com.alligator.market.backend.quotes.stream.providers.list.exceptions.DuplicateProviderException;
 import com.alligator.market.backend.quotes.stream.providers.list.exceptions.ProviderNotFoundException;
+import com.alligator.market.backend.quotes.stream.providers.list.exceptions.ProviderUsedInSettingsException;
 import com.alligator.market.backend.quotes.stream.providers.list.repository.ProviderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,7 @@ import java.util.List;
 public class ProviderServiceImpl implements ProviderService {
 
     private final ProviderRepository repository;
+    private final SettingsRepository settingsRepository;
 
     //==========================
     // Создать нового провайдера
@@ -72,6 +75,11 @@ public class ProviderServiceImpl implements ProviderService {
 
         Provider provider = repository.findByName(name)
                 .orElseThrow(() -> new ProviderNotFoundException(name));
+
+        // Проверка, что провайдер не используется в настройках
+        if (settingsRepository.existsByProvider_Name(name)) {
+            throw new ProviderUsedInSettingsException(name);
+        }
 
         repository.delete(provider);
         log.info("Provider {} deleted (id={})", provider.getName(), provider.getId());

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/web/ProviderRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/list/web/ProviderRestExceptionHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.common.web.dto.ApiResponse;
 import com.alligator.market.backend.common.web.util.ResponseEntityFactory;
 import com.alligator.market.backend.quotes.stream.providers.list.exceptions.DuplicateProviderException;
 import com.alligator.market.backend.quotes.stream.providers.list.exceptions.ProviderNotFoundException;
+import com.alligator.market.backend.quotes.stream.providers.list.exceptions.ProviderUsedInSettingsException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -37,6 +38,15 @@ public class ProviderRestExceptionHandler {
 
         log.warn("ProviderNotFoundException: {}", ex.getMessage());
         return ResponseEntityFactory.notFound(ex.getMessage());
+    }
+
+    /* Провайдер используется в настройках. */
+    @ExceptionHandler(ProviderUsedInSettingsException.class)
+    public ResponseEntity<ApiResponse<Void>> handleProviderUsed(
+            ProviderUsedInSettingsException ex) {
+
+        log.warn("ProviderUsedInSettingsException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.CONFLICT, ex.getMessage());
     }
 
 }


### PR DESCRIPTION
## Summary
- block deleting a provider if it is referenced in `ccypair_feed_settings`
- notify client when provider is in use

## Testing
- `./backend/mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6859ad426c64832d9f5fecc7eb2401ba