### PR TITLE
Fix unsatisfied TaskScheduler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
+++ b/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
@@ -2,8 +2,14 @@ package com.alligator.market.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Точка входа backend-приложения.
+ */
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- enable scheduling in the backend app

## Testing
- `mvn -q -Dtest=TwelvePullQuoteFeedAdapterTest test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685cc07d41d4832d90d14e1211743b36