### PR TITLE
Fix symbol leftover usages

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/dto/PairDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/dto/PairDto.java
@@ -17,7 +17,7 @@ public record PairDto(
 
         @NotBlank
         @Pattern(regexp = "^[A-Z]{6}$")
-        String symbol,
+        String pairCode,
 
         @NotNull
         @Min(0) @Max(10)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/service/CurrencyPairServiceImpl.java
@@ -47,9 +47,9 @@ public class CurrencyPairServiceImpl implements CurrencyPairService {
             throw new DuplicatePairException(currencyPair.pairCode());
         });
 
-        String symbol = repository.save(currencyPair);
-        log.info("Currency pair {} saved", symbol);
-        return symbol;
+        String pairCode = repository.save(currencyPair);
+        log.info("Currency pair {} saved", pairCode);
+        return pairCode;
     }
 
     //==============

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency_pair/web/PairController.java
@@ -41,17 +41,17 @@ public class PairController {
                 dto.decimal()
         );
 
-        // Сохраняем пару и получаем её символ
-        String symbol = service.create(currencyPair);
+        // Сохраняем пару и получаем её код
+        String pairCode = service.create(currencyPair);
 
         // Формируем ссылку на созданный ресурс
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
-                .path("/{symbol}")
-                .buildAndExpand(symbol)
+                .path("/{pairCode}")
+                .buildAndExpand(pairCode)
                 .toUri();
 
-        return ResponseEntityFactory.created(location, symbol);
+        return ResponseEntityFactory.created(location, pairCode);
     }
 
     //==============

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -69,20 +69,20 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
         // Биржевой идентификатор инструмента согласно модели данного приложения
         final String internalCode = instrument.internalCode();
         // Биржевой идентификатор инструмента, требуемый провайдером
-        final String symbolForRequest;
+        final String pairCodeForRequest;
 
         // Для валютных пар данный провайдер ожидает формат биржевого идентификатора "EUR/USD"
         if (instrument.instrumentType() == CURRENCY_PAIR) {
             CurrencyPair pair = (CurrencyPair) instrument;
-            symbolForRequest = pair.base() + "/" + pair.quote();
+            pairCodeForRequest = pair.base() + "/" + pair.quote();
         } else {
-            symbolForRequest = instrument.internalCode();
+            pairCodeForRequest = instrument.internalCode();
         }
 
         return webClient.get()
                 .uri(builder -> builder
                         .path("/price")
-                        .queryParam("symbol", symbolForRequest)
+                        .queryParam("symbol", pairCodeForRequest)
                         .queryParam("apikey", props.apiKey())
                         .build())
                 .retrieve()
@@ -96,7 +96,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
     //-----------------------
 
     /* Метод преобразования ответа провайдера к модели тика котировки */
-    private QuoteTick jsonToQuoteTick(JsonNode json, String symbolByModel) {
+    private QuoteTick jsonToQuoteTick(JsonNode json, String pairCodeByModel) {
 
         // Извлекаем значение поля "price" из JSON-ответа провайдера в виде объекта JsonNode
         JsonNode priceNode = json.get("price");
@@ -108,7 +108,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
         BigDecimal price = new BigDecimal(priceNode.asText());
 
         return new QuoteTick(
-                symbolByModel,
+                pairCodeByModel,
                 price,
                 price,
                 Instant.now(),

--- a/domain/src/main/avro/QuoteTickAvro.avsc
+++ b/domain/src/main/avro/QuoteTickAvro.avsc
@@ -3,7 +3,7 @@
   "type": "record",
   "name": "QuoteTickAvro",
   "fields": [
-    { "name": "symbol", "type": "string" },
+    { "name": "pairCode", "type": "string" },
     { "name": "bid", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
     { "name": "ask", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
     { "name": "ts", "type": { "type": "long", "logicalType": "timestamp-millis" } },

--- a/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
@@ -9,7 +9,7 @@ import java.time.Instant;
  */
 public record QuoteTick(
 
-        String symbol,
+        String pairCode,
         BigDecimal bid,
         BigDecimal ask,
         Instant ts,

--- a/frontend/src/app/features/currency_pair/models/pair.model.ts
+++ b/frontend/src/app/features/currency_pair/models/pair.model.ts
@@ -4,8 +4,8 @@ export interface PairDto {
   base: string;
   /* Код котируемой валюты */
   quote: string;
-  /* Символ валютной пары (base + quote) */
-  symbol: string;
+  /* Код валютной пары (base + quote) */
+  pairCode: string;
   /* Кол-во знаков после запятой */
   decimal: number;
 }

--- a/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.html
+++ b/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.html
@@ -76,9 +76,9 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="symbol">
-          <th mat-header-cell *matHeaderCellDef> Symbol</th>
-          <td mat-cell *matCellDef="let p"> {{ p.symbol }}</td>
+        <ng-container matColumnDef="pairCode">
+          <th mat-header-cell *matHeaderCellDef> Pair Code</th>
+          <td mat-cell *matCellDef="let p"> {{ p.pairCode }}</td>
         </ng-container>
 
         <ng-container matColumnDef="base">
@@ -102,7 +102,7 @@
             <button mat-icon-button color="primary" (click)="onEdit(p)">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button color="warn" (click)="onDelete(p.symbol)">
+            <button mat-icon-button color="warn" (click)="onDelete(p.pairCode)">
               <mat-icon>delete</mat-icon>
             </button>
           </td>

--- a/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.ts
+++ b/frontend/src/app/features/currency_pair/pages/pair-admin/pair-admin.component.ts
@@ -41,7 +41,7 @@ export class PairAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['symbol', 'base', 'quote', 'decimal', 'actions'];
+  displayed: string[] = ['pairCode', 'base', 'quote', 'decimal', 'actions'];
   dataSource  = new MatTableDataSource<PairDto>([]);
 
   //==============================
@@ -51,7 +51,7 @@ export class PairAdminComponent implements OnInit {
 
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
-  editSymbol: string | null = null; // символ пары для редактирования
+  editPairCode: string | null = null; // код пары для редактирования
   currencies: CurrencyDto[] = [];
 
   constructor(
@@ -104,10 +104,10 @@ export class PairAdminComponent implements OnInit {
     const dto: PairCreateDto = this.form.value;
 
     this.service.add(dto).subscribe({
-      next: symbol => {
+      next: pairCode => {
         // Если все ОК
         this.snack.open(
-          `Pair '${symbol}' added`, 'OK', { duration: 2500 }
+          `Pair '${pairCode}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();
         this.form.reset({ decimal: 4 });
@@ -125,7 +125,7 @@ export class PairAdminComponent implements OnInit {
   /* клик по иконке Edit */
   onEdit(p: PairDto): void {
     this.editing = true;
-    this.editSymbol = p.symbol;
+    this.editPairCode = p.pairCode;
     this.form.setValue({
       base: p.base,
       quote: p.quote,
@@ -137,7 +137,7 @@ export class PairAdminComponent implements OnInit {
 
   /* нажата кнопка Save */
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editSymbol) { return; }
+    if (this.form.invalid || this.locked || !this.editPairCode) { return; }
 
     this.locked = true;
 
@@ -145,9 +145,9 @@ export class PairAdminComponent implements OnInit {
       decimal: this.form.controls['decimal'].value
     } as PairUpdateDto;
 
-    this.service.update(this.editSymbol, dto).subscribe({
+    this.service.update(this.editPairCode, dto).subscribe({
       next: () => {
-        this.snack.open(`Pair '${this.editSymbol}' updated`, 'OK', { duration: 2500 });
+        this.snack.open(`Pair '${this.editPairCode}' updated`, 'OK', { duration: 2500 });
         this.refresh();
         this.cancelEdit();
         this.locked = false;
@@ -163,7 +163,7 @@ export class PairAdminComponent implements OnInit {
   /* нажата кнопка Cancel */
   cancelEdit(): void {
     this.editing = false;
-    this.editSymbol = null;
+    this.editPairCode = null;
     this.form.reset({ base: '', quote: '', decimal: 4 });
     this.form.controls['base'].enable();
     this.form.controls['quote'].enable();
@@ -171,10 +171,10 @@ export class PairAdminComponent implements OnInit {
   }
 
   /* клик по иконке Delete */
-  onDelete(symbol: string): void {
-    this.service.delete(symbol).subscribe({
+  onDelete(pairCode: string): void {
+    this.service.delete(pairCode).subscribe({
       next: () => {
-        this.snack.open(`Pair '${symbol}' deleted`, 'OK', { duration: 2500 });
+        this.snack.open(`Pair '${pairCode}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
       error: err =>

--- a/frontend/src/app/features/currency_pair/services/pair.service.ts
+++ b/frontend/src/app/features/currency_pair/services/pair.service.ts
@@ -24,26 +24,26 @@ export class PairService {
       .pipe(map(res => res.data));
   }
 
-  /* Добавить валютную пару, backend вернёт её symbol */
+  /* Добавить валютную пару, backend вернёт её pairCode */
   add(dto: PairCreateDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
       .pipe(map(res => res.data));
   }
 
-  /* Удалить валютную пару по символу */
-  delete(symbol: string): Observable<void> {
-    const base = symbol.substring(0, 3);
-    const quote = symbol.substring(3, 6);
+  /* Удалить валютную пару по коду */
+  delete(pairCode: string): Observable<void> {
+    const base = pairCode.substring(0, 3);
+    const quote = pairCode.substring(3, 6);
     return this.http
       .delete<ApiResponse<void>>(`${this.baseUrl}/${base}/${quote}`)
       .pipe(map(res => res.data));
   }
 
-  /* Обновить валютную пару по символу */
-  update(symbol: string, dto: PairUpdateDto): Observable<void> {
-    const base = symbol.substring(0, 3);
-    const quote = symbol.substring(3, 6);
+  /* Обновить валютную пару по коду */
+  update(pairCode: string, dto: PairUpdateDto): Observable<void> {
+    const base = pairCode.substring(0, 3);
+    const quote = pairCode.substring(3, 6);
     return this.http
       .put<ApiResponse<void>>(`${this.baseUrl}/${base}/${quote}`, dto)
       .pipe(map(res => res.data));


### PR DESCRIPTION
## Summary
- rename symbol references to pairCode in Java and TypeScript
- adjust HTML template to show pair code
- update Avro schema for QuoteTick

## Testing
- `mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_688b791eb448832da47cef423398983c