### PR TITLE
Convert ContextDiff to record

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ContextDiff.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ContextDiff.java
@@ -10,27 +10,14 @@ import java.util.Map;
 /**
  * Результат сопоставления профилей провайдеров.
  */
-public class ContextDiff {
+public record ContextDiff(
+        List<ProviderProfile> add,
+        Map<ProviderProfile, Long> replaced,
+        Map<ProviderProfile, Long> missing
+) {
 
-    /** Список профилей, которые нужно создать. */
-    private final List<ProviderProfile> add = new ArrayList<>();
-
-    /** Профили для пометки статусом REPLACED. */
-    private final Map<ProviderProfile, Long> replaced = new LinkedHashMap<>();
-
-    /** Профили для пометки статусом MISSING. */
-    private final Map<ProviderProfile, Long> missing = new LinkedHashMap<>();
-
-    public List<ProviderProfile> getAdd() {
-        return add;
-    }
-
-    public Map<ProviderProfile, Long> getReplaced() {
-        return replaced;
-    }
-
-    public Map<ProviderProfile, Long> getMissing() {
-        return missing;
+    public ContextDiff() {
+        this(new ArrayList<>(), new LinkedHashMap<>(), new LinkedHashMap<>());
     }
 
     public void putToAddList(ProviderProfile profile) {

--- a/domain/src/test/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliationTest.java
+++ b/domain/src/test/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliationTest.java
@@ -33,15 +33,15 @@ class ProviderProfilesReconciliationTest {
         ProviderProfilesReconciliation service = new ProviderProfilesReconciliation(scanner, storage);
         ContextDiff diff = service.compare();
 
-        assertTrue(diff.getAdd().contains(ctxB));
-        assertTrue(diff.getAdd().contains(ctxD));
-        assertEquals(2, diff.getAdd().size());
+        assertTrue(diff.add().contains(ctxB));
+        assertTrue(diff.add().contains(ctxD));
+        assertEquals(2, diff.add().size());
 
-        assertEquals(1, diff.getReplaced().size());
-        assertEquals(2L, diff.getReplaced().get(dbB));
+        assertEquals(1, diff.replaced().size());
+        assertEquals(2L, diff.replaced().get(dbB));
 
-        assertEquals(1, diff.getMissing().size());
-        assertEquals(3L, diff.getMissing().get(dbC));
+        assertEquals(1, diff.missing().size());
+        assertEquals(3L, diff.missing().get(dbC));
     }
 
     private static ProviderProfile profile(String code, String name) {


### PR DESCRIPTION
## Summary
- refactor `ContextDiff` class into a Java record
- update reconciliation tests to use new record accessors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68878d2ff5ac832dafeb4aaf7248b285