### PR TITLE
Improve logging for TwelveFreeAdapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/providers/pull/twelve/TwelveFreeAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/providers/pull/twelve/TwelveFreeAdapter.java
@@ -76,7 +76,7 @@ public class TwelveFreeAdapter implements PullQuotePort {
             );
 
         } catch (Exception e) {
-            log.error("Cannot fetch quote for pair {} from TwelveData", pairCode, e);
+            log.debug("Cannot fetch quote for pair {} from {}", pairCode, providerName, e);
             throw new QuoteUnavailableException("Failed to fetch quote for pair " + pairCode, e);
         }
     }

--- a/backend/src/main/java/com/alligator/market/backend/quotes/providers/pull/twelve/TwelveFreeAdapterScheduler.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/providers/pull/twelve/TwelveFreeAdapterScheduler.java
@@ -60,7 +60,7 @@ public class TwelveFreeAdapterScheduler implements ApplicationRunner {
                 QuoteTick tick = adapter.fetchQuote(pair);
                 publisher.publish(tick);
             } catch (QuoteUnavailableException e) {
-                log.error("Cannot fetch quote for pair {}", pair, e);
+                log.error("Cannot fetch quote for pair {} from {}", pair, providerName, e);
             }
         }), Duration.ofMillis(periodMs));
     }


### PR DESCRIPTION
## Summary
- lower log level in `TwelveFreeAdapter` so that errors only trigger debug
- include provider name in scheduler error message

## Testing
- `sh ./mvnw -q test` *(fails: could not fetch Maven resources)*

------
https://chatgpt.com/codex/tasks/task_e_6862f27fa898832db3a72916e7892095