### PR TITLE
Configure kafka ports precisely

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -29,7 +29,7 @@ logging.level.com.alligator.market=INFO
 # KAFKA CONFIGURATION
 # ===============================
 spring.kafka.bootstrap-servers=localhost:9092
-spring.kafka.properties.schema.registry.url=http://localhost:8081
+spring.kafka.properties.schema.registry.url=http://localhost:8082
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 # ===============================

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     ports:
       - "5432:5432"
 
-#=====================================
-# 2. Kafka 3.7 (образ Confluent Local)
-#=====================================
+  #=====================================
+  # 2. Kafka 3.7 (образ Confluent Local)
+  #=====================================
   kafka:
     image: confluentinc/confluent-local:7.6.0
     container_name: kafka
@@ -28,10 +28,10 @@ services:
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://host.docker.internal:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,EXTERNAL://host.docker.internal:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
@@ -40,7 +40,8 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
     ports:
-      - "9092:9092"
+      - "9092:9092"   # внешний порт брокера
+      - "29092:29092" # внутренний порт брокера
     volumes:
       - ./kafka-data:/var/lib/kafka/data
 
@@ -56,9 +57,9 @@ services:
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:29092
     ports:
-      - "8081:8081"
+      - "8082:8081"
 
 #================================
 # 4. Объявление именованных томов


### PR DESCRIPTION
## Summary
- expose kafka internal and external ports explicitly
- update schema registry to talk to kafka on the new internal port
- change schema registry host port
- update backend config accordingly

## Testing
- `sh ./mvnw test -q` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_686826e03f94832db11eb119c16d3913