### PR TITLE
Исправление имён методов в сервисе настроек

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsService.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsService.java
@@ -11,11 +11,11 @@ import java.util.List;
  */
 public interface SettingsService {
 
-    String createConfig(SettingsCreateDto dto);
+    String createSettings(SettingsCreateDto dto);
 
-    void updateConfig(String pair, String provider, SettingsUpdateDto dto);
+    void updateSettings(String pair, String provider, SettingsUpdateDto dto);
 
-    void deleteConfig(String pair, String provider);
+    void deleteSettings(String pair, String provider);
 
     List<SettingsDto> findAll();
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/service/SettingsServiceImpl.java
@@ -40,7 +40,7 @@ public class SettingsServiceImpl implements SettingsService {
     // Создать новые настройки
     //========================
     @Override
-    public String createConfig(SettingsCreateDto dto) {
+    public String createSettings(SettingsCreateDto dto) {
 
         repository.findByPair_PairAndProvider_Name(dto.pair(), dto.provider()).ifPresent(c -> {
             throw new DuplicateSettingsException(dto.pair(), dto.provider());
@@ -76,7 +76,7 @@ public class SettingsServiceImpl implements SettingsService {
     // Обновить настройки
     //===================
     @Override
-    public void updateConfig(String pair, String provider, SettingsUpdateDto dto) {
+    public void updateSettings(String pair, String provider, SettingsUpdateDto dto) {
 
         CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider_Name(pair, provider)
                 .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
@@ -95,7 +95,7 @@ public class SettingsServiceImpl implements SettingsService {
     // Удалить настройки
     //==================
     @Override
-    public void deleteConfig(String pair, String provider) {
+    public void deleteSettings(String pair, String provider) {
 
         CcyPairFeedSettingsEntity entity = repository.findByPair_PairAndProvider_Name(pair, provider)
                 .orElseThrow(() -> new SettingsNotFoundException(pair, provider));
@@ -113,15 +113,15 @@ public class SettingsServiceImpl implements SettingsService {
 
         List<SettingsDto> result = repository.findAll(Sort.by("pair.pair", "provider.name"))
                 .stream()
-                .map(cfg -> new SettingsDto(
-                        cfg.getPair().getPair(),
-                        cfg.getProvider().getName(),
-                        cfg.getPriority(),
-                        cfg.getFetchPeriodMs(),
-                        cfg.isEnabled()
+                .map(settings -> new SettingsDto(
+                        settings.getPair().getPair(),
+                        settings.getProvider().getName(),
+                        settings.getPriority(),
+                        settings.getFetchPeriodMs(),
+                        settings.isEnabled()
                 ))
                 .toList();
-        log.debug("Found {} streaming configs", result.size());
+        log.debug("Found {} streaming settings", result.size());
         return result;
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/web/FxPairStreamingConfigController.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/web/FxPairStreamingConfigController.java
@@ -33,7 +33,7 @@ public class FxPairStreamingConfigController {
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid SettingsCreateDto dto) {
 
-        String id = service.createConfig(dto);
+        String id = service.createSettings(dto);
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{pair}/{provider}")
@@ -50,7 +50,7 @@ public class FxPairStreamingConfigController {
             @PathVariable String pair,
             @PathVariable String provider,
             @RequestBody @Valid SettingsUpdateDto dto) {
-        service.updateConfig(pair, provider, dto);
+        service.updateSettings(pair, provider, dto);
         return ResponseEntityFactory.ok(null);
     }
 
@@ -61,7 +61,7 @@ public class FxPairStreamingConfigController {
     public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable String pair,
             @PathVariable String provider) {
-        service.deleteConfig(pair, provider);
+        service.deleteSettings(pair, provider);
         return ResponseEntityFactory.ok(null);
     }
 


### PR DESCRIPTION
## Summary
- переименованы методы `createConfig`, `updateConfig`, `deleteConfig` в `createSettings`, `updateSettings`, `deleteSettings`
- скорректированы вызовы в контроллере
- обновлены переменные и лог в реализации сервиса

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685a24a8ef0c832db6788ab1f9efeece