### PR TITLE
Remove mode field from stream settings

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsCreateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsCreateDto.java
@@ -15,10 +15,6 @@ public record SettingsCreateDto(
         @Size(max = 50)
         String provider,
 
-        @NotBlank
-        @Pattern(regexp = "^(PULL|PUSH)$")
-        String mode,
-
         @NotNull
         @Min(0) @Max(32767)
         Short priority,

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsDto.java
@@ -15,10 +15,6 @@ public record SettingsDto(
         @Size(max = 50)
         String provider,
 
-        @NotBlank
-        @Pattern(regexp = "^(PULL|PUSH)$")
-        String mode,
-
         @NotNull
         @Min(0) @Max(32767)
         Short priority,

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
@@ -41,9 +41,6 @@ public class CcyPairFeedSettingsEntity extends BaseEntity {
             foreignKey = @ForeignKey(name = "fk_feed_settings_provider"))
     private Provider provider;
 
-    /* Режим стриминга (PULL/PUSH) */
-    @Column(length = 4, nullable = false)
-    private String mode;
 
     /* Приоритет провайдера для пары */
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/mapper/CcyPairFeedSettingsMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/mapper/CcyPairFeedSettingsMapper.java
@@ -16,7 +16,6 @@ public class CcyPairFeedSettingsMapper {
         return new com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings(
                 entity.getPair().getPair(),
                 entity.getProvider().getName(),
-                entity.getMode(),
                 entity.getPriority(),
                 entity.getRefreshMs(),
                 entity.isEnabled()
@@ -30,7 +29,6 @@ public class CcyPairFeedSettingsMapper {
         CcyPairFeedSettingsEntity entity = new CcyPairFeedSettingsEntity();
         entity.setPair(pair);
         entity.setProvider(provider);
-        entity.setMode(cfg.mode());
         entity.setPriority(cfg.priority());
         entity.setRefreshMs(cfg.refreshMs());
         entity.setEnabled(cfg.enabled());

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
@@ -49,17 +49,16 @@ public class SettingsServiceImpl implements SettingsService {
         Pair pair = pairRepository.findByPair(dto.pair())
                 .orElseThrow(() -> new PairNotFoundException(dto.pair()));
 
-        // Для PUSH-интервал определяет провайдер, поэтому устанавливаем 0.
-        int refreshMs = "PUSH".equals(dto.mode()) ? 0 : dto.refreshMs();
-
         Provider provider = providerRepository.findByName(dto.provider())
                 .orElseThrow(() -> new ProviderNotFoundException(dto.provider()));
+
+        // Для PUSH-интервал определяет провайдер, поэтому устанавливаем 0.
+        int refreshMs = "PUSH".equals(provider.getMode()) ? 0 : dto.refreshMs();
 
         CcyPairFeedSettingsEntity entity = mapper.toEntity(
                 new com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings(
                         dto.pair(),
                         dto.provider(),
-                        dto.mode(),
                         dto.priority(),
                         refreshMs,
                         dto.enabled()
@@ -69,8 +68,8 @@ public class SettingsServiceImpl implements SettingsService {
         );
 
         CcyPairFeedSettingsEntity saved = repository.save(entity);
-        log.info("CcyPairFeedSettingsEntity {}:{}:{} saved with id={}", dto.pair(), dto.provider(), dto.mode(), saved.getId());
-        return "%s:%s:%s".formatted(saved.getPair().getPair(), saved.getProvider().getName(), saved.getMode());
+        log.info("CcyPairFeedSettingsEntity {}:{} saved with id={}", dto.pair(), dto.provider(), saved.getId());
+        return "%s:%s".formatted(saved.getPair().getPair(), saved.getProvider().getName());
     }
 
     //===================
@@ -84,7 +83,7 @@ public class SettingsServiceImpl implements SettingsService {
 
         entity.setPriority(dto.priority());
         // Если режим PUSH, интервал задаётся провайдером, поэтому сохраняем 0.
-        int refreshMs = "PUSH".equals(entity.getMode()) ? 0 : dto.refreshMs();
+        int refreshMs = "PUSH".equals(entity.getProvider().getMode()) ? 0 : dto.refreshMs();
         entity.setRefreshMs(refreshMs);
         entity.setEnabled(dto.enabled());
 
@@ -112,12 +111,11 @@ public class SettingsServiceImpl implements SettingsService {
     @Transactional(readOnly = true)
     public List<SettingsDto> findAll() {
 
-        List<SettingsDto> result = repository.findAll(Sort.by("pair.pair", "provider.name", "mode"))
+        List<SettingsDto> result = repository.findAll(Sort.by("pair.pair", "provider.name"))
                 .stream()
                 .map(cfg -> new SettingsDto(
                         cfg.getPair().getPair(),
                         cfg.getProvider().getName(),
-                        cfg.getMode(),
                         cfg.getPriority(),
                         cfg.getRefreshMs(),
                         cfg.isEnabled()

--- a/backend/src/main/resources/db/migration/V13__ccypair_feed_settings_drop_mode.sql
+++ b/backend/src/main/resources/db/migration/V13__ccypair_feed_settings_drop_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ccypair_feed_settings
+    DROP COLUMN IF EXISTS mode;

--- a/domain/src/main/java/com/alligator/market/domain/quotes/stream/settings/CcyPairFeedSettings.java
+++ b/domain/src/main/java/com/alligator/market/domain/quotes/stream/settings/CcyPairFeedSettings.java
@@ -7,7 +7,6 @@ public record CcyPairFeedSettings(
 
         String pair,
         String provider,
-        String mode,
         short priority,
         int refreshMs, // 0 для PUSH
         boolean enabled

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-create.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-create.model.ts
@@ -2,7 +2,6 @@
 export interface SettingsCreateDto {
   pair: string;
   provider: string;
-  mode: string;
   priority: number;
   refreshMs: number;
   enabled: boolean;

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings.model.ts
@@ -2,7 +2,6 @@
 export interface SettingsDto {
   pair: string;
   provider: string;
-  mode: string;
   priority: number;
   refreshMs: number;
   enabled: boolean;

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
@@ -32,15 +32,6 @@
           </mat-error>
         </mat-form-field>
 
-        <mat-form-field appearance="outline">
-          <mat-label>Mode</mat-label>
-          <mat-select formControlName="mode">
-            <mat-option *ngFor="let m of availableModes" [value]="m">{{ m }}</mat-option>
-          </mat-select>
-          <mat-error *ngIf="form.controls['mode'].hasError('required')">
-            Is required
-          </mat-error>
-        </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Priority</mat-label>
@@ -87,11 +78,6 @@
         <ng-container matColumnDef="provider">
           <th mat-header-cell *matHeaderCellDef>Provider</th>
           <td mat-cell *matCellDef="let c">{{ c.provider }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="mode">
-          <th mat-header-cell *matHeaderCellDef>Mode</th>
-          <td mat-cell *matCellDef="let c">{{ c.mode }}</td>
         </ng-container>
 
         <ng-container matColumnDef="priority">

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
@@ -45,7 +45,7 @@ export class SettingsAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['pair', 'provider', 'mode', 'priority', 'refreshMs', 'enabled', 'actions'];
+  displayed: string[] = ['pair', 'provider', 'priority', 'refreshMs', 'enabled', 'actions'];
   dataSource = new MatTableDataSource<SettingsDto>([]);
 
   //========================
@@ -58,8 +58,7 @@ export class SettingsAdminComponent implements OnInit {
   editPair: string | null = null;
   editProvider: string | null = null;
   pairs: PairDto[] = [];
-  providers: { name: string, modes: string[] }[] = [];
-  availableModes: string[] = ['PULL', 'PUSH'];
+  providers: ProviderDto[] = [];
 
   constructor(
     private readonly service: SettingsService,
@@ -71,22 +70,17 @@ export class SettingsAdminComponent implements OnInit {
     this.form = this.fb.group({
       pair: ['', [Validators.required]],
       provider: ['', [Validators.required, Validators.maxLength(50)]],
-      mode: ['PULL', [Validators.required]],
       priority: [1, [Validators.required, Validators.min(0), Validators.max(32767)]],
       refreshMs: [1000, [Validators.required, Validators.min(0)]],
       enabled: [true]
     });
 
-    // реакция на выбор режима
-    this.form.controls['mode'].valueChanges
-      .subscribe(m => this.updateRefreshCtrl(m));
-
     // реакция на выбор провайдера
     this.form.controls['provider'].valueChanges
-      .subscribe(p => this.updateModeCtrl(p));
+      .subscribe(p => this.updateRefreshCtrlByProvider(p));
 
     // начальное состояние поля периода
-    this.updateRefreshCtrl(this.form.controls['mode'].value);
+    this.updateRefreshCtrlByProvider(this.form.controls['provider'].value);
   }
 
   //=======================
@@ -100,15 +94,8 @@ export class SettingsAdminComponent implements OnInit {
     });
     this.providerService.list().subscribe({
       next: list => {
-        const map = new Map<string, string[]>();
-        list.forEach(pr => {
-          const arr = map.get(pr.name) ?? [];
-          if (!arr.includes(pr.mode)) { arr.push(pr.mode); }
-          map.set(pr.name, arr);
-        });
-        this.providers = Array.from(map.entries())
-          .map(([name, modes]) => ({ name, modes }));
-        this.updateModeCtrl(this.form.controls['provider'].value);
+        this.providers = list;
+        this.updateRefreshCtrlByProvider(this.form.controls['provider'].value);
       },
       error: err => this.snack.open(err.message ?? 'Load providers failed', 'Close')
     });
@@ -119,17 +106,16 @@ export class SettingsAdminComponent implements OnInit {
 
     this.locked = true;
 
-    // getRawValue() позволяет получить значения выключенных контролов (mode)
+    // getRawValue() позволяет получить значения выключенных контролов
     const dto: SettingsCreateDto = this.form.getRawValue() as SettingsCreateDto;
 
     this.service.add(dto).subscribe({
       next: id => {
         this.snack.open(`Settings '${id}' added`, 'OK', { duration: 2500 });
         this.refresh();
-        this.form.reset({ mode: 'PULL', priority: 1, refreshMs: 1000, enabled: true, pair: '', provider: '' });
+        this.form.reset({ priority: 1, refreshMs: 1000, enabled: true, pair: '', provider: '' });
         this.form.controls['refreshMs'].enable();
-        this.updateModeCtrl(this.form.controls['provider'].value);
-        this.updateRefreshCtrl(this.form.controls['mode'].value);
+        this.updateRefreshCtrlByProvider(this.form.controls['provider'].value);
         this.locked = false;
       },
       error: err => {
@@ -147,16 +133,13 @@ export class SettingsAdminComponent implements OnInit {
     this.form.setValue({
       pair: c.pair,
       provider: c.provider,
-      mode: c.mode,
       priority: c.priority,
       refreshMs: c.refreshMs,
       enabled: c.enabled
     });
-    this.updateModeCtrl(c.provider);
-    this.updateRefreshCtrl(c.mode);
+    this.updateRefreshCtrlByProvider(c.provider);
     this.form.controls['pair'].disable();
     this.form.controls['provider'].disable();
-    this.form.controls['mode'].disable();
   }
 
   onSave(): void {
@@ -189,43 +172,18 @@ export class SettingsAdminComponent implements OnInit {
     this.editing = false;
     this.editPair = null;
     this.editProvider = null;
-    this.form.reset({ pair: '', provider: '', mode: 'PULL', priority: 1, refreshMs: 1000, enabled: true });
+    this.form.reset({ pair: '', provider: '', priority: 1, refreshMs: 1000, enabled: true });
     this.form.controls['pair'].enable();
     this.form.controls['provider'].enable();
-    this.form.controls['mode'].enable();
     this.form.controls['refreshMs'].enable();
-    this.updateModeCtrl(this.form.controls['provider'].value);
-    this.updateRefreshCtrl(this.form.controls['mode'].value);
+    this.updateRefreshCtrlByProvider(this.form.controls['provider'].value);
     this.locked = false;
   }
 
-  /**
-   * Обновляем состояние поля режима в зависимости от провайдера
-   */
-  private updateModeCtrl(provider: string): void {
-    const modeCtrl = this.form.controls['mode'];
-    const item = this.providers.find(p => p.name === provider);
-    if (!item) { this.availableModes = ['PULL', 'PUSH']; modeCtrl.enable(); return; }
-
-    this.availableModes = item.modes;
-
-    if (item.modes.length === 1) {
-      modeCtrl.setValue(item.modes[0]);
-      modeCtrl.disable();
-    } else {
-      modeCtrl.enable();
-      if (!item.modes.includes(modeCtrl.value)) {
-        modeCtrl.setValue(item.modes[0]);
-      }
-    }
-    this.updateRefreshCtrl(modeCtrl.value);
-  }
-
-  /**
-   * Обновляем состояние поля периода в зависимости от режима
-   */
-  private updateRefreshCtrl(mode: string): void {
+  private updateRefreshCtrlByProvider(provider: string): void {
     const ctrl = this.form.controls['refreshMs'];
+    const item = this.providers.find(p => p.name === provider);
+    const mode = item?.mode ?? 'PULL';
     if (mode === 'PUSH') {
       ctrl.setValue(0);
       ctrl.disable();


### PR DESCRIPTION
## Summary
- drop `mode` column from ccypair_feed_settings table and entity
- adjust DTOs, mapper and service logic accordingly
- clean up domain model to exclude mode
- simplify Stream Settings admin UI without mode selection
- add migration to remove mode column

## Testing
- `mvnw test` *(fails: repo.maven.apache.org blocked)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b2473314832da49471b831848deb