### PR TITLE
Add time zone config

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/config/TimeZoneConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/TimeZoneConfig.java
@@ -1,0 +1,24 @@
+package com.alligator.market.backend.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+/**
+ * Конфигурация временной зоны приложения.
+ * Используем локальное время сервера для всего приложения.
+ */
+@Configuration
+public class TimeZoneConfig {
+
+    @Value("${app.time-zone:UTC}")
+    private String timeZone;
+
+    @PostConstruct
+    public void init() {
+        TimeZone tz = TimeZone.getTimeZone(timeZone);
+        TimeZone.setDefault(tz);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -36,3 +36,9 @@ spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.KafkaAvroS
 # PROVIDERS
 # ===============================
 quotes.provider.twelve.pull.name=twelve_free_mid_pull
+# ===============================
+# TIME ZONE
+# ===============================
+app.time-zone=Europe/Moscow
+spring.jackson.time-zone=${app.time-zone}
+spring.jpa.properties.hibernate.jdbc.time_zone=${app.time-zone}


### PR DESCRIPTION
## Summary
- add `TimeZoneConfig` to set default zone for the app
- configure Jackson and Hibernate to use the server time zone

## Testing
- `mvn -q -pl backend -am test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e7866c60832db1e8c767af96c3a0