### PR TITLE
Fix QuoteTickAvro namespace usage

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/publish/adapter/kafka/KafkaQuotePublishAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/publish/adapter/kafka/KafkaQuotePublishAdapter.java
@@ -25,7 +25,7 @@ public class KafkaQuotePublishAdapter implements QuotePublishPort {
     //==========================================
     @Override
     public void publish(QuoteTick tick) {
-        var avroTick = new QuoteTickAvro()
+        var avroTick = QuoteTickAvro.newBuilder()
                 .setPair(tick.pair())
                 .setBid(tick.bid())
                 .setAsk(tick.ask())

--- a/domain/src/main/avro/QuoteTickAvro.avsc
+++ b/domain/src/main/avro/QuoteTickAvro.avsc
@@ -9,4 +9,4 @@
     { "name": "ts", "type": { "type": "long", "logicalType": "timestamp-millis" } },
     { "name": "provider", "type": "string" }
   ]
-}
+}\n

--- a/domain/src/main/java/com/alligator/market/domain/quotes/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quotes/QuoteTick.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 
 /**
  * Модель тика котировки для валютной пары.
- * Аналогична Avro-схеме {@link com.alligator.market.domain.avro.quotes.stream.QuoteTick Avro QuoteTick}.
+ * Аналогична Avro-схеме {@link com.alligator.market.domain.avro.QuoteTickAvro QuoteTickAvro}.
  */
 public record QuoteTick(
 


### PR DESCRIPTION
## Summary
- reference QuoteTickAvro in domain model comment
- build QuoteTickAvro with builder when publishing to Kafka
- ensure schema file ends with newline

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_686b9dbdd928832da74d678251079c04