### PR TITLE
Add ProviderContextScanner integration test

### DIFF
--- a/backend/src/test/java/com/alligator/market/backend/provider/profile/service/ProviderContextScannerTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/profile/service/ProviderContextScannerTest.java
@@ -1,0 +1,25 @@
+package com.alligator.market.backend.provider.profile.service;
+
+import com.alligator.market.domain.provider.ProviderProfile;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/* Интеграционный тест для сканера профилей провайдеров. */
+@SpringBootTest
+class ProviderContextScannerTest {
+
+    @Autowired
+    private ProviderContextScanner scanner;
+
+    @Test
+    void shouldPrintAllProfiles() {
+        List<ProviderProfile> profiles = scanner.findAll();
+        profiles.forEach(System.out::println);
+        assertFalse(profiles.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add a spring boot integration test for `ProviderContextScanner`

## Testing
- `mvn -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688147a83728832da4121bbfb8bbd44d