### PR TITLE
Add diff application for provider profiles

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesReconciliationAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesReconciliationAdapter.java
@@ -22,4 +22,10 @@ public class ProviderProfilesReconciliationAdapter {
         var domain = new ProviderProfilesReconciliation(contextScanner, profileStorage);
         return domain.compare();
     }
+
+    /** Применить diff к хранилищу. */
+    public void applyContextDiffToStorage(ContextDiff diff) {
+        var domain = new ProviderProfilesReconciliation(contextScanner, profileStorage);
+        domain.applyContextDiffToStorage(diff);
+    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileStorageAdapter.java
@@ -38,4 +38,11 @@ public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
                 .toList();
         jpaRepository.saveAll(entities);
     }
+
+    @Override
+    public void updateStatus(Collection<Long> ids, ProviderProfileStatus status) {
+        var entities = jpaRepository.findAllById(ids);
+        entities.forEach(e -> e.setStatus(status));
+        jpaRepository.saveAll(entities);
+    }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ContextDiff.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ContextDiff.java
@@ -3,32 +3,31 @@ package com.alligator.market.domain.provider.context_sync;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Результат сопоставления профилей провайдеров.
  */
 public record ContextDiff(
         List<ProviderProfile> add,
-        Map<ProviderProfile, Long> replaced,
-        Map<ProviderProfile, Long> missing
+        List<Long> replaced,
+        List<Long> missing
 ) {
 
     public ContextDiff() {
-        this(new ArrayList<>(), new LinkedHashMap<>(), new LinkedHashMap<>());
+        this(new ArrayList<>(), new LinkedList<>(), new LinkedList<>());
     }
 
     public void putToAddList(ProviderProfile profile) {
         add.add(profile);
     }
 
-    public void putToReplaceMap(ProviderProfile profile, Long id) {
-        replaced.put(profile, id);
+    public void putToReplaceList(Long id) {
+        replaced.add(id);
     }
 
-    public void putToMissingMap(ProviderProfile profile, Long id) {
-        missing.put(profile, id);
+    public void putToMissingList(Long id) {
+        missing.add(id);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliation.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliation.java
@@ -2,6 +2,7 @@ package com.alligator.market.domain.provider.context_sync;
 
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.provider.profile.ProviderProfileStorage;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +43,7 @@ public class ProviderProfilesReconciliation {
             }
 
             if (contextMatch == null) {
-                diff.putToMissingMap(dbProfile, id);
+                diff.putToMissingList(id);
                 continue;
             }
 
@@ -51,12 +52,27 @@ public class ProviderProfilesReconciliation {
                 continue;
             }
 
-            diff.putToReplaceMap(dbProfile, id);
+            diff.putToReplaceList(id);
             diff.putToAddList(contextMatch);
             restContextProfiles.remove(contextMatch);
         }
 
         restContextProfiles.forEach(diff::putToAddList);
         return diff;
+    }
+
+    /**
+     * Применяет diff к хранилищу профилей.
+     */
+    public void applyContextDiffToStorage(ContextDiff diff) {
+        if (!diff.add().isEmpty()) {
+            profileStorage.saveAll(diff.add());
+        }
+        if (!diff.replaced().isEmpty()) {
+            profileStorage.updateStatus(diff.replaced(), ProviderProfileStatus.REPLACED);
+        }
+        if (!diff.missing().isEmpty()) {
+            profileStorage.updateStatus(diff.missing(), ProviderProfileStatus.MISSING);
+        }
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileStorage.java
@@ -3,6 +3,7 @@ package com.alligator.market.domain.provider.profile;
 import java.util.Collection;
 import java.util.Map;
 
+
 /**
  * Порт хранилища профилей провайдеров.
  */
@@ -13,4 +14,7 @@ public interface ProviderProfileStorage {
 
     /** Сохранить коллекцию профилей со статусом ACTIVE */
     void saveAll(Collection<ProviderProfile> profiles);
+
+    /** Обновить статус профилей по их идентификаторам */
+    void updateStatus(Collection<Long> ids, ProviderProfileStatus status);
 }

--- a/domain/src/test/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliationTest.java
+++ b/domain/src/test/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliationTest.java
@@ -5,6 +5,7 @@ import com.alligator.market.domain.provider.profile.AccessMethod;
 import com.alligator.market.domain.provider.profile.DeliveryMode;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.provider.profile.ProviderProfileStorage;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -40,10 +41,10 @@ class ProviderProfilesReconciliationTest {
         assertEquals(2, diff.add().size());
 
         assertEquals(1, diff.replaced().size());
-        assertEquals(2L, diff.replaced().get(dbB));
+        assertTrue(diff.replaced().contains(2L));
 
         assertEquals(1, diff.missing().size());
-        assertEquals(3L, diff.missing().get(dbC));
+        assertTrue(diff.missing().contains(3L));
     }
 
     private static ProviderProfile profile(String code, String name) {
@@ -73,6 +74,11 @@ class ProviderProfilesReconciliationTest {
 
         @Override
         public void saveAll(java.util.Collection<ProviderProfile> profiles) {
+            // not needed for test
+        }
+
+        @Override
+        public void updateStatus(java.util.Collection<Long> ids, ProviderProfileStatus status) {
             // not needed for test
         }
     }


### PR DESCRIPTION
## Summary
- update `ContextDiff` to store IDs for replaced and missing profiles
- implement diff applying logic in `ProviderProfilesReconciliation`
- extend `ProviderProfileStorage` with status update operation
- support new operation in JPA adapter
- expose diff application via reconciliation adapter
- adjust domain test to new API

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887953e76e0832da10a1782d4de7745