### PR TITLE
Add settlement info to CurrencyPair

### DIFF
--- a/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2Test.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2Test.java
@@ -29,7 +29,7 @@ class TwelveFreeAdapterV2Test {
 
         TwelveFreeAdapterV2 adapter = new TwelveFreeAdapterV2(props, client);
 
-        CurrencyPair pair = new CurrencyPair("EUR", "USD", "EURUSD", 2);
+        CurrencyPair pair = new CurrencyPair("EUR", "USD", 2);
 
         QuoteTick tick = adapter.streamQuotes(pair)
                 .blockFirst(Duration.ofSeconds(5));

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPair.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/CurrencyPair.java
@@ -3,6 +3,9 @@ package com.alligator.market.domain.instrument.type.forex.currency_pair;
 import com.alligator.market.domain.instrument.Instrument;
 import com.alligator.market.domain.instrument.InstrumentType;
 
+import java.time.LocalDate;
+import com.alligator.market.domain.instrument.type.forex.currency_pair.SettlementType;
+
 /**
  * Доменная модель валютной пары.
  */
@@ -10,9 +13,16 @@ public record CurrencyPair(
 
         String base,
         String quote,
-        Integer decimal
+        Integer decimal,
+        LocalDate baseSettlement,
+        LocalDate quoteSettlement,
+        SettlementType settlementType
 
 ) implements Instrument {
+
+    public CurrencyPair(String base, String quote, Integer decimal) {
+        this(base, quote, decimal, null, null, SettlementType.SPOT);
+    }
 
     @Override public String symbol() {
         return base + quote;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/SettlementType.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency_pair/SettlementType.java
@@ -1,0 +1,22 @@
+package com.alligator.market.domain.instrument.type.forex.currency_pair;
+
+/**
+ * Типы расчетов для валютных операций.
+ */
+public enum SettlementType {
+
+    // Сегодня
+    TOD,
+
+    // Завтра
+    TOM,
+
+    // Спот
+    SPOT,
+
+    // Раздельный расчет
+    SPLIT,
+
+    // Форвард
+    FWD
+}


### PR DESCRIPTION
## Summary
- extend `CurrencyPair` with settlement details
- add `SettlementType` enum
- fix TwelveFreeAdapterV2 test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a8d081f84832dbf36db1a7fa940a4