### PR TITLE
Implement provider profile uniqueness check

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.profile.context_sync;
 
 import com.alligator.market.backend.provider.profile.service.ProviderProfileService;
+import com.alligator.market.backend.provider.profile.exception.DuplicateProviderProfileException;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -24,7 +25,17 @@ public class ProviderProfilesMatching {
         List<ProviderProfile> contextProfiles = contextScanner.getProviderProfiles();
 
         // Проверяем, что профили из контекста имеют разные providerCode и displayName
+        Set<String> codes = new HashSet<>();
+        Set<String> names = new HashSet<>();
+        for (ProviderProfile profile : contextProfiles) {
+            if (!codes.add(profile.providerCode())) {
+                throw new DuplicateProviderProfileException("providerCode", profile.providerCode());
+            }
+            if (!names.add(profile.displayName())) {
+                throw new DuplicateProviderProfileException("displayName", profile.displayName());
+            }
 
+        }
 
         // Извлекаем профили из таблицы вместе с PK
         Map<ProviderProfile, Long> dbProfiles = profileService.findAll();

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/exception/DuplicateProviderProfileException.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/exception/DuplicateProviderProfileException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.backend.provider.profile.exception;
+
+/**
+ * Профиль провайдера с указанным полем уже присутствует в контексте.
+ */
+public class DuplicateProviderProfileException extends RuntimeException {
+    public DuplicateProviderProfileException(String field, String value) {
+        super("Provider profile with %s '%s' already exists".formatted(field, value));
+    }
+}


### PR DESCRIPTION
## Summary
- add `DuplicateProviderProfileException`
- ensure provider profiles from context have unique providerCode and displayName
- restore execution flag on mvnw

## Testing
- `./mvnw -q test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6883965e72c4832dba7353f6b00313fa