### PR TITLE
Rename currency pair fields

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Table(
         name = "currency_pair",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_currency_pair", columnNames = "pair")
+                @UniqueConstraint(name = "uq_currency_pair", columnNames = "symbol")
         }
 )
 @Getter
@@ -33,20 +33,20 @@ public class CurrencyPairEntity extends BaseEntity {
 
     /** ISO-4217 код валюты-1 (FK на {@link Currency#code()}). */
     @ManyToOne(optional = false)
-    @JoinColumn(name = "code1", referencedColumnName = "code",
-            foreignKey = @ForeignKey(name = "fk_pair_code1"))
-    private CurrencyEntity code1;
+    @JoinColumn(name = "base", referencedColumnName = "code",
+            foreignKey = @ForeignKey(name = "fk_pair_base"))
+    private CurrencyEntity base;
 
     /** ISO-4217 код валюты-2 (FK на {@link Currency#code()}). */
     @ManyToOne(optional = false)
-    @JoinColumn(name = "code2", referencedColumnName = "code",
-            foreignKey = @ForeignKey(name = "fk_pair_code2"))
-    private CurrencyEntity code2;
+    @JoinColumn(name = "quote", referencedColumnName = "code",
+            foreignKey = @ForeignKey(name = "fk_pair_quote"))
+    private CurrencyEntity quote;
 
-    /** Код пары как code1 + code2. */
+    /** Код пары как base + quote. */
     @Pattern(regexp = "^[A-Z]{6}$")
-    @Column(name = "pair", length = 6, nullable = false)
-    private String pairCode;
+    @Column(name = "symbol", length = 6, nullable = false)
+    private String symbol;
 
     /** Кол-во знаков после запятой для курса. */
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairJpaRepository.java
@@ -11,9 +11,9 @@ import java.util.Optional;
  */
 public interface CurrencyPairJpaRepository extends JpaRepository<CurrencyPairEntity, Long> {
 
-    Optional<CurrencyPairEntity> findByPairCode(String pairCode);
+    Optional<CurrencyPairEntity> findBySymbol(String symbol);
 
-    /** Проверяет, существует ли любая валютная пара с переданным кодом в code1 или code2. */
-    boolean existsByCode1_CodeOrCode2_Code(String code1, String code2);
+    /** Проверяет, существует ли любая валютная пара с переданным кодом в base или quote. */
+    boolean existsByBase_CodeOrQuote_Code(String base, String quote);
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
@@ -28,40 +28,40 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
         CurrencyEntity c1 = currencyJpaRepository.findByCode(pair.base()).orElseThrow();
         CurrencyEntity c2 = currencyJpaRepository.findByCode(pair.quote()).orElseThrow();
         CurrencyPairEntity entity = new CurrencyPairEntity();
-        entity.setCode1(c1);
-        entity.setCode2(c2);
-        entity.setPairCode(pair.pairCode());
+        entity.setBase(c1);
+        entity.setQuote(c2);
+        entity.setSymbol(pair.pairCode());
         entity.setDecimal(pair.decimal());
-        return jpaRepository.save(entity).getPairCode();
+        return jpaRepository.save(entity).getSymbol();
     }
 
     @Override
     public void deleteByPairCode(String pairCode) {
-        jpaRepository.findByPairCode(pairCode).ifPresent(jpaRepository::delete);
+        jpaRepository.findBySymbol(pairCode).ifPresent(jpaRepository::delete);
     }
 
     @Override
     public Optional<CurrencyPair> findByPairCode(String pairCode) {
-        return jpaRepository.findByPairCode(pairCode).map(this::toDomain);
+        return jpaRepository.findBySymbol(pairCode).map(this::toDomain);
     }
 
     @Override
     public boolean existsByCurrency(String code) {
-        return jpaRepository.existsByCode1_CodeOrCode2_Code(code, code);
+        return jpaRepository.existsByBase_CodeOrQuote_Code(code, code);
     }
 
     @Override
     public List<CurrencyPair> findAll() {
-        return jpaRepository.findAll(Sort.by("pairCode")).stream()
+        return jpaRepository.findAll(Sort.by("symbol")).stream()
                 .map(this::toDomain)
                 .toList();
     }
 
     private CurrencyPair toDomain(CurrencyPairEntity entity) {
         return new CurrencyPair(
-                entity.getCode1().getCode(),
-                entity.getCode2().getCode(),
-                entity.getPairCode(),
+                entity.getBase().getCode(),
+                entity.getQuote().getCode(),
+                entity.getSymbol(),
                 entity.getDecimal()
         );
     }

--- a/backend/src/main/resources/db/migration/V6__rename_currency_pair_columns.sql
+++ b/backend/src/main/resources/db/migration/V6__rename_currency_pair_columns.sql
@@ -1,0 +1,12 @@
+-- Переименование столбцов таблицы currency_pair
+ALTER TABLE currency_pair RENAME COLUMN code1 TO base;
+ALTER TABLE currency_pair RENAME COLUMN code2 TO quote;
+ALTER TABLE currency_pair RENAME COLUMN pair TO symbol;
+
+-- Переименование ограничений
+ALTER TABLE currency_pair DROP CONSTRAINT IF EXISTS fk_pair_code1;
+ALTER TABLE currency_pair ADD CONSTRAINT fk_pair_base FOREIGN KEY (base) REFERENCES currency(code);
+ALTER TABLE currency_pair DROP CONSTRAINT IF EXISTS fk_pair_code2;
+ALTER TABLE currency_pair ADD CONSTRAINT fk_pair_quote FOREIGN KEY (quote) REFERENCES currency(code);
+ALTER TABLE currency_pair DROP CONSTRAINT IF EXISTS uq_currency_pair;
+ALTER TABLE currency_pair ADD CONSTRAINT uq_currency_pair UNIQUE (symbol);


### PR DESCRIPTION
## Summary
- rename code1/code2/pairCode to base/quote/symbol in CurrencyPairEntity
- update repository methods and adapter
- add Flyway migration for renaming columns

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a28f5a748832d83fb79aa622d52bf