### PR TITLE
Add provider status column

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -22,7 +22,8 @@ export class ProfileListComponent implements OnInit {
     'deliveryMode',
     'accessMethod',
     'supportsBulkSubscription',
-    'minPollPeriodMs'
+    'minPollPeriodMs',
+    'status'
   ];
   dataSource = new MatTableDataSource<ProviderProfileStatusDto>([]);
   showAll = false;
@@ -42,16 +43,11 @@ export class ProfileListComponent implements OnInit {
   /* обновление таблицы в зависимости от режима */
   private refresh(): void {
     if (this.showAll) {
-      if (!this.displayed.includes('status')) {
-        this.displayed.push('status');
-      }
       this.service.listAll().subscribe({
         next: list => this.dataSource.data = list,
         error: err => console.error(err)
       });
     } else {
-      const idx = this.displayed.indexOf('status');
-      if (idx !== -1) { this.displayed.splice(idx, 1); }
       this.service.list().subscribe({
         next: list => this.dataSource.data = list.map(p => ({
           ...p,


### PR DESCRIPTION
## Summary
- always show status column for providers

## Testing
- `./mvnw -q test` *(fails: Failed to fetch from repo.maven.apache.org)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688828ad3870832db95b14e6cb1eaba4