### PR TITLE
Adjust ProviderProfileServiceImpl repository dependency

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
@@ -1,16 +1,13 @@
 package com.alligator.market.backend.provider.profile.service;
 
 import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
-import com.alligator.market.backend.provider.profile.repository.ProviderProfileJpaRepository;
-import com.alligator.market.backend.provider.profile.mapper.ProviderProfileMapper;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
-import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
+import com.alligator.market.domain.provider.profile.ProviderProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 
 /**
@@ -20,16 +17,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ProviderProfileServiceImpl implements ProviderProfileService {
 
-    private final ProviderProfileJpaRepository repository;
+    private final ProviderProfileRepository repository;
 
     /** Возвращает все профили провайдеров со статусом ACTIVE */
     @Override
     public Map<ProviderProfile, Long> findAllActive() {
-        return repository.findAllByStatus(ProviderProfileStatus.ACTIVE).stream()
-                .collect(Collectors.toMap(
-                        ProviderProfileMapper::toDomain,
-                        ProviderProfileEntity::getId
-                ));
+        return repository.findAllActive();
     }
 
     /** Сохраняет заданную коллекцию профилей */


### PR DESCRIPTION
## Summary
- use `ProviderProfileRepository` in provider profile service
- keep Spring annotation on the adapter

## Testing
- `mvn -q test -pl backend -am` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688761d195a4832d8b63bd631dca670f