### PR TITLE
Исправлен URI для WebClient

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2.java
@@ -74,15 +74,12 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
             symbol = pair.code1() + "/" + pair.code2();
         }
 
-        URI uri = UriComponentsBuilder
-                .fromPath("/price")
-                .queryParam("symbol", symbol)
-                .queryParam("apikey", props.apiKey())
-                .build()
-                .toUri();
-
         return webClient.get()
-                .uri(uri)
+                .uri(builder -> builder
+                        .path("/price")
+                        .queryParam("symbol", symbol)
+                        .queryParam("apikey", props.apiKey())
+                        .build())
                 .retrieve()
                 .bodyToMono(JsonNode.class)
                 .map(this::jsonToTick)


### PR DESCRIPTION
## Summary
- поправил формирование URI в `TwelveFreeAdapterV2`

## Testing
- `mvnw -q -pl backend test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_68781f939f54832d9ffb030f8c0668a6