### PR TITLE
Add provider profile duplication validation

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScanner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScanner.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.profile.context_sync;
 
 import com.alligator.market.domain.provider.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
+import com.alligator.market.backend.provider.profile.exception.DuplicateProviderProfileException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -20,8 +21,27 @@ public class ProviderContextScanner {
 
     /** Возвращает список профилей провайдеров */
     public List<ProviderProfile> getProviderProfiles() {
-        return providers.stream()
+        List<ProviderProfile> profiles = providers.stream()
                 .map(MarketDataProvider::profile)
                 .toList();
+
+        validateNoDuplicates(profiles);
+
+        return profiles;
+    }
+
+    /** Проверяем, что providerCode и displayName уникальны. */
+    private void validateNoDuplicates(List<ProviderProfile> profiles) {
+        java.util.Set<String> codes = new java.util.HashSet<>();
+        java.util.Set<String> names = new java.util.HashSet<>();
+
+        for (ProviderProfile profile : profiles) {
+            if (!codes.add(profile.providerCode())) {
+                throw new DuplicateProviderProfileException("providerCode", profile.providerCode());
+            }
+            if (!names.add(profile.displayName())) {
+                throw new DuplicateProviderProfileException("displayName", profile.displayName());
+            }
+        }
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
@@ -1,7 +1,6 @@
 package com.alligator.market.backend.provider.profile.context_sync;
 
 import com.alligator.market.backend.provider.profile.service.ProviderProfileService;
-import com.alligator.market.backend.provider.profile.exception.DuplicateProviderProfileException;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -24,17 +23,6 @@ public class ProviderProfilesMatching {
         // Извлекаем профили из контекста
         List<ProviderProfile> contextProfiles = contextScanner.getProviderProfiles();
 
-        // Проверяем, что среди профилей из контекста нет профилей с совпадающими providerCode или displayName
-        Set<String> codes = new HashSet<>();
-        Set<String> names = new HashSet<>();
-        for (ProviderProfile profile : contextProfiles) {
-            if (!codes.add(profile.providerCode())) {
-                throw new DuplicateProviderProfileException("providerCode", profile.providerCode());
-            }
-            if (!names.add(profile.displayName())) {
-                throw new DuplicateProviderProfileException("displayName", profile.displayName());
-            }
-        }
 
         // Извлекаем активные профили из таблицы вместе с PK
         Map<ProviderProfile, Long> dbActiveProfiles = profileService.findAllActive();

--- a/backend/src/test/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScannerValidationTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScannerValidationTest.java
@@ -1,0 +1,60 @@
+package com.alligator.market.backend.provider.profile.context_sync;
+
+import com.alligator.market.backend.provider.profile.exception.DuplicateProviderProfileException;
+import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.InstrumentType;
+import com.alligator.market.domain.provider.MarketDataProvider;
+import com.alligator.market.domain.provider.profile.AccessMethod;
+import com.alligator.market.domain.provider.profile.DeliveryMode;
+import com.alligator.market.domain.provider.profile.ProviderProfile;
+import com.alligator.market.domain.quote.QuoteTick;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Тесты проверки уникальности профилей в ProviderContextScanner. */
+class ProviderContextScannerValidationTest {
+
+    @Test
+    void shouldThrowOnDuplicateCode() {
+        MarketDataProvider p1 = provider("A", "Name1");
+        MarketDataProvider p2 = provider("A", "Name2");
+        ProviderContextScanner scanner = new ProviderContextScanner(List.of(p1, p2));
+        assertThrows(DuplicateProviderProfileException.class, scanner::getProviderProfiles);
+    }
+
+    @Test
+    void shouldThrowOnDuplicateName() {
+        MarketDataProvider p1 = provider("A", "Same");
+        MarketDataProvider p2 = provider("B", "Same");
+        ProviderContextScanner scanner = new ProviderContextScanner(List.of(p1, p2));
+        assertThrows(DuplicateProviderProfileException.class, scanner::getProviderProfiles);
+    }
+
+    private static MarketDataProvider provider(String code, String name) {
+        ProviderProfile profile = new ProviderProfile(
+                code,
+                name,
+                Set.of(InstrumentType.CURRENCY),
+                DeliveryMode.PULL,
+                AccessMethod.API_POLL,
+                false,
+                1
+        );
+        return new MarketDataProvider() {
+            @Override
+            public ProviderProfile profile() {
+                return profile;
+            }
+
+            @Override
+            public Flux<QuoteTick> streamQuotes(Instrument instrument) {
+                return Flux.empty();
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- validate unique provider profiles inside ProviderContextScanner
- rely on scanning validation in ProviderProfilesMatching
- add tests for duplicate provider profiles

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688639b308d0832d949889cf8e55bd69