### PR TITLE
Add provider context scanner contract

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ContextDiff.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ContextDiff.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.profile.context_sync;
 
-import com.alligator.market.backend.provider.profile.service.ProviderProfileServiceImpl;
+import com.alligator.market.domain.provider.profile.ProviderContextScanner;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScanner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScanner.java
@@ -14,12 +14,14 @@ import java.util.List;
  */
 @Component
 @RequiredArgsConstructor
-public class ProviderContextScanner {
+public class ProviderContextScanner
+        implements com.alligator.market.domain.provider.profile.ProviderContextScanner {
 
     /** Список всех адаптеров провайдеров */
     private final List<MarketDataProvider> providers;
 
     /** Возвращает список профилей провайдеров */
+    @Override
     public List<ProviderProfile> getProviderProfiles() {
         List<ProviderProfile> profiles = providers.stream()
                 .map(MarketDataProvider::profile)

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesReconciliation.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesReconciliation.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.profile.context_sync;
 
 import com.alligator.market.backend.provider.profile.service.ProviderProfileService;
+import com.alligator.market.domain.provider.profile.ProviderContextScanner;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderContextScanner.java
@@ -1,0 +1,13 @@
+package com.alligator.market.domain.provider.profile;
+
+import java.util.List;
+
+/**
+ * Порт поиска в контексте Spring всех адаптеров провайдеров рыночных данных
+ * и извлечения их профилей.
+ */
+public interface ProviderContextScanner {
+
+    /** Вернуть список профилей провайдеров */
+    List<ProviderProfile> getProviderProfiles();
+}


### PR DESCRIPTION
## Summary
- define domain interface `ProviderContextScanner`
- implement the interface in backend
- use domain interface where profiles are reconciled

## Testing
- `mvn -q -pl domain,backend test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688754a9d890832da17ac198629bbe72