### PR TITLE
Handle invalid JSON in TwelveFreeAdapterV2

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2.java
@@ -94,10 +94,18 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
     /* Вспомогательный метод преобразования ответа провайдера к модели тика котировки */
     private QuoteTick jsonToTick(JsonNode json) {
 
-        BigDecimal price = new BigDecimal(json.get("price").asText());
+        // В ответе провайдера ключи могут отсутствовать -> проверяем наличие
+        JsonNode priceNode = json.get("price");
+        JsonNode symbolNode = json.get("symbol");
+
+        if (priceNode == null || symbolNode == null) {
+            throw new IllegalArgumentException("Invalid provider response: " + json);
+        }
+
+        BigDecimal price = new BigDecimal(priceNode.asText());
 
         return new QuoteTick(
-                json.get("symbol").asText(),
+                symbolNode.asText(),
                 price,
                 price,
                 Instant.now(),


### PR DESCRIPTION
## Summary
- throw informative exception when `price` or `symbol` is missing

## Testing
- `./mvnw -q -pl backend test` *(fails: Failed to fetch https://repo.maven.apache.org because internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687826695b10832db2ee158bb7f697ce