### PR TITLE
Fix TwelveFreeAdapterSmokeTest

### DIFF
--- a/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterSmokeTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterSmokeTest.java
@@ -5,8 +5,8 @@ import com.alligator.market.backend.provider.twelve.free.config.TwelveFreeProps;
 import com.alligator.market.backend.provider.twelve.free.config.web.TwelveFreeWebConfig;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +18,7 @@ import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 
+import com.alligator.market.domain.instrument.Instrument;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = {
@@ -29,24 +30,19 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TwelveFreeAdapterSmokeTest {
 
-    private MockWebServer server;
-
-    // Один раз перед запуском всех тестов этого класса поднимаем виртуальный сервер
-    @BeforeAll
-    void start() throws Exception {
-        server = new MockWebServer();
-        server.start();
-    }
+    private static MockWebServer server;
 
     // После окончания тестов закрываем сервер
     @AfterAll
-    void stop() throws Exception {
+    static void stop() throws Exception {
         server.close();
     }
 
     // Подменяем base-url и api-key только для этого тестового контекста
     @DynamicPropertySource
-    static void overrideBaseUrl(DynamicPropertyRegistry reg) {
+    static void overrideBaseUrl(DynamicPropertyRegistry reg) throws Exception {
+        server = new MockWebServer();
+        server.start();
         reg.add("provider.connection-config.twelve-free.base-url",
                 () -> server.url("/").toString());
         reg.add("provider.connection-config.twelve-free.api-key",
@@ -61,14 +57,15 @@ class TwelveFreeAdapterSmokeTest {
 
         // 1. Заглушка отдаёт цену 1.1087
         server.enqueue(new MockResponse()
-                .setBody("{\"price\":\"1.1087\"}")
+                .setBody("{\"price\":\"1.1087\",\"symbol\":\"EUR/USD\"}")
                 .addHeader("Content-Type", "application/json"));
 
         // 2. Вызываем адаптер (Mono/Flux — неважно; здесь Mono для краткости)
-        StepVerifier.create(adapter.streamQuotes("EUR/USD"))
+        StepVerifier.create(adapter.streamQuotes(new Instrument("EUR/USD")))
                 .assertNext(q -> {
                     assertEquals("EUR/USD", q.symbol());
-                    assertEquals(new BigDecimal("1.1087"), q.price());
+                    assertEquals(new BigDecimal("1.1087"), q.bid());
+                    assertEquals(new BigDecimal("1.1087"), q.ask());
                 })
                 .verifyComplete();
 


### PR DESCRIPTION
## Summary
- adjust smoke test for TwelveFreeAdapterV2
- ensure mock server properly started and validate bid/ask fields

## Testing
- `mvnw test -Dtest=TwelveFreeAdapterSmokeTest` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687520fdd6e0832db9de6fa569461e70