### PR TITLE
Fix provider profiles lazy loading

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileStorageAdapter.java
@@ -7,6 +7,7 @@ import com.alligator.market.domain.provider.profile.ProviderProfileStorage;
 import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.Collection;
@@ -23,6 +24,7 @@ public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
     private final ProviderProfileJpaRepository jpaRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Map<ProviderProfile, Long> findAllActive() {
         return jpaRepository.findAllByStatus(ProviderProfileStatus.ACTIVE).stream()
                 .collect(Collectors.toMap(


### PR DESCRIPTION
## Summary
- keep Hibernate session open when reading provider profiles

## Testing
- `mvnw -pl backend test` *(fails: Could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6888206983b4832da34e83af7427cd2c