### PR TITLE
Rename pair code fields

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/dto/PairDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/dto/PairDto.java
@@ -17,7 +17,7 @@ public record PairDto(
 
         @NotBlank
         @Pattern(regexp = "^[A-Z]{6}$")
-        String pair,
+        String pairCode,
 
         @NotNull
         @Min(0) @Max(10)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
@@ -43,10 +43,10 @@ public class CurrencyPairEntity extends BaseEntity {
             foreignKey = @ForeignKey(name = "fk_pair_code2"))
     private CurrencyEntity code2;
 
-    /** Валютная пара как code1 + code2. */
+    /** Код пары как code1 + code2. */
     @Pattern(regexp = "^[A-Z]{6}$")
-    @Column(length = 6, nullable = false)
-    private String pair;
+    @Column(name = "pair", length = 6, nullable = false)
+    private String pairCode;
 
     /** Кол-во знаков после запятой для курса. */
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/exception/DuplicatePairException.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/exception/DuplicatePairException.java
@@ -4,7 +4,7 @@ package com.alligator.market.backend.instrument.type.forex.currency_pair.excepti
  * Очевидно из названия.
  */
 public class DuplicatePairException extends RuntimeException {
-    public DuplicatePairException(String pair) {
-        super("Currency pair '%s' already exists".formatted(pair));
+    public DuplicatePairException(String pairCode) {
+        super("Currency pair '%s' already exists".formatted(pairCode));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/exception/PairNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/exception/PairNotFoundException.java
@@ -6,7 +6,7 @@ import jakarta.persistence.EntityNotFoundException;
  * Очевидно из названия.
  */
 public class PairNotFoundException extends EntityNotFoundException {
-    public PairNotFoundException(String pair) {
-        super("Currency pair '%s' not found".formatted(pair));
+    public PairNotFoundException(String pairCode) {
+        super("Currency pair '%s' not found".formatted(pairCode));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairJpaRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 public interface CurrencyPairJpaRepository extends JpaRepository<CurrencyPairEntity, Long> {
 
-    Optional<CurrencyPairEntity> findByPair(String pair);
+    Optional<CurrencyPairEntity> findByPairCode(String pairCode);
 
     /** Проверяет, существует ли любая валютная пара с переданным кодом в code1 или code2. */
     boolean existsByCode1_CodeOrCode2_Code(String code1, String code2);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
@@ -30,19 +30,19 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
         CurrencyPairEntity entity = new CurrencyPairEntity();
         entity.setCode1(c1);
         entity.setCode2(c2);
-        entity.setPair(pair.pair());
+        entity.setPairCode(pair.pairCode());
         entity.setDecimal(pair.decimal());
-        return jpaRepository.save(entity).getPair();
+        return jpaRepository.save(entity).getPairCode();
     }
 
     @Override
-    public void deleteByPair(String pair) {
-        jpaRepository.findByPair(pair).ifPresent(jpaRepository::delete);
+    public void deleteByPairCode(String pairCode) {
+        jpaRepository.findByPairCode(pairCode).ifPresent(jpaRepository::delete);
     }
 
     @Override
-    public Optional<CurrencyPair> findByPair(String pair) {
-        return jpaRepository.findByPair(pair).map(this::toDomain);
+    public Optional<CurrencyPair> findByPairCode(String pairCode) {
+        return jpaRepository.findByPairCode(pairCode).map(this::toDomain);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
 
     @Override
     public List<CurrencyPair> findAll() {
-        return jpaRepository.findAll(Sort.by("pair")).stream()
+        return jpaRepository.findAll(Sort.by("pairCode")).stream()
                 .map(this::toDomain)
                 .toList();
     }
@@ -61,7 +61,7 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
         return new CurrencyPair(
                 entity.getCode1().getCode(),
                 entity.getCode2().getCode(),
-                entity.getPair(),
+                entity.getPairCode(),
                 entity.getDecimal()
         );
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairService.java
@@ -16,7 +16,7 @@ public interface CurrencyPairService {
     void updatePair(CurrencyPair pair);
 
     /** Удалить пару по коду. */
-    void deletePair(String pair);
+    void deletePair(String pairCode);
 
     /** Вернуть все пары. */
     List<CurrencyPair> findAll();

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
@@ -41,13 +41,13 @@ public class CurrencyPairServiceImpl implements CurrencyPairService {
         currencyStorage.findByCode(currencyPair.quote())
                 .orElseThrow(() -> new CurrencyFromPairNotFoundException(currencyPair.quote()));
 
-        repository.findByPair(currencyPair.pair()).ifPresent(p -> {
-            throw new DuplicatePairException(currencyPair.pair());
+        repository.findByPairCode(currencyPair.pairCode()).ifPresent(p -> {
+            throw new DuplicatePairException(currencyPair.pairCode());
         });
 
-        String pair = repository.save(currencyPair);
-        log.info("Currency pair {} saved", pair);
-        return pair;
+        String pairCode = repository.save(currencyPair);
+        log.info("Currency pair {} saved", pairCode);
+        return pairCode;
     }
 
     //==============
@@ -57,24 +57,24 @@ public class CurrencyPairServiceImpl implements CurrencyPairService {
     public void updatePair(CurrencyPair currencyPair) {
 
         // Проверка наличия валютной пары к обновлению
-        repository.findByPair(currencyPair.pair())
-                .orElseThrow(() -> new PairNotFoundException(currencyPair.pair()));
+        repository.findByPairCode(currencyPair.pairCode())
+                .orElseThrow(() -> new PairNotFoundException(currencyPair.pairCode()));
 
         repository.save(currencyPair);
-        log.info("Currency pair {} updated", currencyPair.pair());
+        log.info("Currency pair {} updated", currencyPair.pairCode());
     }
 
     //=============
     // Удалить пару
     //=============
     @Override
-    public void deletePair(String currencyPair) {
+    public void deletePair(String pairCode) {
 
-        repository.findByPair(currencyPair)
-                .orElseThrow(() -> new PairNotFoundException(currencyPair));
+        repository.findByPairCode(pairCode)
+                .orElseThrow(() -> new PairNotFoundException(pairCode));
 
-        repository.deleteByPair(currencyPair);
-        log.info("Currency pair {} deleted", currencyPair);
+        repository.deleteByPairCode(pairCode);
+        log.info("Currency pair {} deleted", pairCode);
     }
 
     //==================

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
@@ -43,28 +43,28 @@ public class PairController {
         );
 
         // Применяем к валютной паре метод сервиса, который вернет код пары из созданной новой записи
-        String pair = service.createPair(currencyPair);
+        String pairCode = service.createPair(currencyPair);
 
         // Формируем ссылку на созданный ресурс
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
-                .path("/{pair}")
-                .buildAndExpand(pair)
+                .path("/{pairCode}")
+                .buildAndExpand(pairCode)
                 .toUri();
 
-        return ResponseEntityFactory.created(location, pair);
+        return ResponseEntityFactory.created(location, pairCode);
     }
 
     //==============
     // Обновить пару
     //==============
-    @PutMapping("/{pair}")
+    @PutMapping("/{pairCode}")
     public ResponseEntity<ApiResponse<Void>> update(
-            @PathVariable String pair,
+            @PathVariable String pairCode,
             @RequestBody @Valid PairUpdateDto dto) {
         
         // Формируем урезанную модель валютной пары для обновления единственного параметра
-        CurrencyPair currencyPair = new CurrencyPair(null,null, pair, dto.decimal());
+        CurrencyPair currencyPair = new CurrencyPair(null,null, pairCode, dto.decimal());
 
         service.updatePair(currencyPair);
 
@@ -74,10 +74,10 @@ public class PairController {
     //=============
     // Удалить пару
     //=============
-    @DeleteMapping("/{pair}")
-    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String pair) {
+    @DeleteMapping("/{pairCode}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String pairCode) {
 
-        service.deletePair(pair);
+        service.deletePair(pairCode);
 
         return ResponseEntityFactory.ok(null);
     }
@@ -94,7 +94,7 @@ public class PairController {
                 .map(p -> new PairDto(
                         p.base(),
                         p.quote(),
-                        p.pair(),
+                        p.pairCode(),
                         p.decimal()
                 ))
                 .toList();

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPair.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPair.java
@@ -14,8 +14,8 @@ public record CurrencyPair(
         /* Код котируемой валюты */
         String quote,
 
-        /* Валютная пара как base + quote */
-        String pair,
+        /* Код пары: base + quote */
+        String pairCode,
 
         /* Кол-во знаков после запятой */
         Integer decimal
@@ -23,7 +23,7 @@ public record CurrencyPair(
 ) implements Instrument {
 
     @Override public String symbol() {
-        return base + quote;
+        return pairCode;
     }
 
     @Override public InstrumentType instrumentType() {

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPairStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPairStorage.java
@@ -12,10 +12,10 @@ public interface CurrencyPairStorage {
     String save(CurrencyPair pair);
 
     /** Удалить валютную пару по её коду. */
-    void deleteByPair(String pair);
+    void deleteByPairCode(String pairCode);
 
     /** Найти валютную пару по коду. */
-    Optional<CurrencyPair> findByPair(String pair);
+    Optional<CurrencyPair> findByPairCode(String pairCode);
 
     /** Проверить использование валюты в любой паре. */
     boolean existsByCurrency(String code);

--- a/frontend/src/app/features/currency_pair/models/pair.model.ts
+++ b/frontend/src/app/features/currency_pair/models/pair.model.ts
@@ -2,6 +2,6 @@
 export interface PairDto {
   code1: string;
   code2: string;
-  pair: string;
+  pairCode: string;
   decimal: number;
 }

--- a/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.html
@@ -76,9 +76,9 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="pair">
+        <ng-container matColumnDef="pairCode">
           <th mat-header-cell *matHeaderCellDef> Currency Pair</th>
-          <td mat-cell *matCellDef="let p"> {{ p.pair }}</td>
+          <td mat-cell *matCellDef="let p"> {{ p.pairCode }}</td>
         </ng-container>
 
         <ng-container matColumnDef="code1">
@@ -102,7 +102,7 @@
             <button mat-icon-button color="primary" (click)="onEdit(p)">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button color="warn" (click)="onDelete(p.pair)">
+            <button mat-icon-button color="warn" (click)="onDelete(p.pairCode)">
               <mat-icon>delete</mat-icon>
             </button>
           </td>

--- a/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.ts
+++ b/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.ts
@@ -41,7 +41,7 @@ export class PairAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['pair', 'code1', 'code2', 'decimal', 'actions'];
+  displayed: string[] = ['pairCode', 'code1', 'code2', 'decimal', 'actions'];
   dataSource  = new MatTableDataSource<PairDto>([]);
 
   //==============================
@@ -51,7 +51,7 @@ export class PairAdminComponent implements OnInit {
 
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
-  editPair: string | null = null; // код пары для редактирования
+  editPairCode: string | null = null; // код пары для редактирования
   currencies: CurrencyDto[] = [];
 
   constructor(
@@ -104,10 +104,10 @@ export class PairAdminComponent implements OnInit {
     const dto: PairCreateDto = this.form.value;
 
     this.service.add(dto).subscribe({
-      next: pair => {
+      next: pairCode => {
         // Если все ОК
         this.snack.open(
-          `Pair '${pair}' added`, 'OK', { duration: 2500 }
+          `Pair '${pairCode}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();
         this.form.reset({ decimal: 4 });
@@ -125,7 +125,7 @@ export class PairAdminComponent implements OnInit {
   /* клик по иконке Edit */
   onEdit(p: PairDto): void {
     this.editing = true;
-    this.editPair = p.pair;
+    this.editPairCode = p.pairCode;
     this.form.setValue({
       code1: p.code1,
       code2: p.code2,
@@ -137,7 +137,7 @@ export class PairAdminComponent implements OnInit {
 
   /* нажата кнопка Save */
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editPair) { return; }
+    if (this.form.invalid || this.locked || !this.editPairCode) { return; }
 
     this.locked = true;
 
@@ -145,9 +145,9 @@ export class PairAdminComponent implements OnInit {
       decimal: this.form.controls['decimal'].value
     } as PairUpdateDto;
 
-    this.service.update(this.editPair, dto).subscribe({
+    this.service.update(this.editPairCode, dto).subscribe({
       next: () => {
-        this.snack.open(`Pair '${this.editPair}' updated`, 'OK', { duration: 2500 });
+        this.snack.open(`Pair '${this.editPairCode}' updated`, 'OK', { duration: 2500 });
         this.refresh();
         this.cancelEdit();
         this.locked = false;
@@ -163,7 +163,7 @@ export class PairAdminComponent implements OnInit {
   /* нажата кнопка Cancel */
   cancelEdit(): void {
     this.editing = false;
-    this.editPair = null;
+    this.editPairCode = null;
     this.form.reset({ code1: '', code2: '', decimal: 4 });
     this.form.controls['code1'].enable();
     this.form.controls['code2'].enable();
@@ -171,10 +171,10 @@ export class PairAdminComponent implements OnInit {
   }
 
   /* клик по иконке Delete */
-  onDelete(pair: string): void {
-    this.service.delete(pair).subscribe({
+  onDelete(pairCode: string): void {
+    this.service.delete(pairCode).subscribe({
       next: () => {
-        this.snack.open(`Pair '${pair}' deleted`, 'OK', { duration: 2500 });
+        this.snack.open(`Pair '${pairCode}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
       error: err =>

--- a/frontend/src/app/features/currency_pair/services/pair.service.ts
+++ b/frontend/src/app/features/currency_pair/services/pair.service.ts
@@ -24,24 +24,24 @@ export class PairService {
       .pipe(map(res => res.data));
   }
 
-  /* Добавить валютную пару, backend вернёт её pair */
+  /* Добавить валютную пару, backend вернёт её pairCode */
   add(dto: PairCreateDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
       .pipe(map(res => res.data));
   }
 
-  /* Удалить валютную пару по коду pair */
-  delete(pair: string): Observable<void> {
+  /* Удалить валютную пару по коду pairCode */
+  delete(pairCode: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${pair}`)
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${pairCode}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить валютную пару по коду pair */
-  update(pair: string, dto: PairUpdateDto): Observable<void> {
+  /* Обновить валютную пару по коду pairCode */
+  update(pairCode: string, dto: PairUpdateDto): Observable<void> {
     return this.http
-      .put<ApiResponse<void>>(`${this.baseUrl}/${pair}`, dto)
+      .put<ApiResponse<void>>(`${this.baseUrl}/${pairCode}`, dto)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- rename `pair` code fields to `pairCode`
- update backend services and controllers
- adjust frontend models and components

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a14124cc8832d917a855d8760c3b9