### PR TITLE
Add real quote test for TwelveFreeAdapterV2

### DIFF
--- a/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2Test.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2Test.java
@@ -1,0 +1,37 @@
+package com.alligator.market.backend.provider.twelve.free.adapter;
+
+import com.alligator.market.backend.provider.twelve.free.config.TwelveFreeProps;
+import com.alligator.market.domain.instrument.forex.currency_pair.CurrencyPair;
+import com.alligator.market.domain.quote.QuoteTick;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/* Интеграционный тест для адаптера TwelveFreeAdapterV2. */
+class TwelveFreeAdapterV2Test {
+
+    @Test
+    void shouldFetchRealQuote() {
+        // Параметры подключения к провайдеру
+        TwelveFreeProps props = new TwelveFreeProps(
+                "https://api.twelvedata.com",
+                "2b8e2659372340d5b922cd6b8d6d2cb2"
+        );
+        WebClient client = WebClient.builder()
+                .baseUrl(props.baseUrl())
+                .build();
+
+        TwelveFreeAdapterV2 adapter = new TwelveFreeAdapterV2(props, client);
+
+        CurrencyPair pair = new CurrencyPair("EUR", "USD", "EURUSD", 2);
+
+        QuoteTick tick = adapter.streamQuotes(pair)
+                .blockFirst(Duration.ofSeconds(5));
+
+        assertNotNull(tick);
+        System.out.println(tick);
+    }
+}


### PR DESCRIPTION
## Summary
- create integration test to request a real quote from TwelveData

## Testing
- `mvnw -q test` *(fails: access to repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68781bea7ccc832dbe9e34d848eb8525