### PR TITLE
Align frontend with backend currency pair fields

### DIFF
--- a/frontend/src/app/features/currency_pair/models/pair-create.model.ts
+++ b/frontend/src/app/features/currency_pair/models/pair-create.model.ts
@@ -1,6 +1,9 @@
 /** DTO для создания валютной пары аналогичный backend. */
 export interface PairCreateDto {
-  code1: string;
-  code2: string;
+  /* Код базовой валюты */
+  base: string;
+  /* Код котируемой валюты */
+  quote: string;
+  /* Кол-во знаков после запятой */
   decimal: number;
 }

--- a/frontend/src/app/features/currency_pair/models/pair.model.ts
+++ b/frontend/src/app/features/currency_pair/models/pair.model.ts
@@ -1,7 +1,11 @@
 /** DTO для валютной пары аналогичный backend. */
 export interface PairDto {
-  code1: string;
-  code2: string;
-  pairCode: string;
+  /* Код базовой валюты */
+  base: string;
+  /* Код котируемой валюты */
+  quote: string;
+  /* Символ валютной пары (base + quote) */
+  symbol: string;
+  /* Кол-во знаков после запятой */
   decimal: number;
 }

--- a/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.html
@@ -13,24 +13,24 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Base Currency</mat-label>
-          <mat-select formControlName="code1">
+          <mat-select formControlName="base">
             <mat-option *ngFor="let c of currencies" [value]="c.code">
               {{ c.code }}
             </mat-option>
           </mat-select>
-          <mat-error *ngIf="form.controls['code1'].hasError('required')">
+          <mat-error *ngIf="form.controls['base'].hasError('required')">
             Is required
           </mat-error>
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Quote Currency</mat-label>
-          <mat-select formControlName="code2">
+          <mat-select formControlName="quote">
             <mat-option *ngFor="let c of currencies" [value]="c.code">
               {{ c.code }}
             </mat-option>
           </mat-select>
-          <mat-error *ngIf="form.controls['code2'].hasError('required')">
+          <mat-error *ngIf="form.controls['quote'].hasError('required')">
             Is required
           </mat-error>
         </mat-form-field>
@@ -76,19 +76,19 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="pairCode">
+        <ng-container matColumnDef="symbol">
           <th mat-header-cell *matHeaderCellDef> Symbol</th>
-          <td mat-cell *matCellDef="let p"> {{ p.pairCode }}</td>
+          <td mat-cell *matCellDef="let p"> {{ p.symbol }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="code1">
+        <ng-container matColumnDef="base">
           <th mat-header-cell *matHeaderCellDef> Base Currency</th>
-          <td mat-cell *matCellDef="let p"> {{ p.code1 }}</td>
+          <td mat-cell *matCellDef="let p"> {{ p.base }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="code2">
+        <ng-container matColumnDef="quote">
           <th mat-header-cell *matHeaderCellDef> Quote Currency</th>
-          <td mat-cell *matCellDef="let p"> {{ p.code2 }}</td>
+          <td mat-cell *matCellDef="let p"> {{ p.quote }}</td>
         </ng-container>
 
         <ng-container matColumnDef="decimal">
@@ -102,7 +102,7 @@
             <button mat-icon-button color="primary" (click)="onEdit(p)">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button color="warn" (click)="onDelete(p.pairCode)">
+            <button mat-icon-button color="warn" (click)="onDelete(p.symbol)">
               <mat-icon>delete</mat-icon>
             </button>
           </td>

--- a/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.ts
+++ b/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.ts
@@ -41,7 +41,7 @@ export class PairAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['pairCode', 'code1', 'code2', 'decimal', 'actions'];
+  displayed: string[] = ['symbol', 'base', 'quote', 'decimal', 'actions'];
   dataSource  = new MatTableDataSource<PairDto>([]);
 
   //==============================
@@ -51,7 +51,7 @@ export class PairAdminComponent implements OnInit {
 
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
-  editPairCode: string | null = null; // код пары для редактирования
+  editSymbol: string | null = null; // символ пары для редактирования
   currencies: CurrencyDto[] = [];
 
   constructor(
@@ -61,12 +61,12 @@ export class PairAdminComponent implements OnInit {
     private readonly currencyService: CurrencyService
   ) {
     this.form = this.fb.group({
-      code1: [
+      base: [
         '',
         [Validators.required]
       ],
 
-      code2: [
+      quote: [
         '',
         [Validators.required]
       ],
@@ -104,10 +104,10 @@ export class PairAdminComponent implements OnInit {
     const dto: PairCreateDto = this.form.value;
 
     this.service.add(dto).subscribe({
-      next: pairCode => {
+      next: symbol => {
         // Если все ОК
         this.snack.open(
-          `Pair '${pairCode}' added`, 'OK', { duration: 2500 }
+          `Pair '${symbol}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();
         this.form.reset({ decimal: 4 });
@@ -125,19 +125,19 @@ export class PairAdminComponent implements OnInit {
   /* клик по иконке Edit */
   onEdit(p: PairDto): void {
     this.editing = true;
-    this.editPairCode = p.pairCode;
+    this.editSymbol = p.symbol;
     this.form.setValue({
-      code1: p.code1,
-      code2: p.code2,
+      base: p.base,
+      quote: p.quote,
       decimal: p.decimal
     });
-    this.form.controls['code1'].disable();
-    this.form.controls['code2'].disable();
+    this.form.controls['base'].disable();
+    this.form.controls['quote'].disable();
   }
 
   /* нажата кнопка Save */
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editPairCode) { return; }
+    if (this.form.invalid || this.locked || !this.editSymbol) { return; }
 
     this.locked = true;
 
@@ -145,9 +145,9 @@ export class PairAdminComponent implements OnInit {
       decimal: this.form.controls['decimal'].value
     } as PairUpdateDto;
 
-    this.service.update(this.editPairCode, dto).subscribe({
+    this.service.update(this.editSymbol, dto).subscribe({
       next: () => {
-        this.snack.open(`Pair '${this.editPairCode}' updated`, 'OK', { duration: 2500 });
+        this.snack.open(`Pair '${this.editSymbol}' updated`, 'OK', { duration: 2500 });
         this.refresh();
         this.cancelEdit();
         this.locked = false;
@@ -163,18 +163,18 @@ export class PairAdminComponent implements OnInit {
   /* нажата кнопка Cancel */
   cancelEdit(): void {
     this.editing = false;
-    this.editPairCode = null;
-    this.form.reset({ code1: '', code2: '', decimal: 4 });
-    this.form.controls['code1'].enable();
-    this.form.controls['code2'].enable();
+    this.editSymbol = null;
+    this.form.reset({ base: '', quote: '', decimal: 4 });
+    this.form.controls['base'].enable();
+    this.form.controls['quote'].enable();
     this.locked = false;
   }
 
   /* клик по иконке Delete */
-  onDelete(pairCode: string): void {
-    this.service.delete(pairCode).subscribe({
+  onDelete(symbol: string): void {
+    this.service.delete(symbol).subscribe({
       next: () => {
-        this.snack.open(`Pair '${pairCode}' deleted`, 'OK', { duration: 2500 });
+        this.snack.open(`Pair '${symbol}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
       error: err =>

--- a/frontend/src/app/features/currency_pair/services/pair.service.ts
+++ b/frontend/src/app/features/currency_pair/services/pair.service.ts
@@ -24,26 +24,26 @@ export class PairService {
       .pipe(map(res => res.data));
   }
 
-  /* Добавить валютную пару, backend вернёт её pairCode */
+  /* Добавить валютную пару, backend вернёт её symbol */
   add(dto: PairCreateDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
       .pipe(map(res => res.data));
   }
 
-  /* Удалить валютную пару по коду pairCode */
-  delete(pairCode: string): Observable<void> {
-    const base = pairCode.substring(0, 3);
-    const quote = pairCode.substring(3, 6);
+  /* Удалить валютную пару по символу */
+  delete(symbol: string): Observable<void> {
+    const base = symbol.substring(0, 3);
+    const quote = symbol.substring(3, 6);
     return this.http
       .delete<ApiResponse<void>>(`${this.baseUrl}/${base}/${quote}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить валютную пару по коду pairCode */
-  update(pairCode: string, dto: PairUpdateDto): Observable<void> {
-    const base = pairCode.substring(0, 3);
-    const quote = pairCode.substring(3, 6);
+  /* Обновить валютную пару по символу */
+  update(symbol: string, dto: PairUpdateDto): Observable<void> {
+    const base = symbol.substring(0, 3);
+    const quote = symbol.substring(3, 6);
     return this.http
       .put<ApiResponse<void>>(`${this.baseUrl}/${base}/${quote}`, dto)
       .pipe(map(res => res.data));


### PR DESCRIPTION
## Summary
- rename currency pair DTO fields
- update admin page to use `base`, `quote`, `symbol`
- adjust service methods for renamed parameters

## Testing
- `npm test` *(fails: `ng: not found`)*
- `./mvnw -q test` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a2ff81a10832daa412f8408131fb4