### PR TITLE
Fix variable names after currency pair refactor

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
@@ -41,17 +41,17 @@ public class PairController {
                 dto.decimal()
         );
 
-        // Применяем к валютной паре метод сервиса, который вернет код пары из созданной новой записи
-        String pairCode = service.create(currencyPair);
+        // Сохраняем пару и получаем её символ
+        String symbol = service.create(currencyPair);
 
         // Формируем ссылку на созданный ресурс
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{symbol}")
-                .buildAndExpand(pairCode)
+                .buildAndExpand(symbol)
                 .toUri();
 
-        return ResponseEntityFactory.created(location, pairCode);
+        return ResponseEntityFactory.created(location, symbol);
     }
 
     //==============


### PR DESCRIPTION
## Summary
- rename `pairCode` variable in PairController to `symbol`

## Testing
- `./mvnw -q -pl backend test` *(fails: repository fetch blocked)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3f66ddec832d97248943c59b36fd