### PR TITLE
Implement findAllActive for provider profiles

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
@@ -37,8 +37,8 @@ public class ProviderProfilesMatching {
 
         }
 
-        // Извлекаем профили из таблицы вместе с PK
-        Map<ProviderProfile, Long> dbProfiles = profileService.findAll();
+        // Извлекаем активные профили из таблицы вместе с PK
+        Map<ProviderProfile, Long> dbProfiles = profileService.findAllActive();
 
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileJpaRepository.java
@@ -1,10 +1,15 @@
 package com.alligator.market.backend.provider.profile.repository;
 
 import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 /**
  * Репозиторий для работы с профилями провайдеров.
  */
 public interface ProviderProfileJpaRepository extends JpaRepository<ProviderProfileEntity, Long> {
+
+    /** Найти все профили по статусу */
+    List<ProviderProfileEntity> findAllByStatus(ProviderProfileStatus status);
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
@@ -4,8 +4,8 @@ import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntit
 import com.alligator.market.backend.provider.profile.mapper.ProviderProfileMapper;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.provider.profile.ProviderProfileRepository;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
@@ -22,8 +22,9 @@ public class ProviderProfileRepositoryAdapter implements ProviderProfileReposito
     private final ProviderProfileJpaRepository jpaRepository;
 
     @Override
-    public Map<ProviderProfile, Long> findAll() {
-        return jpaRepository.findAll(Sort.by("providerCode")).stream()
+    public Map<ProviderProfile, Long> findAllActive() {
+        return jpaRepository.findAllByStatus(ProviderProfileStatus.ACTIVE).stream()
+                .sorted((o1, o2) -> o1.getProviderCode().compareTo(o2.getProviderCode()))
                 .collect(Collectors.toMap(
                         ProviderProfileMapper::toDomain,
                         ProviderProfileEntity::getId

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
@@ -10,8 +10,8 @@ import java.util.Map;
  */
 public interface ProviderProfileService {
 
-    /** Вернуть все профили провайдеров вместе с PK */
-    Map<ProviderProfile, Long> findAll();
+    /** Вернуть все активные профили провайдеров вместе с PK */
+    Map<ProviderProfile, Long> findAllActive();
 
     /** Сохранить коллекцию профилей */
     void saveAll(Collection<ProviderProfileEntity> entities);

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntit
 import com.alligator.market.backend.provider.profile.repository.ProviderProfileJpaRepository;
 import com.alligator.market.backend.provider.profile.mapper.ProviderProfileMapper;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,10 +22,10 @@ public class ProviderProfileServiceImpl implements ProviderProfileService {
 
     private final ProviderProfileJpaRepository repository;
 
-    /** Возвращает все профили провайдеров */
+    /** Возвращает все профили провайдеров со статусом ACTIVE */
     @Override
-    public Map<ProviderProfile, Long> findAll() {
-        return repository.findAll().stream()
+    public Map<ProviderProfile, Long> findAllActive() {
+        return repository.findAllByStatus(ProviderProfileStatus.ACTIVE).stream()
                 .collect(Collectors.toMap(
                         ProviderProfileMapper::toDomain,
                         ProviderProfileEntity::getId

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileRepository.java
@@ -7,6 +7,6 @@ import java.util.Map;
  */
 public interface ProviderProfileRepository {
 
-    /** Вернуть все профили провайдеров вместе с PK */
-    Map<ProviderProfile, Long> findAll();
+    /** Вернуть все активные профили провайдеров вместе с PK */
+    Map<ProviderProfile, Long> findAllActive();
 }


### PR DESCRIPTION
## Summary
- fetch only active provider profiles
- rename service method to `findAllActive`
- adjust repository and matching component

## Testing
- `./mvnw -q test` *(fails: cannot fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68849a8a766c832d85b9d551771974aa