### PR TITLE
Добавлен возврат Map профилей с PK

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfileSync.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfileSync.java
@@ -23,8 +23,8 @@ public class ProviderProfileSync {
     public SyncResult compare() {
         // Извлекаем профили из контекста
         List<ProviderProfile> contextProfiles = contextScanner.getProviderProfiles();
-        // Извлекаем профили из таблицы
-        List<ProviderProfile> dbProfiles = profileService.findAll();
+        // Извлекаем профили из таблицы вместе с их PK
+        Map<ProviderProfile, Long> dbProfiles = profileService.findAll();
 
         Map<String, ProviderProfile> contextMap = contextProfiles.stream()
                 .collect(java.util.stream.Collectors.toMap(ProviderProfile::providerCode, p -> p));
@@ -34,7 +34,8 @@ public class ProviderProfileSync {
         List<ProviderProfile> onlyDb = new ArrayList<>();
         List<ProviderProfile> onlyContext = new ArrayList<>();
 
-        for (ProviderProfile dbProfile : dbProfiles) {
+        for (Map.Entry<ProviderProfile, Long> entry : dbProfiles.entrySet()) {
+            ProviderProfile dbProfile = entry.getKey();
             ProviderProfile contextProfile = contextMap.remove(dbProfile.providerCode());
             if (contextProfile == null) {
                 onlyDb.add(dbProfile);

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
@@ -1,12 +1,14 @@
 package com.alligator.market.backend.provider.profile.repository;
 
+import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
 import com.alligator.market.backend.provider.profile.mapper.ProviderProfileMapper;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Адаптер реализующий доменный репозиторий {@link com.alligator.market.domain.provider.ProviderProfileRepository}
@@ -19,9 +21,11 @@ public class ProviderProfileRepositoryAdapter implements com.alligator.market.do
     private final ProviderProfileJpaRepository jpaRepository;
 
     @Override
-    public List<ProviderProfile> findAll() {
+    public Map<ProviderProfile, Long> findAll() {
         return jpaRepository.findAll(Sort.by("providerCode")).stream()
-                .map(ProviderProfileMapper::toDomain)
-                .toList();
+                .collect(Collectors.toMap(
+                        ProviderProfileMapper::toDomain,
+                        ProviderProfileEntity::getId
+                ));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
@@ -3,15 +3,15 @@ package com.alligator.market.backend.provider.profile.service;
 import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import java.util.Collection;
-import java.util.List;
+import java.util.Map;
 
 /**
  * Сервис для работы с профилями провайдеров в таблице БД.
  */
 public interface ProviderProfileService {
 
-    /** Вернуть все профили провайдеров */
-    List<ProviderProfile> findAll();
+    /** Вернуть все профили провайдеров вместе с PK */
+    Map<ProviderProfile, Long> findAll();
 
     /** Сохранить коллекцию профилей */
     void saveAll(Collection<ProviderProfileEntity> entities);

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
@@ -22,10 +23,12 @@ public class ProviderProfileServiceImpl implements ProviderProfileService {
 
     /** Возвращает все профили провайдеров */
     @Override
-    public List<ProviderProfile> findAll() {
+    public Map<ProviderProfile, Long> findAll() {
         return repository.findAll().stream()
-                .map(ProviderProfileMapper::toDomain)
-                .toList();
+                .collect(Collectors.toMap(
+                        ProviderProfileMapper::toDomain,
+                        ProviderProfileEntity::getId
+                ));
     }
 
     /** Сохраняет заданную коллекцию профилей */

--- a/domain/src/main/java/com/alligator/market/domain/provider/ProviderProfileRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/ProviderProfileRepository.java
@@ -2,13 +2,13 @@ package com.alligator.market.domain.provider;
 
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Порт хранилища профилей провайдеров.
  */
 public interface ProviderProfileRepository {
 
-    /** Вернуть все профили провайдера */
-    List<ProviderProfile> findAll();
+    /** Вернуть все профили провайдеров вместе с PK */
+    Map<ProviderProfile, Long> findAll();
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileRepository.java
@@ -1,12 +1,12 @@
 package com.alligator.market.domain.provider.profile;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Порт хранилища профилей провайдеров.
  */
 public interface ProviderProfileRepository {
 
-    /** Вернуть все профили провайдера */
-    List<ProviderProfile> findAll();
+    /** Вернуть все профили провайдеров вместе с PK */
+    Map<ProviderProfile, Long> findAll();
 }


### PR DESCRIPTION
## Summary
- возвращаем карту `<ProviderProfile, id>` из хранилища профилей
- адаптирован сервис и синхронизатор профилей

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688381fa3670832d9742a2cffb769a7b