### PR TITLE
Fix scheduler for non positive period

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/TwelveFreeAdapterScheduler.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/providers/pull/scheduler/TwelveFreeAdapterScheduler.java
@@ -43,8 +43,13 @@ public class TwelveFreeAdapterScheduler implements ApplicationRunner {
                 .forEach(this::scheduleGroup);
     }
 
-    /* Планируем один task на период. */
+    /* Планируем один task на период; пропускаем, если период не положительный. */
     private void scheduleGroup(Integer periodMs, List<CcyPairFeedSettingsEntity> settings) {
+        if (periodMs == null || periodMs <= 0) {
+            log.warn("Skip scheduling with non-positive period: {}", periodMs);
+            return;
+        }
+
         List<String> pairs = settings.stream()
                 .map(s -> s.getPair().getPair())
                 .toList();


### PR DESCRIPTION
## Summary
- skip scheduling tasks in TwelveFreeAdapterScheduler when period is non-positive

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_685effbebdf4832d98d5bae8204fced2