### PR TITLE
Remove BuildProperties from TwelveFree Web config

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/twelve/free/config/web/TwelveFreeWebConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/twelve/free/config/web/TwelveFreeWebConfig.java
@@ -2,7 +2,6 @@ package com.alligator.market.backend.provider.twelve.free.config.web;
 
 import com.alligator.market.backend.provider.twelve.free.config.TwelveFreeConnectionProps;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -18,17 +17,14 @@ public class TwelveFreeWebConfig {
 
     private final TwelveFreeConnectionProps props;
     private final HttpClient httpClient;
-    private final BuildProperties build;
 
     // Конструктор с инжекцией общего http-клиента для всех провайдеров
     public TwelveFreeWebConfig(
             TwelveFreeConnectionProps props,
-            @Qualifier("providerHttpClient") HttpClient httpClient,
-            BuildProperties build
+            @Qualifier("providerHttpClient") HttpClient httpClient
     ) {
         this.props = props;
         this.httpClient = httpClient;
-        this.build = build;
     }
 
     /**
@@ -37,12 +33,10 @@ public class TwelveFreeWebConfig {
     @Bean("twelveFreeWebClient")
     WebClient twelveFreeWebClient() {
 
-        String userAgent = build.getName() + "/" + build.getVersion();
-
         return WebClient.builder()
                 .baseUrl(props.baseUrl())
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .defaultHeader("User-Agent", userAgent)
+                .defaultHeader("User-Agent", "Alligator Market Backend")
                 .build();
     }
 }

--- a/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/config/web/TwelveFreeWebConfigTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/config/web/TwelveFreeWebConfigTest.java
@@ -6,15 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,24 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
 })
 @SpringBootTest(classes = {
         ProviderHttpConfigGlobal.class,
-        TwelveFreeWebConfig.class,
-        TwelveFreeWebConfigTest.BuildPropsStub.class
+        TwelveFreeWebConfig.class
 })
 @EnableConfigurationProperties(TwelveFreeConnectionProps.class)
 class TwelveFreeWebConfigTest {
-
-    /* Мини-конфигурация, подменяющая отсутствующий в тестовом контексте бин BuildProperties. */
-    @TestConfiguration
-    static class BuildPropsStub {
-        @Bean
-        BuildProperties buildProperties() {
-            // Двух полей «name» и «version» достаточно
-            Properties p = new Properties();
-            p.put("name", "alligator-test");
-            p.put("version", "0.0.0-SNAPSHOT");
-            return new BuildProperties(p);
-        }
-    }
 
     @Autowired
     @Qualifier("twelveFreeWebClient")


### PR DESCRIPTION
## Summary
- drop `BuildProperties` from TwelveFreeWebConfig
- fix User-Agent header value
- simplify TwelveFreeWebConfigTest and remove extra stub

## Testing
- `./mvnw -q -Dtest=TwelveFreeWebConfigTest -pl backend test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6874b2478548832d8fa1b3f8143fce92