### PR TITLE
Add missing provider catalog fields

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/entity/ProviderCatalogEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/entity/ProviderCatalogEntity.java
@@ -2,6 +2,8 @@ package com.alligator.market.backend.provider.catalog.entity;
 
 import com.alligator.market.backend.common.jpa.BaseEntity;
 import com.alligator.market.domain.provider.MarketDataProvider;
+import com.alligator.market.domain.provider.AccessMethod;
+import com.alligator.market.domain.provider.DeliveryMode;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +38,30 @@ public class ProviderCatalogEntity extends BaseEntity {
      * согласно {@link MarketDataProvider#providerCode()}
      */
     @Column(length = 50, nullable = false)
-    String providerCode;
+    private String providerCode;
+
+    /**
+     * Режим доставки рыночных данных
+     * согласно {@link MarketDataProvider#deliveryMode()}
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private DeliveryMode deliveryMode;
+
+    /**
+     * Метод доступа к рыночным данным
+     * согласно {@link MarketDataProvider#accessMethod()}
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private AccessMethod accessMethod;
+
+    /**
+     * Поддержка массовой подписки на инструменты
+     * согласно {@link MarketDataProvider#supportsBulkSubscription()}
+     */
+    @Column(nullable = false)
+    private boolean supportsBulkSubscription;
 
 
 }


### PR DESCRIPTION
## Summary
- extend ProviderCatalogEntity with delivery mode, access method and bulk subscription support

## Testing
- `mvnw -q test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_687b5538f89c832da6d041dadb2e81d8