### PR TITLE
Switch provider service output model

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.profile.service;
 
 import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
+import com.alligator.market.domain.provider.ProviderProfile;
 import java.util.Collection;
 import java.util.List;
 
@@ -10,7 +11,7 @@ import java.util.List;
 public interface ProviderProfileService {
 
     /** Вернуть все профили провайдеров */
-    List<ProviderProfileEntity> findAll();
+    List<ProviderProfile> findAll();
 
     /** Сохранить коллекцию профилей */
     void saveAll(Collection<ProviderProfileEntity> entities);

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
@@ -2,6 +2,8 @@ package com.alligator.market.backend.provider.profile.service;
 
 import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
 import com.alligator.market.backend.provider.profile.repository.ProviderProfileRepository;
+import com.alligator.market.backend.provider.profile.mapper.ProviderProfileMapper;
+import com.alligator.market.domain.provider.ProviderProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,8 +22,10 @@ public class ProviderProfileServiceImpl implements ProviderProfileService {
 
     /** Возвращает все профили провайдеров */
     @Override
-    public List<ProviderProfileEntity> findAll() {
-        return repository.findAll();
+    public List<ProviderProfile> findAll() {
+        return repository.findAll().stream()
+                .map(ProviderProfileMapper::toDomain)
+                .toList();
     }
 
     /** Сохраняет заданную коллекцию профилей */


### PR DESCRIPTION
## Summary
- switch `ProviderProfileService` to return domain models
- map entities to domain models in `ProviderProfileServiceImpl`

## Testing
- `mvnw -q test` *(fails: could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68815779fe4c832db45efde08dd190ef