### PR TITLE
feat(pair): validate currency codes differ

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/forex/currency_pair/exception/EqualCurrenciesInPairException.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/forex/currency_pair/exception/EqualCurrenciesInPairException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.backend.instrument.forex.currency_pair.exception;
+
+/**
+ * Валютные коды пары не могут совпадать.
+ */
+public class EqualCurrenciesInPairException extends RuntimeException {
+    public EqualCurrenciesInPairException(String code) {
+        super("Both currency codes are '%s'".formatted(code));
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/forex/currency_pair/service/PairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/forex/currency_pair/service/PairServiceImpl.java
@@ -6,6 +6,7 @@ import com.alligator.market.backend.instrument.forex.currency_pair.entity.PairEn
 import com.alligator.market.backend.instrument.forex.currency_pair.exception.CurrencyFromPairNotFoundException;
 import com.alligator.market.backend.instrument.forex.currency_pair.exception.DuplicatePairException;
 import com.alligator.market.backend.instrument.forex.currency_pair.exception.PairNotFoundException;
+import com.alligator.market.backend.instrument.forex.currency_pair.exception.EqualCurrenciesInPairException;
 import com.alligator.market.backend.instrument.forex.currency_pair.repository.PairRepository;
 import com.alligator.market.domain.instrument.forex.currency_pair.CurrencyPair;
 import com.alligator.market.domain.instrument.forex.currency_pair.CurrencyPairService;
@@ -38,6 +39,10 @@ public class PairServiceImpl implements CurrencyPairService {
         repository.findByPair(currencyPair.pair()).ifPresent(p -> {
             throw new DuplicatePairException(currencyPair.pair());
         });
+
+        if (currencyPair.code1().equals(currencyPair.code2())) {
+            throw new EqualCurrenciesInPairException(currencyPair.code1());
+        }
 
         CurrencyEntity c1 = currencyRepository.findByCode(currencyPair.code1())
                 .orElseThrow(() -> new CurrencyFromPairNotFoundException(currencyPair.code1()));

--- a/backend/src/main/java/com/alligator/market/backend/instrument/forex/currency_pair/web/PairExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/forex/currency_pair/web/PairExceptionHandler.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.common.web.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.forex.currency_pair.exception.CurrencyFromPairNotFoundException;
 import com.alligator.market.backend.instrument.forex.currency_pair.exception.DuplicatePairException;
 import com.alligator.market.backend.instrument.forex.currency_pair.exception.PairNotFoundException;
+import com.alligator.market.backend.instrument.forex.currency_pair.exception.EqualCurrenciesInPairException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -46,6 +47,15 @@ public class PairExceptionHandler {
             CurrencyFromPairNotFoundException ex) {
 
         log.warn("CurrencyFromPairNotFoundException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    /* Валютные коды в паре совпадают. */
+    @ExceptionHandler(EqualCurrenciesInPairException.class)
+    public ResponseEntity<ApiResponse<Void>> handleEqualCurrencies(
+            EqualCurrenciesInPairException ex) {
+
+        log.warn("EqualCurrenciesInPairException: {}", ex.getMessage());
         return ResponseEntityFactory.error(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 


### PR DESCRIPTION
## Summary
- add validation for equal currency codes in pair service
- introduce `EqualCurrenciesInPairException`
- handle new exception in controller advice

## Testing
- `mvn -q -pl backend -am test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6c645638832d88f5050f25e34ec3