### PR TITLE
Remove provider profile unique constraints

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/entity/ProviderProfileEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/entity/ProviderProfileEntity.java
@@ -17,13 +17,7 @@ import lombok.Setter;
  * Доменная модель профиля провайдера - {@link ProviderProfile}.
  */
 @Entity
-@Table(
-        name = "provider_profile",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uq_provider_code", columnNames = "provider_code"),
-                @UniqueConstraint(name = "uq_display_name", columnNames = "display_name")
-        }
-)
+@Table(name = "provider_profile")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/resources/db/migration/V3__create_provider_profile_table.sql
+++ b/backend/src/main/resources/db/migration/V3__create_provider_profile_table.sql
@@ -12,7 +12,5 @@ CREATE TABLE provider_profile (
     delivery_mode VARCHAR(10) NOT NULL,
     access_method VARCHAR(20) NOT NULL,
     supports_bulk_subscription BOOLEAN NOT NULL,
-    min_poll_period_ms INTEGER NOT NULL,
-    CONSTRAINT uq_provider_code UNIQUE (provider_code),
-    CONSTRAINT uq_display_name UNIQUE (display_name)
+    min_poll_period_ms INTEGER NOT NULL
 );

--- a/backend/src/main/resources/db/migration/V5__drop_provider_profile_unique_constraints.sql
+++ b/backend/src/main/resources/db/migration/V5__drop_provider_profile_unique_constraints.sql
@@ -1,0 +1,3 @@
+-- Убирает уникальные ограничения с provider_profile
+ALTER TABLE provider_profile DROP CONSTRAINT IF EXISTS uq_provider_code;
+ALTER TABLE provider_profile DROP CONSTRAINT IF EXISTS uq_display_name;


### PR DESCRIPTION
## Summary
- drop unique constraints from provider_profile entity
- remove uniqueness from initial provider_profile table creation
- add migration to drop constraints on existing DBs

## Testing
- `mvn test` *(fails: could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6882e60a8ffc832db1e80f46150139ad