### PR TITLE
Unify naming of currency pair persistence objects

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
@@ -24,7 +24,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class PairEntity extends BaseEntity {
+public class CurrencyPairEntity extends BaseEntity {
 
     /** Суррогатный PK */
     @Id

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairJpaRepository.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.currency_pair.repository;
 
-import com.alligator.market.backend.instrument.type.forex.currency_pair.entity.PairEntity;
+import com.alligator.market.backend.instrument.type.forex.currency_pair.entity.CurrencyPairEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,9 +8,9 @@ import java.util.Optional;
 /**
  * Репозиторий для работы с таблицей валютных пар.
  */
-public interface PairJpaRepository extends JpaRepository<PairEntity, Long> {
+public interface CurrencyPairJpaRepository extends JpaRepository<CurrencyPairEntity, Long> {
 
-    Optional<PairEntity> findByPair(String pair);
+    Optional<CurrencyPairEntity> findByPair(String pair);
 
     /** Проверяет, существует ли любая валютная пара с переданным кодом в code1 или code2 */
     boolean existsByCode1_CodeOrCode2_Code(String code1, String code2);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairRepositoryAdapter.java
@@ -2,9 +2,10 @@ package com.alligator.market.backend.instrument.type.forex.currency_pair.reposit
 
 import com.alligator.market.backend.instrument.type.forex.currency.entity.CurrencyEntity;
 import com.alligator.market.backend.instrument.type.forex.currency.repository.CurrencyJpaRepository;
-import com.alligator.market.backend.instrument.type.forex.currency_pair.entity.PairEntity;
+import com.alligator.market.backend.instrument.type.forex.currency_pair.entity.CurrencyPairEntity;
 import com.alligator.market.domain.instrument.type.forex.currency_pair.CurrencyPair;
 import com.alligator.market.domain.instrument.type.forex.currency_pair.CurrencyPairRepository;
+import com.alligator.market.backend.instrument.type.forex.currency_pair.repository.CurrencyPairJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
@@ -17,16 +18,16 @@ import java.util.Optional;
  */
 @Repository
 @RequiredArgsConstructor
-public class PairRepositoryAdapter implements CurrencyPairRepository {
+public class CurrencyPairRepositoryAdapter implements CurrencyPairRepository {
 
-    private final PairJpaRepository jpaRepository;
+    private final CurrencyPairJpaRepository jpaRepository;
     private final CurrencyJpaRepository currencyJpaRepository;
 
     @Override
     public String save(CurrencyPair pair) {
         CurrencyEntity c1 = currencyJpaRepository.findByCode(pair.code1()).orElseThrow();
         CurrencyEntity c2 = currencyJpaRepository.findByCode(pair.code2()).orElseThrow();
-        PairEntity entity = new PairEntity();
+        CurrencyPairEntity entity = new CurrencyPairEntity();
         entity.setCode1(c1);
         entity.setCode2(c2);
         entity.setPair(pair.pair());
@@ -56,7 +57,7 @@ public class PairRepositoryAdapter implements CurrencyPairRepository {
                 .toList();
     }
 
-    private CurrencyPair toDomain(PairEntity entity) {
+    private CurrencyPair toDomain(CurrencyPairEntity entity) {
         return new CurrencyPair(
                 entity.getCode1().getCode(),
                 entity.getCode2().getCode(),

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
@@ -22,7 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 @Slf4j
-public class PairServiceImpl implements CurrencyPairService {
+public class CurrencyPairServiceImpl implements CurrencyPairService {
 
     private final CurrencyPairRepository repository;
     private final CurrencyRepository currencyRepository;


### PR DESCRIPTION
## Summary
- rename PairEntity to CurrencyPairEntity
- rename PairJpaRepository to CurrencyPairJpaRepository
- rename PairRepositoryAdapter to CurrencyPairRepositoryAdapter
- rename PairServiceImpl to CurrencyPairServiceImpl

## Testing
- `./mvnw -q -DskipTests package` *(fails: wget failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_687d4c6ca024832da4a958f130e6d42f