### PR TITLE
Fix base-url in TwelveFree smoke test

### DIFF
--- a/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterSmokeTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterSmokeTest.java
@@ -49,7 +49,10 @@ class TwelveFreeAdapterSmokeTest {
         server = new MockWebServer();
         server.start();
         reg.add("provider.connection-config.twelve-free.base-url",
-                () -> server.url("/").toString()); // Пример - http://localhost:51423/
+                () -> {
+                    String base = server.url("/").toString();
+                    return base.substring(0, base.length() - 1);
+                }); // Пример - http://localhost:51423
         reg.add("provider.connection-config.twelve-free.api-key",
                 () -> "2b8e2659372340d5b922cd6b8d6d2cb2");
     }


### PR DESCRIPTION
## Summary
- avoid trailing slash when overriding `twelve-free` base-url in smoke test

## Testing
- `mvnw -q -DskipTests=false test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875fb53ec7c832dbbf435ffcf84f8a4