### PR TITLE
Add provider profile audit toggle

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/dto/ProviderProfileStatusDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/dto/ProviderProfileStatusDto.java
@@ -1,0 +1,23 @@
+package com.alligator.market.backend.provider.profile.dto;
+
+import com.alligator.market.domain.instrument.InstrumentType;
+import com.alligator.market.domain.provider.profile.AccessMethod;
+import com.alligator.market.domain.provider.profile.DeliveryMode;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Set;
+
+/**
+ * DTO с информацией о статусе профиля провайдера.
+ */
+public record ProviderProfileStatusDto(
+        @NotBlank String providerCode,
+        @NotBlank String displayName,
+        @NotNull Set<InstrumentType> instrumentTypes,
+        @NotNull DeliveryMode deliveryMode,
+        @NotNull AccessMethod accessMethod,
+        boolean supportsBulkSubscription,
+        int minPollPeriodMs,
+        @NotNull ProviderProfileStatus status
+) {}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/repository/ProviderProfileStorageAdapter.java
@@ -34,6 +34,16 @@ public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public Map<ProviderProfile, ProviderProfileStatus> findAllWithStatus() {
+        return jpaRepository.findAll().stream()
+                .collect(Collectors.toMap(
+                        ProviderProfileMapper::toDomain,
+                        ProviderProfileEntity::getStatus
+                ));
+    }
+
+    @Override
     public void saveAll(Collection<ProviderProfile> profiles) {
         var entities = profiles.stream()
                 .map(p -> ProviderProfileMapper.toEntity(p, ProviderProfileStatus.ACTIVE))

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileService.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.profile.service;
 
 import com.alligator.market.domain.provider.profile.ProviderProfile;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import java.util.Map;
 
 /**
@@ -10,4 +11,7 @@ public interface ProviderProfileService {
 
     /** Вернуть все активные профили провайдеров вместе с PK. */
     Map<ProviderProfile, Long> findAllActive();
+
+    /** Вернуть все профили провайдеров с их статусами. */
+    Map<ProviderProfile, ProviderProfileStatus> findAllWithStatus();
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/service/ProviderProfileServiceImpl.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.profile.service;
 
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.provider.profile.ProviderProfileStorage;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,5 +22,10 @@ public class ProviderProfileServiceImpl implements ProviderProfileService {
     @Override
     public Map<ProviderProfile, Long> findAllActive() {
         return storage.findAllActive();
+    }
+
+    @Override
+    public Map<ProviderProfile, ProviderProfileStatus> findAllWithStatus() {
+        return storage.findAllWithStatus();
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/web/ProviderProfileController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/web/ProviderProfileController.java
@@ -3,8 +3,10 @@ package com.alligator.market.backend.provider.profile.web;
 import com.alligator.market.backend.common.web.ApiResponse;
 import com.alligator.market.backend.common.web.ResponseEntityFactory;
 import com.alligator.market.backend.provider.profile.dto.ProviderProfileDto;
+import com.alligator.market.backend.provider.profile.dto.ProviderProfileStatusDto;
 import com.alligator.market.backend.provider.profile.service.ProviderProfileService;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
+import com.alligator.market.domain.provider.profile.ProviderProfileStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,6 +34,15 @@ public class ProviderProfileController {
         return ResponseEntityFactory.ok(list);
     }
 
+    /** Вернуть все профили провайдеров со статусами. */
+    @GetMapping("/audit")
+    public ResponseEntity<ApiResponse<List<ProviderProfileStatusDto>>> getAllWithStatus() {
+        List<ProviderProfileStatusDto> list = service.findAllWithStatus().entrySet().stream()
+                .map(e -> toStatusDto(e.getKey(), e.getValue()))
+                .toList();
+        return ResponseEntityFactory.ok(list);
+    }
+
     /* Утилита преобразует доменную модель в DTO. */
     private ProviderProfileDto toDto(ProviderProfile profile) {
 
@@ -43,6 +54,20 @@ public class ProviderProfileController {
                 profile.accessMethod(),
                 profile.supportsBulkSubscription(),
                 profile.minPollPeriodMs()
+        );
+    }
+
+    /* Утилита преобразует доменную модель и статус в DTO. */
+    private ProviderProfileStatusDto toStatusDto(ProviderProfile profile, ProviderProfileStatus status) {
+        return new ProviderProfileStatusDto(
+                profile.providerCode(),
+                profile.displayName(),
+                profile.instrumentTypes(),
+                profile.deliveryMode(),
+                profile.accessMethod(),
+                profile.supportsBulkSubscription(),
+                profile.minPollPeriodMs(),
+                status
         );
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/ProviderProfileStorage.java
@@ -12,6 +12,9 @@ public interface ProviderProfileStorage {
     /** Вернуть все активные профили провайдеров вместе с PK. */
     Map<ProviderProfile, Long> findAllActive();
 
+    /** Вернуть все профили провайдеров с их статусами. */
+    Map<ProviderProfile, ProviderProfileStatus> findAllWithStatus();
+
     /** Сохранить коллекцию профилей со статусом ACTIVE. */
     void saveAll(Collection<ProviderProfile> profiles);
 

--- a/frontend/src/app/features/provider_profile/models/provider-profile-status.model.ts
+++ b/frontend/src/app/features/provider_profile/models/provider-profile-status.model.ts
@@ -1,0 +1,10 @@
+export interface ProviderProfileStatusDto {
+  providerCode: string;
+  displayName: string;
+  instrumentTypes: string[];
+  deliveryMode: string;
+  accessMethod: string;
+  supportsBulkSubscription: boolean;
+  minPollPeriodMs: number;
+  status: string;
+}

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -2,6 +2,7 @@
   <h1 class="mat-headline-4">Provider Profiles</h1>
   <mat-card>
     <mat-card-content>
+      <mat-slide-toggle (change)="onToggle()" color="primary">Show all status</mat-slide-toggle>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
         <ng-container matColumnDef="providerCode">
@@ -37,6 +38,11 @@
         <ng-container matColumnDef="minPollPeriodMs">
           <th mat-header-cell *matHeaderCellDef>Min Poll ms</th>
           <td mat-cell *matCellDef="let p">{{ p.minPollPeriodMs }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let p">{{ p.status }}</td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -2,13 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { ProviderProfileService } from '../../services/provider-profile.service';
-import { ProviderProfileDto } from '../../models/provider-profile.model';
+import { ProviderProfileStatusDto } from '../../models/provider-profile-status.model';
 
 @Component({
   selector: 'app-provider-profile-list',
   standalone: true,
-  imports: [CommonModule, MatTableModule, MatCardModule],
+  imports: [CommonModule, MatTableModule, MatCardModule, MatSlideToggleModule],
   templateUrl: './profile-list.component.html',
   styleUrl: './profile-list.component.scss'
 })
@@ -23,15 +24,41 @@ export class ProfileListComponent implements OnInit {
     'supportsBulkSubscription',
     'minPollPeriodMs'
   ];
-  dataSource = new MatTableDataSource<ProviderProfileDto>([]);
+  dataSource = new MatTableDataSource<ProviderProfileStatusDto>([]);
+  showAll = false;
 
   constructor(private readonly service: ProviderProfileService) {}
 
   /* загрузка списка при открытии страницы */
   ngOnInit(): void {
-    this.service.list().subscribe({
-      next: list => this.dataSource.data = list,
-      error: err => console.error(err)
-    });
+    this.refresh();
+  }
+
+  /* переключение отображения всех статусов */
+  onToggle(): void {
+    this.refresh();
+  }
+
+  /* обновление таблицы в зависимости от режима */
+  private refresh(): void {
+    if (this.showAll) {
+      if (!this.displayed.includes('status')) {
+        this.displayed.push('status');
+      }
+      this.service.listAll().subscribe({
+        next: list => this.dataSource.data = list,
+        error: err => console.error(err)
+      });
+    } else {
+      const idx = this.displayed.indexOf('status');
+      if (idx !== -1) { this.displayed.splice(idx, 1); }
+      this.service.list().subscribe({
+        next: list => this.dataSource.data = list.map(p => ({
+          ...p,
+          status: 'ACTIVE'
+        } as ProviderProfileStatusDto)),
+        error: err => console.error(err)
+      });
+    }
   }
 }

--- a/frontend/src/app/features/provider_profile/services/provider-profile.service.ts
+++ b/frontend/src/app/features/provider_profile/services/provider-profile.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiResponse } from '../../../shared/api-response.model';
 import { ProviderProfileDto } from '../models/provider-profile.model';
+import { ProviderProfileStatusDto } from '../models/provider-profile-status.model';
 
 /* Сервис для чтения профилей провайдеров */
 @Injectable({
@@ -19,6 +20,13 @@ export class ProviderProfileService {
   list(): Observable<ProviderProfileDto[]> {
     return this.http
       .get<ApiResponse<ProviderProfileDto[]>>(this.baseUrl)
+      .pipe(map(res => res.data));
+  }
+
+  /* Получить список всех профилей со статусами */
+  listAll(): Observable<ProviderProfileStatusDto[]> {
+    return this.http
+      .get<ApiResponse<ProviderProfileStatusDto[]>>(`${this.baseUrl}/audit`)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- support fetching provider profiles with status
- expose `/api/v1/providers/audit` endpoint
- show toggle on provider profiles list to view all statuses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent --yes` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888247ae9fc832dad84a1f6af18b44a