### PR TITLE
Add provider profile list page

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/dto/ProviderProfileDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/dto/ProviderProfileDto.java
@@ -1,0 +1,21 @@
+package com.alligator.market.backend.provider.profile.dto;
+
+import com.alligator.market.domain.instrument.InstrumentType;
+import com.alligator.market.domain.provider.profile.AccessMethod;
+import com.alligator.market.domain.provider.profile.DeliveryMode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Set;
+
+/**
+ * DTO для информативного представления профиля провайдера.
+ */
+public record ProviderProfileDto(
+        @NotBlank String providerCode,
+        @NotBlank String displayName,
+        @NotNull Set<InstrumentType> instrumentTypes,
+        @NotNull DeliveryMode deliveryMode,
+        @NotNull AccessMethod accessMethod,
+        boolean supportsBulkSubscription,
+        int minPollPeriodMs
+) {}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/web/ProviderProfileController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/web/ProviderProfileController.java
@@ -1,0 +1,47 @@
+package com.alligator.market.backend.provider.profile.web;
+
+import com.alligator.market.backend.common.web.ApiResponse;
+import com.alligator.market.backend.common.web.ResponseEntityFactory;
+import com.alligator.market.backend.provider.profile.dto.ProviderProfileDto;
+import com.alligator.market.backend.provider.profile.service.ProviderProfileService;
+import com.alligator.market.domain.provider.profile.ProviderProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST-контроллер для чтения профилей провайдеров.
+ */
+@RestController
+@RequestMapping("/api/v1/providers")
+@RequiredArgsConstructor
+public class ProviderProfileController {
+
+    private final ProviderProfileService service;
+
+    /** Вернуть все активные профили провайдеров. */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ProviderProfileDto>>> getAll() {
+        List<ProviderProfileDto> list = service.findAllActive().keySet().stream()
+                .map(this::toDto)
+                .toList();
+        return ResponseEntityFactory.ok(list);
+    }
+
+    /* Утилита преобразует доменную модель в DTO. */
+    private ProviderProfileDto toDto(ProviderProfile profile) {
+        return new ProviderProfileDto(
+                profile.providerCode(),
+                profile.displayName(),
+                profile.instrumentTypes(),
+                profile.deliveryMode(),
+                profile.accessMethod(),
+                profile.supportsBulkSubscription(),
+                profile.minPollPeriodMs()
+        );
+    }
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,12 @@ export const routes: Routes = [
       import('./features/currency_pair/pair.module').then(m => m.PairModule)
   },
   {
+    path: 'providers',
+    loadChildren: () =>
+      import('./features/provider_profile/provider-profile.module')
+        .then(m => m.ProviderProfileModule)
+  },
+  {
     path: '',
     loadComponent: () =>
       import('./home/home.component').then(c => c.HomeComponent)

--- a/frontend/src/app/features/provider_profile/models/provider-profile.model.ts
+++ b/frontend/src/app/features/provider_profile/models/provider-profile.model.ts
@@ -1,0 +1,10 @@
+/** DTO для профиля провайдера, аналогичный backend */
+export interface ProviderProfileDto {
+  providerCode: string;
+  displayName: string;
+  instrumentTypes: string[];
+  deliveryMode: string;
+  accessMethod: string;
+  supportsBulkSubscription: boolean;
+  minPollPeriodMs: number;
+}

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -1,0 +1,47 @@
+<div class="center-box">
+  <h1 class="mat-headline-4">Provider Profiles</h1>
+  <mat-card>
+    <mat-card-content>
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
+
+        <ng-container matColumnDef="providerCode">
+          <th mat-header-cell *matHeaderCellDef>Code</th>
+          <td mat-cell *matCellDef="let p">{{ p.providerCode }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="displayName">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let p">{{ p.displayName }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="instrumentTypes">
+          <th mat-header-cell *matHeaderCellDef>Instrument Types</th>
+          <td mat-cell *matCellDef="let p">{{ p.instrumentTypes.join(', ') }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="deliveryMode">
+          <th mat-header-cell *matHeaderCellDef>Delivery</th>
+          <td mat-cell *matCellDef="let p">{{ p.deliveryMode }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="accessMethod">
+          <th mat-header-cell *matHeaderCellDef>Access</th>
+          <td mat-cell *matCellDef="let p">{{ p.accessMethod }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="supportsBulkSubscription">
+          <th mat-header-cell *matHeaderCellDef>Bulk</th>
+          <td mat-cell *matCellDef="let p">{{ p.supportsBulkSubscription }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="minPollPeriodMs">
+          <th mat-header-cell *matHeaderCellDef>Min Poll ms</th>
+          <td mat-cell *matCellDef="let p">{{ p.minPollPeriodMs }}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+      </table>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -1,0 +1,8 @@
+.center-box {
+  max-width: 960px;
+  margin: 32px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 0 16px;
+}

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatCardModule } from '@angular/material/card';
+import { ProviderProfileService } from '../../services/provider-profile.service';
+import { ProviderProfileDto } from '../../models/provider-profile.model';
+
+@Component({
+  selector: 'app-provider-profile-list',
+  standalone: true,
+  imports: [CommonModule, MatTableModule, MatCardModule],
+  templateUrl: './profile-list.component.html',
+  styleUrl: './profile-list.component.scss'
+})
+export class ProfileListComponent implements OnInit {
+
+  displayed: string[] = [
+    'providerCode',
+    'displayName',
+    'instrumentTypes',
+    'deliveryMode',
+    'accessMethod',
+    'supportsBulkSubscription',
+    'minPollPeriodMs'
+  ];
+  dataSource = new MatTableDataSource<ProviderProfileDto>([]);
+
+  constructor(private readonly service: ProviderProfileService) {}
+
+  /* загрузка списка при открытии страницы */
+  ngOnInit(): void {
+    this.service.list().subscribe({
+      next: list => this.dataSource.data = list,
+      error: err => console.error(err)
+    });
+  }
+}

--- a/frontend/src/app/features/provider_profile/provider-profile-routing.module.ts
+++ b/frontend/src/app/features/provider_profile/provider-profile-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/profile-list/profile-list.component')
+        .then(c => c.ProfileListComponent)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ProviderProfileRoutingModule {}

--- a/frontend/src/app/features/provider_profile/provider-profile.module.ts
+++ b/frontend/src/app/features/provider_profile/provider-profile.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ProviderProfileRoutingModule } from './provider-profile-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, ProviderProfileRoutingModule]
+})
+export class ProviderProfileModule {}

--- a/frontend/src/app/features/provider_profile/services/provider-profile.service.ts
+++ b/frontend/src/app/features/provider_profile/services/provider-profile.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/api-response.model';
+import { ProviderProfileDto } from '../models/provider-profile.model';
+
+/* Сервис для чтения профилей провайдеров */
+@Injectable({
+  providedIn: 'root'
+})
+export class ProviderProfileService {
+
+  constructor(private http: HttpClient) { }
+
+  /* Базовый URL (через proxy уйдёт на Spring) */
+  private readonly baseUrl = '/api/v1/providers';
+
+  /* Получить список всех профилей */
+  list(): Observable<ProviderProfileDto[]> {
+    return this.http
+      .get<ApiResponse<ProviderProfileDto[]>>(this.baseUrl)
+      .pipe(map(res => res.data));
+  }
+}


### PR DESCRIPTION
## Summary
- expose provider profiles via `/api/v1/providers`
- display provider profiles table in Angular
- add routing for Providers link

## Testing
- `mvn -q -pl backend -am test` *(fails: Non-resolvable parent POM)*
- `npm --prefix frontend test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68881a993874832d907b8dbe80cd395d