### PR TITLE
Unify Twelve provider name via properties

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/adapters/TwelvePullQuoteFeedAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/adapters/TwelvePullQuoteFeedAdapter.java
@@ -7,6 +7,7 @@ import com.alligator.market.domain.quotes.stream.QuoteTick;
 import com.alligator.market.domain.quotes.stream.exeptions.QuoteUnavailableException;
 import com.alligator.market.domain.quotes.stream.ports.PullQuoteFeedPort;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -20,14 +21,16 @@ import java.time.Instant;
 @Slf4j
 public class TwelvePullQuoteFeedAdapter implements PullQuoteFeedPort {
 
-    private static final String PROVIDER = "twelve_free_mid_pull";
-
+    private final String providerName;
     private final WebClient webClient;
     private final String apiKey;
 
-    public TwelvePullQuoteFeedAdapter(WebClient.Builder builder, ProviderRepository repository) {
-        Provider provider = repository.findByName(PROVIDER)
-                .orElseThrow(() -> new ProviderNotFoundException(PROVIDER));
+    public TwelvePullQuoteFeedAdapter(@Value("${quotes.provider.twelve.pull.name}") String providerName,
+                                      WebClient.Builder builder,
+                                      ProviderRepository repository) {
+        this.providerName = providerName;
+        Provider provider = repository.findByName(providerName)
+                .orElseThrow(() -> new ProviderNotFoundException(providerName));
         this.webClient = builder.baseUrl(provider.getBaseUrl()).build();
         this.apiKey = provider.getApiKey();
     }
@@ -68,7 +71,7 @@ public class TwelvePullQuoteFeedAdapter implements PullQuoteFeedPort {
                     price,
                     price,
                     Instant.now(),
-                    PROVIDER
+                    providerName
             );
 
         } catch (Exception e) {

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/TwelvePullScheduler.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/TwelvePullScheduler.java
@@ -7,6 +7,7 @@ import com.alligator.market.domain.quotes.stream.QuoteTick;
 import com.alligator.market.domain.quotes.stream.exeptions.QuoteUnavailableException;
 import com.alligator.market.domain.quotes.stream.ports.QuotePublishPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -18,14 +19,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Планировщик для загрузки котировок от {@code twelve_free_mid_pull}.
+ * Планировщик для загрузки котировок от провайдера, имя которого задано в настройках.
  */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class TwelvePullScheduler implements ApplicationRunner {
 
-    private static final String PROVIDER = "twelve_free_mid_pull";
+    @Value("${quotes.provider.twelve.pull.name}")
+    private String providerName;
 
     private final CcyPairFeedSettingsRepository settingsRepository;
     private final TwelvePullQuoteFeedAdapter adapter;
@@ -36,7 +38,7 @@ public class TwelvePullScheduler implements ApplicationRunner {
     public void run(ApplicationArguments args) {
         settingsRepository.findAll().stream()
                 .filter(CcyPairFeedSettingsEntity::isEnabled)
-                .filter(s -> PROVIDER.equalsIgnoreCase(s.getProvider().getName()))
+                .filter(s -> providerName.equalsIgnoreCase(s.getProvider().getName()))
                 .collect(Collectors.groupingBy(CcyPairFeedSettingsEntity::getFetchPeriodMs))
                 .forEach(this::scheduleGroup);
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -32,3 +32,6 @@ spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.properties.schema.registry.url=http://localhost:8081
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
+
+# Имя провайдера данных TwelveData для pull-запросов
+quotes.provider.twelve.pull.name=twelve_free_mid_pull


### PR DESCRIPTION
## Summary
- move provider name for Twelve pull service to `application.properties`
- inject this property into `TwelvePullQuoteFeedAdapter`
- inject this property into `TwelvePullScheduler`

## Testing
- `./mvnw test` *(fails: Failed to fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_685dbe30eab8832d8e3d4eac54284fc0