### PR TITLE
Rename symbol to pairCode in CurrencyPairEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/entity/CurrencyPairEntity.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Table(
         name = "currency_pair",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_symbol", columnNames = "symbol")
+                @UniqueConstraint(name = "uq_pair_code", columnNames = "pair_code")
         }
 )
 @Getter
@@ -45,8 +45,8 @@ public class CurrencyPairEntity extends BaseEntity {
 
     /** Условный код валютной пары, составленный из базовой и котируемой валют. */
     @Pattern(regexp = "^[A-Z]{6}$")
-    @Column(name = "symbol", length = 6, nullable = false)
-    private String symbol;
+    @Column(name = "pair_code", length = 6, nullable = false)
+    private String pairCode;
 
     /** Кол-во знаков после запятой для курса. */
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/repository/CurrencyPairStorageAdapter.java
@@ -29,9 +29,9 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
         CurrencyPairEntity entity = new CurrencyPairEntity();
         entity.setBase(c1);
         entity.setQuote(c2);
-        entity.setSymbol(pair.pairCode());
+        entity.setPairCode(pair.pairCode());
         entity.setDecimal(pair.decimal());
-        return jpaRepository.save(entity).getSymbol();
+        return jpaRepository.save(entity).getPairCode();
     }
 
     @Override
@@ -51,7 +51,7 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
 
     @Override
     public List<CurrencyPair> findAll() {
-        return jpaRepository.findAll(Sort.by("symbol")).stream()
+        return jpaRepository.findAll(Sort.by("pairCode")).stream()
                 .map(this::toDomain)
                 .toList();
     }

--- a/backend/src/main/resources/db/migration/V7__rename_symbol_to_pair_code.sql
+++ b/backend/src/main/resources/db/migration/V7__rename_symbol_to_pair_code.sql
@@ -1,0 +1,6 @@
+-- Переименовывает столбец symbol в pair_code
+ALTER TABLE currency_pair RENAME COLUMN symbol TO pair_code;
+
+-- Переименовывает уникальное ограничение
+ALTER TABLE currency_pair DROP CONSTRAINT IF EXISTS uq_symbol;
+ALTER TABLE currency_pair ADD CONSTRAINT uq_pair_code UNIQUE (pair_code);


### PR DESCRIPTION
## Summary
- rename `symbol` field to `pairCode` in `CurrencyPairEntity`
- adjust repository adapter for new field name
- add Flyway migration to rename DB column

## Testing
- `mvn -q -pl backend test` *(fails: permission denied / offline)*

------
https://chatgpt.com/codex/tasks/task_e_688b739f9d78832d9b36dbf5059775b4