### PR TITLE
Add Flyway migrations for DB tables

### DIFF
--- a/backend/src/main/resources/db/migration/V1__create_currency_table.sql
+++ b/backend/src/main/resources/db/migration/V1__create_currency_table.sql
@@ -1,0 +1,16 @@
+-- Создает таблицу currency
+CREATE TABLE currency (
+    id BIGSERIAL PRIMARY KEY,
+    version BIGINT,
+    created_timestamp TIMESTAMP,
+    created_by VARCHAR(255),
+    updated_timestamp TIMESTAMP,
+    updated_by VARCHAR(255),
+    code VARCHAR(3) NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    country VARCHAR(100) NOT NULL,
+    decimal INTEGER NOT NULL,
+    CONSTRAINT uq_currency_code UNIQUE (code),
+    CONSTRAINT uq_currency_name UNIQUE (name),
+    CONSTRAINT uq_currency_country UNIQUE (country)
+);

--- a/backend/src/main/resources/db/migration/V2__create_currency_pair_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_currency_pair_table.sql
@@ -1,0 +1,16 @@
+-- Создает таблицу currency_pair
+CREATE TABLE currency_pair (
+    id BIGSERIAL PRIMARY KEY,
+    version BIGINT,
+    created_timestamp TIMESTAMP,
+    created_by VARCHAR(255),
+    updated_timestamp TIMESTAMP,
+    updated_by VARCHAR(255),
+    code1 VARCHAR(3) NOT NULL,
+    code2 VARCHAR(3) NOT NULL,
+    pair VARCHAR(6) NOT NULL,
+    decimal INTEGER NOT NULL,
+    CONSTRAINT fk_pair_code1 FOREIGN KEY (code1) REFERENCES currency(code),
+    CONSTRAINT fk_pair_code2 FOREIGN KEY (code2) REFERENCES currency(code),
+    CONSTRAINT uq_currency_pair UNIQUE (pair)
+);

--- a/backend/src/main/resources/db/migration/V3__create_provider_profile_table.sql
+++ b/backend/src/main/resources/db/migration/V3__create_provider_profile_table.sql
@@ -1,0 +1,18 @@
+-- Создает таблицу provider_profile
+CREATE TABLE provider_profile (
+    id BIGSERIAL PRIMARY KEY,
+    version BIGINT,
+    created_timestamp TIMESTAMP,
+    created_by VARCHAR(255),
+    updated_timestamp TIMESTAMP,
+    updated_by VARCHAR(255),
+    status VARCHAR(10) NOT NULL,
+    provider_code VARCHAR(50) NOT NULL,
+    display_name VARCHAR(50) NOT NULL,
+    delivery_mode VARCHAR(10) NOT NULL,
+    access_method VARCHAR(20) NOT NULL,
+    supports_bulk_subscription BOOLEAN NOT NULL,
+    min_poll_period_ms INTEGER NOT NULL,
+    CONSTRAINT uq_provider_code UNIQUE (provider_code),
+    CONSTRAINT uq_display_name UNIQUE (display_name)
+);

--- a/backend/src/main/resources/db/migration/V4__create_provider_profile_instrument_type_table.sql
+++ b/backend/src/main/resources/db/migration/V4__create_provider_profile_instrument_type_table.sql
@@ -1,0 +1,7 @@
+-- Создает таблицу provider_profile_instrument_type
+CREATE TABLE provider_profile_instrument_type (
+    provider_id BIGINT NOT NULL,
+    instrument_type VARCHAR(20) NOT NULL,
+    PRIMARY KEY (provider_id, instrument_type),
+    CONSTRAINT fk_provider_instrument_type_provider FOREIGN KEY (provider_id) REFERENCES provider_profile(id)
+);


### PR DESCRIPTION
## Summary
- create Flyway migration scripts for currency, currency pair, provider profile and provider instrument type tables

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881471b2410832db50696171ac786fa