### PR TITLE
Improve pair-specific error logging

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/adapters/TwelvePullQuoteFeedAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/adapters/TwelvePullQuoteFeedAdapter.java
@@ -76,8 +76,8 @@ public class TwelvePullQuoteFeedAdapter implements PullQuoteFeedPort {
             );
 
         } catch (Exception e) {
-            log.error("Cannot fetch quote from TwelveData", e);
-            throw new QuoteUnavailableException("Failed to fetch quote", e);
+            log.error("Cannot fetch quote for pair {} from TwelveData", pairCode, e);
+            throw new QuoteUnavailableException("Failed to fetch quote for pair " + pairCode, e);
         }
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/TwelvePullScheduler.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/TwelvePullScheduler.java
@@ -54,7 +54,7 @@ public class TwelvePullScheduler implements ApplicationRunner {
                 QuoteTick tick = adapter.fetchQuote(pair);
                 publisher.publish(tick);
             } catch (QuoteUnavailableException e) {
-                log.error("Cannot fetch quote", e);
+                log.error("Cannot fetch quote for pair {}", pair, e);
             }
         }), Duration.ofMillis(periodMs));
     }


### PR DESCRIPTION
## Summary
- show pair code in logging and exceptions for `TwelvePullQuoteFeedAdapter`
- include pair information in scheduler error logs

## Testing
- `bash backend/mvnw -q -f backend/pom.xml test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685dc44f2a54832db21b8734e86f91dc