### PR TITLE
feat(sync): simplify diff storage

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ContextDiff.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ContextDiff.java
@@ -1,7 +1,11 @@
 package com.alligator.market.backend.provider.profile.context_sync;
 
 import com.alligator.market.domain.provider.profile.ProviderProfile;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -9,14 +13,43 @@ import java.util.Map;
  * Модель содержит списки профилей, касательно которых требуются действия в базе данных для обеспечения
  * синхронизации профилей провайдеров получаемых методом {@link ProviderContextScanner#getProviderProfiles()} и
  * профилей провайдеров, содержащихся в базе данных.
- *
- * @param addWithActiveStatus
- * @param changeStatusToReplaced
- * @param changeStatusToMissing
  */
-public record ContextDiff(
+@Getter
+@NoArgsConstructor
+public class ContextDiff {
 
-        List<ProviderProfile> addWithActiveStatus,
-        Map<ProviderProfile, Long> changeStatusToReplaced,
-        Map<ProviderProfile, Long> changeStatusToMissing
-) {}
+    /** Профили, которые нужно создать со статусом ACTIVE */
+    private final List<ProviderProfile> addWithActiveStatus = new ArrayList<>();
+
+    /** Профили для замены на новые */
+    private final Map<ProviderProfile, Long> changeStatusToReplaced = new LinkedHashMap<>();
+
+    /** Профили отсутствующие в контексте */
+    private final Map<ProviderProfile, Long> changeStatusToMissing = new LinkedHashMap<>();
+
+    /**
+     * Конструктор инициализирует модель заранее подготовленными контейнерами.
+     */
+    public ContextDiff(List<ProviderProfile> addWithActiveStatus,
+                       Map<ProviderProfile, Long> changeStatusToReplaced,
+                       Map<ProviderProfile, Long> changeStatusToMissing) {
+        this.addWithActiveStatus.addAll(addWithActiveStatus);
+        this.changeStatusToReplaced.putAll(changeStatusToReplaced);
+        this.changeStatusToMissing.putAll(changeStatusToMissing);
+    }
+
+    /** Добавить новый профиль со статусом ACTIVE. */
+    public void putAddList(ProviderProfile profile) {
+        addWithActiveStatus.add(profile);
+    }
+
+    /** Пометить профиль в БД как REPLACED. */
+    public void putToReplaceMap(ProviderProfile profile, Long id) {
+        changeStatusToReplaced.put(profile, id);
+    }
+
+    /** Пометить профиль в БД как MISSING. */
+    public void putToMissingMap(ProviderProfile profile, Long id) {
+        changeStatusToMissing.put(profile, id);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesMatching.java
@@ -5,7 +5,9 @@ import com.alligator.market.domain.provider.profile.ProviderProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Компонент сравнивает профили провайдеров, извлеченных из контекста Spring и извлеченных из базы данных,
@@ -32,9 +34,7 @@ public class ProviderProfilesMatching {
         //===============================
 
         // Контейнеры для результата
-        List<ProviderProfile> addNew = new ArrayList<>();
-        Map<ProviderProfile, Long> toReplaced = new LinkedHashMap<>();
-        Map<ProviderProfile, Long> toMissing = new LinkedHashMap<>();
+        ContextDiff diff = new ContextDiff();
 
         // Создаем копию списка профилей из контекста, чтобы удалять найденные
         List<ProviderProfile> restContextProfiles = new ArrayList<>(contextProfiles);
@@ -56,7 +56,7 @@ public class ProviderProfilesMatching {
 
             if (contextMatch == null) {
                 // Профиль в контексте не найден
-                toMissing.put(dbProfile, id);
+                diff.putToMissingMap(dbProfile, id);
                 continue;
             }
 
@@ -67,14 +67,14 @@ public class ProviderProfilesMatching {
             }
 
             // providerCode совпадает, но есть отличия
-            toReplaced.put(dbProfile, id);
-            addNew.add(contextMatch);
+            diff.putToReplaceMap(dbProfile, id);
+            diff.putAddList(contextMatch);
             restContextProfiles.remove(contextMatch);
         }
 
         // Оставшиеся в контексте профили новые
-        addNew.addAll(restContextProfiles);
+        restContextProfiles.forEach(diff::putAddList);
 
-        return new ContextDiff(addNew, toReplaced, toMissing);
+        return diff;
     }
 }


### PR DESCRIPTION
## Summary
- add mutable `ContextDiff` for provider profile synchronization
- update matching logic to populate `ContextDiff` directly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68863eb92890832d8d621f496913902a