### PR TITLE
Limit fetch period

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/FeedSettingsCreateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/FeedSettingsCreateDto.java
@@ -20,8 +20,8 @@ public record FeedSettingsCreateDto(
         Short priority,
 
         @NotNull
-        @Min(0)
-        Integer fetchPeriodMs, // для PUSH игнорируется
+        @Min(1000)
+        Integer fetchPeriodMs, // для PUSH игнорируется, минимум 1000 мс
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/FeedSettingsDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/FeedSettingsDto.java
@@ -20,8 +20,8 @@ public record FeedSettingsDto(
         Short priority,
 
         @NotNull
-        @Min(0)
-        Integer fetchPeriodMs, // для PUSH игнорируется
+        @Min(1000)
+        Integer fetchPeriodMs, // для PUSH игнорируется, минимум 1000 мс
 
         @NotNull
         Boolean enabled

--- a/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/FeedSettingsUpdateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/stream/ccypair_feed_settings/dto/FeedSettingsUpdateDto.java
@@ -14,8 +14,8 @@ public record FeedSettingsUpdateDto(
         Short priority,
 
         @NotNull
-        @Min(0)
-        Integer fetchPeriodMs, // для PUSH игнорируется
+        @Min(1000)
+        Integer fetchPeriodMs, // для PUSH игнорируется, минимум 1000 мс
 
         @NotNull
         Boolean enabled

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-create.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-create.model.ts
@@ -3,6 +3,6 @@ export interface SettingsCreateDto {
   pair: string;
   provider: string;
   priority: number;
-  fetchPeriodMs: number;
+  fetchPeriodMs: number; // минимум 1000 или 0 для PUSH
   enabled: boolean;
 }

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-update.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings-update.model.ts
@@ -1,6 +1,6 @@
 /** DTO обновления настроек потока котировок аналогичный backend */
 export interface SettingsUpdateDto {
   priority: number;
-  fetchPeriodMs: number;
+  fetchPeriodMs: number; // минимум 1000 или 0 для PUSH
   enabled: boolean;
 }

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings.model.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/models/settings.model.ts
@@ -3,6 +3,6 @@ export interface SettingsDto {
   pair: string;
   provider: string;
   priority: number;
-  fetchPeriodMs: number;
+  fetchPeriodMs: number; // минимум 1000 или 0 для PUSH
   enabled: boolean;
 }

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.html
@@ -47,6 +47,9 @@
           <mat-error *ngIf="form.controls['fetchPeriodMs'].hasError('required')">
             Is required
           </mat-error>
+          <mat-error *ngIf="form.controls['fetchPeriodMs'].hasError('min')">
+            &gt;= 1000
+          </mat-error>
         </mat-form-field>
 
         <mat-checkbox formControlName="enabled">Enabled</mat-checkbox>

--- a/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
+++ b/frontend/src/app/features/quotes/stream/ccypair_feed_settings/pages/settings-admin/settings-admin.component.ts
@@ -71,7 +71,7 @@ export class SettingsAdminComponent implements OnInit {
       pair: ['', [Validators.required]],
       provider: ['', [Validators.required, Validators.maxLength(50)]],
       priority: [1, [Validators.required, Validators.min(0), Validators.max(32767)]],
-      fetchPeriodMs: [1000, [Validators.required, Validators.min(0)]],
+      fetchPeriodMs: [1000, [Validators.required, Validators.min(1000)]],
       enabled: [true]
     });
 
@@ -189,7 +189,7 @@ export class SettingsAdminComponent implements OnInit {
       ctrl.disable();
     } else {
       ctrl.enable();
-      if (ctrl.value === 0) {
+      if (ctrl.value < 1000) {
         ctrl.setValue(1000);
       }
     }


### PR DESCRIPTION
## Summary
- enforce minimum fetchPeriodMs in backend DTOs
- validate minimal value in frontend form
- show validation errors and comments for frontend models

## Testing
- `sh mvnw -q test` *(fails: maven-wrapper missing)*
- `npm test --silent` *(fails: ng not found and no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9157d7c832db29399ba8f05dffc