### PR TITLE
Исправление TwelveFreeAdapterV2 и ProviderCatalogEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -57,7 +57,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
     }
     @Override
     public Set<InstrumentType> instrumentTypes() {
-        return CURRENCY_PAIR;
+        return Set.of(CURRENCY_PAIR);
     }
 
     //===========================

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/entity/ProviderCatalogEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/entity/ProviderCatalogEntity.java
@@ -1,9 +1,11 @@
 package com.alligator.market.backend.provider.catalog.entity;
 
 import com.alligator.market.backend.common.jpa.BaseEntity;
+import com.alligator.market.domain.instrument.InstrumentType;
 import com.alligator.market.domain.provider.MarketDataProvider;
 import com.alligator.market.domain.provider.AccessMethod;
 import com.alligator.market.domain.provider.DeliveryMode;
+import java.util.Set;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -62,4 +64,17 @@ public class ProviderCatalogEntity extends BaseEntity {
      */
     @Column(nullable = false)
     private boolean supportsBulkSubscription;
+
+    /**
+     * Поддерживаемые инструменты
+     * согласно {@link MarketDataProvider#instrumentTypes()}
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "provider_catalog_instrument_types",
+            joinColumns = @JoinColumn(name = "provider_catalog_id")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "instrument_type", length = 20, nullable = false)
+    private Set<InstrumentType> instrumentTypes;
 }


### PR DESCRIPTION
## Summary
- исправлен тип возврата в `TwelveFreeAdapterV2.instrumentTypes`
- добавлено хранение поддерживаемых типов инструментов в `ProviderCatalogEntity`

## Testing
- `mvn test` *(failed: Permission denied / no Maven)*

------
https://chatgpt.com/codex/tasks/task_e_687b63af2fa0832dbc9125eb25efc832