### PR TITLE
Добавлены handlers и дефолтная обработка котировок

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -1,24 +1,17 @@
 package com.alligator.market.backend.provider.adapter.twelve.free;
 
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.backend.provider.adapter.twelve.free.handler.TwelveFreeCurrencyPairHandler;
+import com.alligator.market.domain.instrument.InstrumentType;
+import com.alligator.market.domain.provider.model.InstrumentHandler;
+import com.alligator.market.domain.provider.model.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.AccessMethod;
 import com.alligator.market.domain.provider.profile.DeliveryMode;
-import com.alligator.market.domain.provider.model.MarketDataProvider;
-import com.alligator.market.domain.instrument.InstrumentType;
-import com.alligator.market.domain.instrument.type.forex.currency_pair.CurrencyPair;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
-import com.alligator.market.domain.quote.QuoteTick;
-import com.fasterxml.jackson.databind.JsonNode;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
-import java.math.BigDecimal;
-import java.time.Instant;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
@@ -27,14 +20,12 @@ import java.util.Set;
  * Адаптер для провайдера TwelveData (free).
  */
 @Component
-@Slf4j
 public class TwelveFreeAdapterV2 implements MarketDataProvider {
 
-    // Параметры подключения к провайдеру. Автоматически считываются из настроек приложения.
-    private final TwelveFreeConnectionProps props;
-    // Веб клиент провайдера
-    private final WebClient webClient;
-    // Карта соответствия: тип инструмента <--> handler
+    // Код провайдера
+    private static final String PROVIDER_CODE = "TWELVE_FREE";
+
+    // Карта соответствия: тип инструмента → handler
     private final Map<InstrumentType, InstrumentHandler> handlerMap = new EnumMap<>(InstrumentType.class);
 
     /** Конструктор адаптера TwelveFreeAdapterV2. */
@@ -42,22 +33,17 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
             TwelveFreeConnectionProps props,
             @Qualifier("twelveFreeWebClient") WebClient webClient // Инъекция нужного веб-клиента
     ) {
-        this.props = props;
-        this.webClient = webClient;
-
-        // Добавляем handler для валютных пар
-        handlerMap.put(InstrumentType.CURRENCY_PAIR, this::fetchFxSpot);
+        handlerMap.put(
+                InstrumentType.CURRENCY_PAIR,
+                new TwelveFreeCurrencyPairHandler(webClient, props, PROVIDER_CODE)
+        );
     }
 
-    //===========================
-    //    Профиль провайдера
-    //===========================
-
-    /** Переопределяем метод, который возвращает профиль провайдера. */
+    /** Возвращает профиль провайдера. */
     @Override
     public ProviderProfile profile() {
         return new ProviderProfile(
-                "TWELVE_FREE",
+                PROVIDER_CODE,
                 "TwelveData (free)",
                 Set.of(InstrumentType.CURRENCY_PAIR),
                 DeliveryMode.PULL,
@@ -67,73 +53,10 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
         );
     }
 
-    //===========================
-    // Реактивный поток котировок
-    //===========================
-
-    /** Переопределяем метод, который возвращает котировки. */
+    /** Возвращает карту обработчиков инструментов. */
     @Override
-    public Flux<QuoteTick> quote(Instrument instrument) {
-
-        // Извлекаем handler для данного типа инструмента
-        InstrumentHandler handler = handlerMap.get(instrument.instrumentType());
-
-        if (handler == null) {
-            return Flux.error(new UnsupportedOperationException(
-                    "Instrument type " + instrument.instrumentType()
-                            + " not supported by " + profile().providerCode()));
-        }
-
-        return handler.fetch(instrument).flux();
-    }
-
-    //===========================
-    //  Вспомогательные методы
-    //===========================
-
-    /** Контракт-handler для работы с конкретным инструментом. */
-    @FunctionalInterface
-    private interface InstrumentHandler {
-        Mono<QuoteTick> fetch(Instrument instrument);
-    }
-
-    /** Реализация handler для запросов котировок валютных пар. */
-    private Mono<QuoteTick> fetchFxSpot(Instrument instrument) {
-
-        CurrencyPair pair = (CurrencyPair) instrument;
-
-        // Требуемый формат символа валютной пары для запроса котировки
-        String symbol = pair.base() + "/" + pair.quote();
-
-        return webClient.get()
-                .uri(b -> b
-                        .path("/price")
-                        .queryParam("symbol", symbol)
-                        .queryParam("apikey", props.apiKey())
-                        .build())
-                .retrieve()
-                .bodyToMono(JsonNode.class)
-                .map(json -> jsonToQuoteTick(json, instrument.internalCode()));
-    }
-
-    /** Метод формирования котировки {@link QuoteTick} из JSON-ответа провайдера. */
-    private QuoteTick jsonToQuoteTick(JsonNode json, String internalInstrumentCode) {
-
-        // Извлекаем значение поля "price" из JSON-ответа провайдера
-        JsonNode priceNode = json.get("price");
-
-        if (priceNode == null) {
-            throw new IllegalArgumentException("Invalid provider response: " + json);
-        }
-
-        BigDecimal price = new BigDecimal(priceNode.asText());
-
-        return new QuoteTick(
-                internalInstrumentCode,
-                price,
-                price,
-                Instant.now(),
-                profile().providerCode()
-        );
+    public Map<InstrumentType, InstrumentHandler> instrumentHandlers() {
+        return handlerMap;
     }
 }
+

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/TwelveFreeCurrencyPairHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/TwelveFreeCurrencyPairHandler.java
@@ -1,0 +1,74 @@
+package com.alligator.market.backend.provider.adapter.twelve.free.handler;
+
+import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
+import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.InstrumentType;
+import com.alligator.market.domain.instrument.type.forex.currency_pair.CurrencyPair;
+import com.alligator.market.domain.provider.model.InstrumentHandler;
+import com.alligator.market.domain.quote.QuoteTick;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Handler котировок валютных пар для TwelveData (free). */
+public class TwelveFreeCurrencyPairHandler implements InstrumentHandler {
+
+    private final WebClient webClient;
+    private final TwelveFreeConnectionProps props;
+    private final String providerCode;
+
+    public TwelveFreeCurrencyPairHandler(
+            WebClient webClient,
+            TwelveFreeConnectionProps props,
+            String providerCode
+    ) {
+        this.webClient = webClient;
+        this.props = props;
+        this.providerCode = providerCode;
+    }
+
+    /** Возвращает поддерживаемый тип инструмента. */
+    @Override
+    public InstrumentType supportedInstrument() {
+        return InstrumentType.CURRENCY_PAIR;
+    }
+
+    /** Возвращает котировку для указанного инструмента. */
+    @Override
+    public Flux<QuoteTick> instrumentQuote(Instrument instrument) {
+        CurrencyPair pair = (CurrencyPair) instrument;
+        String symbol = pair.base() + "/" + pair.quote();
+
+        return webClient.get()
+                .uri(b -> b
+                        .path("/price")
+                        .queryParam("symbol", symbol)
+                        .queryParam("apikey", props.apiKey())
+                        .build())
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(json -> jsonToQuoteTick(json, instrument.internalCode()))
+                .flux();
+    }
+
+    private QuoteTick jsonToQuoteTick(JsonNode json, String internalCode) {
+        JsonNode priceNode = json.get("price");
+        if (priceNode == null) {
+            throw new IllegalArgumentException("Invalid provider response: " + json);
+        }
+
+        BigDecimal price = new BigDecimal(priceNode.asText());
+
+        return new QuoteTick(
+                internalCode,
+                price,
+                price,
+                Instant.now(),
+                providerCode
+        );
+    }
+}
+

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
@@ -3,6 +3,8 @@ package com.alligator.market.domain.provider.model;
 import com.alligator.market.domain.instrument.Instrument;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.quote.QuoteTick;
+import com.alligator.market.domain.instrument.InstrumentType;
+import java.util.Map;
 import reactor.core.publisher.Flux;
 
 /**
@@ -13,6 +15,17 @@ public interface MarketDataProvider {
     /** Возвращает профиль провайдера. */
     ProviderProfile profile();
 
+    /** Возвращает карту обработчиков инструментов. */
+    Map<InstrumentType, InstrumentHandler> instrumentHandlers();
+
     /** Возвращает котировку. */
-    Flux<QuoteTick> quote(Instrument instrument);
+    default Flux<QuoteTick> quote(Instrument instrument) {
+        InstrumentHandler handler = instrumentHandlers().get(instrument.instrumentType());
+        if (handler != null) {
+            return handler.instrumentQuote(instrument);
+        }
+        return Flux.error(new UnsupportedOperationException(
+                "Instrument type " + instrument.instrumentType()
+                        + " not supported by " + profile().providerCode()));
+    }
 }


### PR DESCRIPTION
## Summary
- расширен контракт MarketDataProvider картой handler'ов и дефолтной обработкой quote
- вынесена логика работы с валютными парами TwelveData в отдельный handler
- адаптер TwelveFreeAdapterV2 заполняет карту handler'ов

## Testing
- `mvn -q test` *(ошибка: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 ...)*

------
https://chatgpt.com/codex/tasks/task_e_688fb3aaf488832da32ae51155b04e0e