### PR TITLE
Implement Kafka publish adapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/adapters/kafka/KafkaQuotePublishAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/adapters/kafka/KafkaQuotePublishAdapter.java
@@ -1,0 +1,37 @@
+package com.alligator.market.backend.quotes.stream.providers.adapters.kafka;
+
+import com.alligator.market.domain.quotes.stream.QuoteTick;
+import com.alligator.market.domain.quotes.stream.ports.QuotePublishPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Адаптер публикации тиков котировок в Kafka.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaQuotePublishAdapter implements QuotePublishPort {
+
+    private static final String TOPIC = "quotes";
+
+    private final KafkaTemplate<String, com.alligator.market.domain.avro.quotes.stream.QuoteTick> template;
+
+    //=============================================
+    // Опубликовать тик котировки в топик Kafka
+    //=============================================
+    @Override
+    public void publish(QuoteTick tick) {
+        var avroTick = com.alligator.market.domain.avro.quotes.stream.QuoteTick.newBuilder()
+                .setPair(tick.pair())
+                .setBid(tick.bid())
+                .setAsk(tick.ask())
+                .setTs(tick.ts().toEpochMilli())
+                .setProvider(tick.provider())
+                .build();
+        template.send(TOPIC, tick.pair(), avroTick);
+        log.debug("Tick {} sent to Kafka", avroTick);
+    }
+}

--- a/backend/src/test/java/com/alligator/market/backend/quotes/stream/adapters/twelvedata/TwelvePullQuoteFeedAdapterTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/quotes/stream/adapters/twelvedata/TwelvePullQuoteFeedAdapterTest.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.quotes.stream.adapters.twelvedata;
 
 import com.alligator.market.backend.quotes.stream.providers.adapters.twelve_free_mid_pull.TwelvePullQuoteFeedAdapter;
 import com.alligator.market.domain.quotes.stream.QuoteTick;
+import com.alligator.market.domain.quotes.stream.ports.QuotePublishPort;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,10 +16,14 @@ public class TwelvePullQuoteFeedAdapterTest {
     @Autowired
     private TwelvePullQuoteFeedAdapter adapter;
 
+    @Autowired
+    private QuotePublishPort publisher;
+
     @Test
-    void fetchQuotePrint() {
+    void fetchQuotePublish() {
         try {
             QuoteTick tick = adapter.fetchQuote("EURUSD");
+            publisher.publish(tick);
             System.out.println("EURUSD price: " + tick.bid());
         } catch (Exception e) {
             System.out.println("Cannot fetch quote: " + e.getMessage());


### PR DESCRIPTION
## Summary
- add `KafkaQuotePublishAdapter` to send quote ticks to Kafka
- publish fetched quote to Kafka in `TwelvePullQuoteFeedAdapterTest`

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ab90620832d81541ccd13fdf5a9