### PR TITLE
feat(provider): add saveAll for profiles

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileRepositoryAdapter.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 /**
@@ -29,5 +30,13 @@ public class ProviderProfileRepositoryAdapter implements ProviderProfileReposito
                         ProviderProfileMapper::toDomain,
                         ProviderProfileEntity::getId
                 ));
+    }
+
+    @Override
+    public void saveAll(Collection<ProviderProfile> profiles) {
+        var entities = profiles.stream()
+                .map(p -> ProviderProfileMapper.toEntity(p, ProviderProfileStatus.ACTIVE))
+                .toList();
+        jpaRepository.saveAll(entities);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.provider.profile.service;
 
-import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import java.util.Collection;
 import java.util.Map;
@@ -13,6 +12,6 @@ public interface ProviderProfileService {
     /** Вернуть все активные профили провайдеров вместе с PK */
     Map<ProviderProfile, Long> findAllActive();
 
-    /** Сохранить коллекцию профилей */
-    void saveAll(Collection<ProviderProfileEntity> entities);
+    /** Сохранить коллекцию профилей со статусом ACTIVE */
+    void saveAll(Collection<ProviderProfile> profiles);
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.provider.profile.service;
 
-import com.alligator.market.backend.provider.profile.entity.ProviderProfileEntity;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.provider.profile.ProviderProfileRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +24,9 @@ public class ProviderProfileServiceImpl implements ProviderProfileService {
         return repository.findAllActive();
     }
 
-    /** Сохраняет заданную коллекцию профилей */
+    /** Сохраняет заданную коллекцию профилей со статусом ACTIVE */
     @Override
-    public void saveAll(Collection<ProviderProfileEntity> entities) {
-        repository.saveAll(entities);
+    public void saveAll(Collection<ProviderProfile> profiles) {
+        repository.saveAll(profiles);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileRepository.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.profile;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -9,4 +10,7 @@ public interface ProviderProfileRepository {
 
     /** Вернуть все активные профили провайдеров вместе с PK */
     Map<ProviderProfile, Long> findAllActive();
+
+    /** Сохранить коллекцию профилей со статусом ACTIVE */
+    void saveAll(Collection<ProviderProfile> profiles);
 }


### PR DESCRIPTION
## Summary
- extend `ProviderProfileRepository` with `saveAll`
- update service layer to accept domain profiles
- implement saving in JPA adapter

## Testing
- `./mvnw -q test` *(fails: Maven could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68876660e27c832dad14a87d67b247ce