### PR TITLE
Add provider profile repository port and adapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
@@ -1,0 +1,26 @@
+package com.alligator.market.backend.provider.profile.repository;
+
+import com.alligator.market.backend.provider.profile.mapper.ProviderProfileMapper;
+import com.alligator.market.domain.provider.ProviderProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Адаптер реализующий доменный репозиторий {@link com.alligator.market.domain.provider.ProviderProfileRepository} в контексте Spring Data JPA.
+ */
+@Repository
+@RequiredArgsConstructor
+public class ProviderProfileRepositoryAdapter implements com.alligator.market.domain.provider.ProviderProfileRepository {
+
+    private final ProviderProfileRepository jpaRepository;
+
+    @Override
+    public List<ProviderProfile> findAll() {
+        return jpaRepository.findAll(Sort.by("providerCode")).stream()
+                .map(ProviderProfileMapper::toDomain)
+                .toList();
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/ProviderProfileRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/ProviderProfileRepository.java
@@ -1,0 +1,12 @@
+package com.alligator.market.domain.provider;
+
+import java.util.List;
+
+/**
+ * Порт хранилища профилей провайдеров.
+ */
+public interface ProviderProfileRepository {
+
+    /** Вернуть все профили провайдера */
+    List<ProviderProfile> findAll();
+}


### PR DESCRIPTION
## Summary
- add `ProviderProfileRepository` interface to domain
- implement `ProviderProfileRepositoryAdapter` in backend using Spring Data

## Testing
- `mvn test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6882da864e78832db33cb94f8da69d31