### PR TITLE
Fix Kafka volume path in compose

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
@@ -42,7 +43,7 @@ services:
     ports:
       - "9092:9092"
     volumes:
-     - ./kafka-data:/tmp/kraft-combined-logs
+      - kafka-data:/var/lib/kafka/data
 
 #=============================
 # 3. Confluent Schema Registry
@@ -59,3 +60,6 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
     ports:
       - "8081:8081"
+
+volumes:
+  kafka-data:


### PR DESCRIPTION
## Summary
- map Kafka logs to a named volume and specify `KAFKA_LOG_DIRS`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644eeb4c3c832dbaee71e38b5917e4