### PR TITLE
Rename pair to symbol in QuoteTick model

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quotes/publish/adapter/kafka/KafkaQuotePublishAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/quotes/publish/adapter/kafka/KafkaQuotePublishAdapter.java
@@ -26,13 +26,13 @@ public class KafkaQuotePublishAdapter implements QuotePublishPort {
     @Override
     public void publish(QuoteTick tick) {
         var avroTick = QuoteTickAvro.newBuilder()
-                .setPair(tick.pair())
+                .setSymbol(tick.symbol())
                 .setBid(tick.bid())
                 .setAsk(tick.ask())
                 .setTs(tick.ts())
                 .setProvider(tick.provider())
                 .build();
-        template.send(TOPIC, tick.pair(), avroTick);
+        template.send(TOPIC, tick.symbol(), avroTick);
         log.debug("Tick {} sent to Kafka", avroTick);
     }
 }

--- a/domain/src/main/avro/QuoteTickAvro.avsc
+++ b/domain/src/main/avro/QuoteTickAvro.avsc
@@ -3,7 +3,7 @@
   "type": "record",
   "name": "QuoteTickAvro",
   "fields": [
-    { "name": "pair", "type": "string" },
+    { "name": "symbol", "type": "string" },
     { "name": "bid", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
     { "name": "ask", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
     { "name": "ts", "type": { "type": "long", "logicalType": "timestamp-millis" } },

--- a/domain/src/main/java/com/alligator/market/domain/quotes/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quotes/QuoteTick.java
@@ -9,7 +9,8 @@ import java.time.Instant;
  */
 public record QuoteTick(
 
-        String pair,
+        /* Символ (валютная пара или другой инструмент). */
+        String symbol,
         BigDecimal bid,
         BigDecimal ask,
         Instant ts,


### PR DESCRIPTION
## Summary
- rename `pair` field to `symbol` in domain model `QuoteTick`
- update Avro schema accordingly
- adjust Kafka publish adapter to use the new field

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1fd66ac832dae83b97c48ee3c77