### PR TITLE
Add basic repository for ProviderCatalogEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/repository/ProviderCatalogRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/repository/ProviderCatalogRepository.java
@@ -1,0 +1,10 @@
+package com.alligator.market.backend.provider.catalog.repository;
+
+import com.alligator.market.backend.provider.catalog.entity.ProviderCatalogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Репозиторий для работы с таблицей provider_catalog.
+ */
+public interface ProviderCatalogRepository extends JpaRepository<ProviderCatalogEntity, Long> {
+}


### PR DESCRIPTION
## Summary
- introduce `ProviderCatalogRepository` for standard JPA operations

## Testing
- `./mvnw -q -pl backend test` *(fails: could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_687bdd99d384832da4e630b8f9c42a4b