### PR TITLE
Refactor currency pair naming

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
@@ -25,8 +25,8 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
 
     @Override
     public String save(CurrencyPair pair) {
-        CurrencyEntity c1 = currencyJpaRepository.findByCode(pair.code1()).orElseThrow();
-        CurrencyEntity c2 = currencyJpaRepository.findByCode(pair.code2()).orElseThrow();
+        CurrencyEntity c1 = currencyJpaRepository.findByCode(pair.base()).orElseThrow();
+        CurrencyEntity c2 = currencyJpaRepository.findByCode(pair.quote()).orElseThrow();
         CurrencyPairEntity entity = new CurrencyPairEntity();
         entity.setCode1(c1);
         entity.setCode2(c2);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
@@ -32,14 +32,14 @@ public class CurrencyPairServiceImpl implements CurrencyPairService {
     @Override
     public String createPair(CurrencyPair currencyPair) {
 
-        if (currencyPair.code1().equals(currencyPair.code2())) {
-            throw new EqualCurrenciesInPairException(currencyPair.code1());
+        if (currencyPair.base().equals(currencyPair.quote())) {
+            throw new EqualCurrenciesInPairException(currencyPair.base());
         }
 
-        currencyStorage.findByCode(currencyPair.code1())
-                .orElseThrow(() -> new CurrencyFromPairNotFoundException(currencyPair.code1()));
-        currencyStorage.findByCode(currencyPair.code2())
-                .orElseThrow(() -> new CurrencyFromPairNotFoundException(currencyPair.code2()));
+        currencyStorage.findByCode(currencyPair.base())
+                .orElseThrow(() -> new CurrencyFromPairNotFoundException(currencyPair.base()));
+        currencyStorage.findByCode(currencyPair.quote())
+                .orElseThrow(() -> new CurrencyFromPairNotFoundException(currencyPair.quote()));
 
         repository.findByPair(currencyPair.pair()).ifPresent(p -> {
             throw new DuplicatePairException(currencyPair.pair());

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
@@ -92,8 +92,8 @@ public class PairController {
         List<PairDto> pairDtoList = service.findAll()
                 .stream()
                 .map(p -> new PairDto(
-                        p.code1(),
-                        p.code2(),
+                        p.base(),
+                        p.quote(),
                         p.pair(),
                         p.decimal()
                 ))

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -74,7 +74,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
         // Для валютных пар данный провайдер ожидает формат биржевого идентификатора "EUR/USD"
         if (instrument.instrumentType() == CURRENCY_PAIR) {
             CurrencyPair pair = (CurrencyPair) instrument;
-            symbolForRequest = pair.code1() + "/" + pair.code2();
+            symbolForRequest = pair.base() + "/" + pair.quote();
         } else {
             symbolForRequest = instrument.symbol();
         }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPair.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPair.java
@@ -8,15 +8,22 @@ import com.alligator.market.domain.instrument.InstrumentType;
  */
 public record CurrencyPair(
 
-        String code1,
-        String code2,
+        /* Код базовой валюты */
+        String base,
+
+        /* Код котируемой валюты */
+        String quote,
+
+        /* Валютная пара как base + quote */
         String pair,
+
+        /* Кол-во знаков после запятой */
         Integer decimal
 
 ) implements Instrument {
 
     @Override public String symbol() {
-        return code1 + code2;
+        return base + quote;
     }
 
     @Override public InstrumentType instrumentType() {


### PR DESCRIPTION
## Summary
- rename `code1`/`code2` to `base`/`quote` in `CurrencyPair`
- adjust adapters, services and controller
- update provider to use renamed getters

## Testing
- `mvn -q -pl domain,backend test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6889fbfff704832d8c1fb9a951b820fc