### PR TITLE
docs(scanner): add Russian JavaDocs to ProviderContextScanner

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderContextScanner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderContextScanner.java
@@ -6,12 +6,16 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+/**
+ * Компонент для доступа ко всем зарегистрированным провайдерам котировок.
+ */
 @Component
 @RequiredArgsConstructor
 public class ProviderContextScanner {
 
     private final List<MarketDataProvider> providers;
 
+    /** Возвращает неизменяемый список всех обнаруженных провайдеров. */
     public List<MarketDataProvider> findAll() {
         return List.copyOf(providers);
     }


### PR DESCRIPTION
## Summary
- describe ProviderContextScanner purpose in JavaDoc
- document `findAll` method

## Testing
- `mvnw -q test` *(fails: could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_687fa2edfc7c832d8966715febde17a6