### PR TITLE
Rename QuoteFeedPort to PullQuoteFeedPort

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/adapters/TwelvePullQuoteFeedAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/adapters/TwelvePullQuoteFeedAdapter.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.quotes.stream.providers.pull.adapters;
 
 import com.alligator.market.domain.quotes.stream.QuoteTick;
 import com.alligator.market.domain.quotes.stream.exeptions.QuoteUnavailableException;
-import com.alligator.market.domain.quotes.stream.ports.QuoteFeedPort;
+import com.alligator.market.domain.quotes.stream.ports.PullQuoteFeedPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,7 +15,7 @@ import java.time.Instant;
  */
 @Service
 @Slf4j
-public class TwelvePullQuoteFeedAdapter implements QuoteFeedPort {
+public class TwelvePullQuoteFeedAdapter implements PullQuoteFeedPort {
 
     private static final String PROVIDER = "twelve_free_mid_pull";
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/PullScheduler.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/PullScheduler.java
@@ -4,7 +4,7 @@ import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.entity.C
 import com.alligator.market.backend.quotes.stream.ccypair_feed_settings.repository.CcyPairFeedSettingsRepository;
 import com.alligator.market.domain.quotes.stream.QuoteTick;
 import com.alligator.market.domain.quotes.stream.exeptions.QuoteUnavailableException;
-import com.alligator.market.domain.quotes.stream.ports.QuoteFeedPort;
+import com.alligator.market.domain.quotes.stream.ports.PullQuoteFeedPort;
 import com.alligator.market.domain.quotes.stream.ports.QuotePublishPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
@@ -22,7 +22,7 @@ import static java.util.stream.Collectors.groupingBy;
 public class PullScheduler implements ApplicationRunner {
 
     private final CcyPairFeedSettingsRepository ccyPairFeedSettingsRepository;
-    private final Map<String, QuoteFeedPort> adapters;      // провайдер → бин‑адаптер
+    private final Map<String, PullQuoteFeedPort> adapters;  // провайдер → бин‑адаптер
     private final QuotePublishPort publisher;
     private final TaskScheduler scheduler;                  // spring.task.scheduling.pool
 
@@ -41,7 +41,7 @@ public class PullScheduler implements ApplicationRunner {
         String provider = list.get(0).getProvider().getName();
         int periodMs = list.get(0).getFetchPeriodMs();
 
-        QuoteFeedPort adapter = adapters.get(provider);
+        PullQuoteFeedPort adapter = adapters.get(provider);
         List<String> pairs = list.stream().map(s -> s.getPair().getPair()).toList();
 
         scheduler.scheduleAtFixedRate(() -> pairs.forEach(pair -> {

--- a/domain/src/main/java/com/alligator/market/domain/quotes/stream/ports/PullQuoteFeedPort.java
+++ b/domain/src/main/java/com/alligator/market/domain/quotes/stream/ports/PullQuoteFeedPort.java
@@ -4,9 +4,9 @@ import com.alligator.market.domain.quotes.stream.QuoteTick;
 import com.alligator.market.domain.quotes.stream.exeptions.QuoteUnavailableException;
 
 /**
- * Входной порт «получить тик откуда‑то».
+ * Входной порт для получения тика в режиме PULL.
  */
-public interface QuoteFeedPort {
+public interface PullQuoteFeedPort {
 
     /* Получить последний тик котировки для пары. */
     QuoteTick fetchQuote(String pairCode) throws QuoteUnavailableException;


### PR DESCRIPTION
## Summary
- rename `QuoteFeedPort` to `PullQuoteFeedPort`
- update backend scheduler and adapter to use the renamed interface

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685db12cf6f4832d83fd8d7d4bfda140