### PR TITLE
Rename refreshMs column

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsCreateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsCreateDto.java
@@ -21,7 +21,7 @@ public record SettingsCreateDto(
 
         @NotNull
         @Min(0)
-        Integer refreshMs, // для PUSH игнорируется
+        Integer fetchPeriodMs, // для PUSH игнорируется
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsDto.java
@@ -21,7 +21,7 @@ public record SettingsDto(
 
         @NotNull
         @Min(0)
-        Integer refreshMs, // для PUSH игнорируется
+        Integer fetchPeriodMs, // для PUSH игнорируется
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsUpdateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/SettingsUpdateDto.java
@@ -15,7 +15,7 @@ public record SettingsUpdateDto(
 
         @NotNull
         @Min(0)
-        Integer refreshMs, // для PUSH игнорируется
+        Integer fetchPeriodMs, // для PUSH игнорируется
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/entity/CcyPairFeedSettingsEntity.java
@@ -45,9 +45,9 @@ public class CcyPairFeedSettingsEntity extends BaseEntity {
     @Column(nullable = false)
     private short priority;
 
-    /* Частота обновления, мс (для PUSH всегда 0) */
-    @Column(name = "refresh_ms", nullable = false)
-    private int refreshMs;
+    /* Период запроса котировок, мс (для PUSH всегда 0) */
+    @Column(name = "fetch_period_ms", nullable = false)
+    private int fetchPeriodMs;
 
     /* Признак активности потока */
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/mapper/CcyPairFeedSettingsMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/mapper/CcyPairFeedSettingsMapper.java
@@ -17,7 +17,7 @@ public class CcyPairFeedSettingsMapper {
                 entity.getPair().getPair(),
                 entity.getProvider().getName(),
                 entity.getPriority(),
-                entity.getRefreshMs(),
+                entity.getFetchPeriodMs(),
                 entity.isEnabled()
         );
     }
@@ -30,7 +30,7 @@ public class CcyPairFeedSettingsMapper {
         entity.setPair(pair);
         entity.setProvider(provider);
         entity.setPriority(cfg.priority());
-        entity.setRefreshMs(cfg.refreshMs());
+        entity.setFetchPeriodMs(cfg.fetchPeriodMs());
         entity.setEnabled(cfg.enabled());
         return entity;
     }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
@@ -53,14 +53,14 @@ public class SettingsServiceImpl implements SettingsService {
                 .orElseThrow(() -> new ProviderNotFoundException(dto.provider()));
 
         // Для PUSH-интервал определяет провайдер, поэтому устанавливаем 0.
-        int refreshMs = "PUSH".equals(provider.getMode()) ? 0 : dto.refreshMs();
+        int fetchPeriodMs = "PUSH".equals(provider.getMode()) ? 0 : dto.fetchPeriodMs();
 
         CcyPairFeedSettingsEntity entity = mapper.toEntity(
                 new com.alligator.market.domain.quotes.stream.settings.CcyPairFeedSettings(
                         dto.pair(),
                         dto.provider(),
                         dto.priority(),
-                        refreshMs,
+                        fetchPeriodMs,
                         dto.enabled()
                 ),
                 pair,
@@ -83,8 +83,8 @@ public class SettingsServiceImpl implements SettingsService {
 
         entity.setPriority(dto.priority());
         // Если режим PUSH, интервал задаётся провайдером, поэтому сохраняем 0.
-        int refreshMs = "PUSH".equals(entity.getProvider().getMode()) ? 0 : dto.refreshMs();
-        entity.setRefreshMs(refreshMs);
+        int fetchPeriodMs = "PUSH".equals(entity.getProvider().getMode()) ? 0 : dto.fetchPeriodMs();
+        entity.setFetchPeriodMs(fetchPeriodMs);
         entity.setEnabled(dto.enabled());
 
         repository.save(entity);
@@ -117,7 +117,7 @@ public class SettingsServiceImpl implements SettingsService {
                         cfg.getPair().getPair(),
                         cfg.getProvider().getName(),
                         cfg.getPriority(),
-                        cfg.getRefreshMs(),
+                        cfg.getFetchPeriodMs(),
                         cfg.isEnabled()
                 ))
                 .toList();

--- a/backend/src/main/resources/db/migration/V14__ccypair_feed_settings_rename_refresh_ms.sql
+++ b/backend/src/main/resources/db/migration/V14__ccypair_feed_settings_rename_refresh_ms.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ccypair_feed_settings
+    RENAME COLUMN refresh_ms TO fetch_period_ms;

--- a/domain/src/main/java/com/alligator/market/domain/quotes/stream/settings/CcyPairFeedSettings.java
+++ b/domain/src/main/java/com/alligator/market/domain/quotes/stream/settings/CcyPairFeedSettings.java
@@ -8,7 +8,7 @@ public record CcyPairFeedSettings(
         String pair,
         String provider,
         short priority,
-        int refreshMs, // 0 для PUSH
+        int fetchPeriodMs, // 0 для PUSH
         boolean enabled
 
 ) {

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-create.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-create.model.ts
@@ -3,6 +3,6 @@ export interface SettingsCreateDto {
   pair: string;
   provider: string;
   priority: number;
-  refreshMs: number;
+  fetchPeriodMs: number;
   enabled: boolean;
 }

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-update.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-update.model.ts
@@ -1,6 +1,6 @@
 /** DTO обновления настроек потока котировок аналогичный backend */
 export interface SettingsUpdateDto {
   priority: number;
-  refreshMs: number;
+  fetchPeriodMs: number;
   enabled: boolean;
 }

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings.model.ts
@@ -3,6 +3,6 @@ export interface SettingsDto {
   pair: string;
   provider: string;
   priority: number;
-  refreshMs: number;
+  fetchPeriodMs: number;
   enabled: boolean;
 }

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
@@ -42,9 +42,9 @@
         </mat-form-field>
 
         <mat-form-field appearance="outline">
-          <mat-label>Refresh, ms</mat-label>
-          <input matInput type="number" formControlName="refreshMs" />
-          <mat-error *ngIf="form.controls['refreshMs'].hasError('required')">
+          <mat-label>Fetch Period, ms</mat-label>
+          <input matInput type="number" formControlName="fetchPeriodMs" />
+          <mat-error *ngIf="form.controls['fetchPeriodMs'].hasError('required')">
             Is required
           </mat-error>
         </mat-form-field>
@@ -85,9 +85,9 @@
           <td mat-cell *matCellDef="let c">{{ c.priority }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="refreshMs">
-          <th mat-header-cell *matHeaderCellDef>Refresh, ms</th>
-          <td mat-cell *matCellDef="let c">{{ c.refreshMs }}</td>
+        <ng-container matColumnDef="fetchPeriodMs">
+          <th mat-header-cell *matHeaderCellDef>Fetch Period, ms</th>
+          <td mat-cell *matCellDef="let c">{{ c.fetchPeriodMs }}</td>
         </ng-container>
 
         <ng-container matColumnDef="enabled">

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
@@ -45,7 +45,7 @@ export class SettingsAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['pair', 'provider', 'priority', 'refreshMs', 'enabled', 'actions'];
+  displayed: string[] = ['pair', 'provider', 'priority', 'fetchPeriodMs', 'enabled', 'actions'];
   dataSource = new MatTableDataSource<SettingsDto>([]);
 
   //========================
@@ -71,7 +71,7 @@ export class SettingsAdminComponent implements OnInit {
       pair: ['', [Validators.required]],
       provider: ['', [Validators.required, Validators.maxLength(50)]],
       priority: [1, [Validators.required, Validators.min(0), Validators.max(32767)]],
-      refreshMs: [1000, [Validators.required, Validators.min(0)]],
+      fetchPeriodMs: [1000, [Validators.required, Validators.min(0)]],
       enabled: [true]
     });
 
@@ -113,8 +113,8 @@ export class SettingsAdminComponent implements OnInit {
       next: id => {
         this.snack.open(`Settings '${id}' added`, 'OK', { duration: 2500 });
         this.refresh();
-        this.form.reset({ priority: 1, refreshMs: 1000, enabled: true, pair: '', provider: '' });
-        this.form.controls['refreshMs'].enable();
+        this.form.reset({ priority: 1, fetchPeriodMs: 1000, enabled: true, pair: '', provider: '' });
+        this.form.controls['fetchPeriodMs'].enable();
         this.updateRefreshCtrlByProvider(this.form.controls['provider'].value);
         this.locked = false;
       },
@@ -134,7 +134,7 @@ export class SettingsAdminComponent implements OnInit {
       pair: c.pair,
       provider: c.provider,
       priority: c.priority,
-      refreshMs: c.refreshMs,
+      fetchPeriodMs: c.fetchPeriodMs,
       enabled: c.enabled
     });
     this.updateRefreshCtrlByProvider(c.provider);
@@ -149,7 +149,7 @@ export class SettingsAdminComponent implements OnInit {
 
     const dto: SettingsUpdateDto = {
       priority: this.form.controls['priority'].value,
-      refreshMs: this.form.controls['refreshMs'].value,
+      fetchPeriodMs: this.form.controls['fetchPeriodMs'].value,
       enabled: this.form.controls['enabled'].value
     } as SettingsUpdateDto;
 
@@ -172,16 +172,16 @@ export class SettingsAdminComponent implements OnInit {
     this.editing = false;
     this.editPair = null;
     this.editProvider = null;
-    this.form.reset({ pair: '', provider: '', priority: 1, refreshMs: 1000, enabled: true });
+    this.form.reset({ pair: '', provider: '', priority: 1, fetchPeriodMs: 1000, enabled: true });
     this.form.controls['pair'].enable();
     this.form.controls['provider'].enable();
-    this.form.controls['refreshMs'].enable();
+    this.form.controls['fetchPeriodMs'].enable();
     this.updateRefreshCtrlByProvider(this.form.controls['provider'].value);
     this.locked = false;
   }
 
   private updateRefreshCtrlByProvider(provider: string): void {
-    const ctrl = this.form.controls['refreshMs'];
+    const ctrl = this.form.controls['fetchPeriodMs'];
     const item = this.providers.find(p => p.name === provider);
     const mode = item?.mode ?? 'PULL';
     if (mode === 'PUSH') {


### PR DESCRIPTION
## Summary
- rename `refreshMs` column to `fetch_period_ms`
- update backend DTOs, service and entity
- adjust domain model to `fetchPeriodMs`
- rename frontend models and UI column
- add Flyway migration

## Testing
- `./backend/mvnw -q -f backend/pom.xml test` *(fails: wget unable to fetch maven)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b76b42ac832d84b8b3a2a0eabcc1