### PR TITLE
Add profile service interface

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
@@ -1,31 +1,17 @@
 package com.alligator.market.backend.provider.profile.service;
 
 import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
-import com.alligator.market.backend.provider.profile.repository.ProviderProfileRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.Collection;
 import java.util.List;
 
-
 /**
- * Сервис для работы с профилями провайдеров рыночных данных.
- * Предоставляет базовые операции для получения и сохранения профилей.
+ * Сервис для работы с профилями провайдеров.
  */
-@Service
-@RequiredArgsConstructor
-public class ProviderProfileService {
+public interface ProviderProfileService {
 
-    private final ProviderProfileRepository repository;
+    /** Вернуть все профили провайдеров */
+    List<ProviderProfileEntity> findAll();
 
-    /** Возвращает все профили провайдеров */
-    public List<ProviderProfileEntity> findAll() {
-        return repository.findAll();
-    }
-
-    /** Сохраняет заданную коллекцию профилей */
-    public void saveAll(Collection<ProviderProfileEntity> entities) {
-        repository.saveAll(entities);
-    }
+    /** Сохранить коллекцию профилей */
+    void saveAll(Collection<ProviderProfileEntity> entities);
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
@@ -1,0 +1,33 @@
+package com.alligator.market.backend.provider.profile.service;
+
+import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
+import com.alligator.market.backend.provider.profile.repository.ProviderProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * Сервис для работы с профилями провайдеров рыночных данных.
+ * Предоставляет базовые операции для получения и сохранения профилей.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProviderProfileServiceImpl implements ProviderProfileService {
+
+    private final ProviderProfileRepository repository;
+
+    /** Возвращает все профили провайдеров */
+    @Override
+    public List<ProviderProfileEntity> findAll() {
+        return repository.findAll();
+    }
+
+    /** Сохраняет заданную коллекцию профилей */
+    @Override
+    public void saveAll(Collection<ProviderProfileEntity> entities) {
+        repository.saveAll(entities);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ProviderProfileService` interface
- move implementation to `ProviderProfileServiceImpl`

## Testing
- `mvn -q test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881548843b8832da57f8bb893ad7d54