### PR TITLE
Inline provider profile

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -29,17 +29,19 @@ import static com.alligator.market.domain.instrument.InstrumentType.CURRENCY_PAI
 @Slf4j
 public class TwelveFreeAdapterV2 implements MarketDataProvider {
 
-    // Создаем профиль провайдера
-    private static final ProviderProfile PROFILE = new ProviderProfile(
-            "TWELVE_FREE",
-            "TwelveData (free)",
-            Set.of(InstrumentType.CURRENCY_PAIR),
-            DeliveryMode.PULL,
-            AccessMethod.API_POLL,
-            false,
-            60_000
-    );
-
+    /* Профиль провайдера TwelveData (free). */
+    @Override
+    public ProviderProfile profile() {
+        return new ProviderProfile(
+                "TWELVE_FREE",
+                "TwelveData (free)",
+                Set.of(InstrumentType.CURRENCY_PAIR),
+                DeliveryMode.PULL,
+                AccessMethod.API_POLL,
+                false,
+                60_000
+        );
+    }
     private final TwelveFreeProps props;
     private final WebClient webClient;
 
@@ -51,13 +53,6 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
         this.props = props;
         this.webClient = webClient;
     }
-
-    //===================
-    // Профиль провайдера
-    //===================
-    /** Возвращает профиль заданного провайдера. */
-    @Override
-    public ProviderProfile profile() { return PROFILE; }
 
     //===========================
     // Реактивный поток котировок


### PR DESCRIPTION
## Summary
- refactor TwelveFreeAdapterV2 so provider profile is declared only in one place

## Testing
- `mvnw -q -DskipTests install` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688bca40c200832d876385138e8d7d12