### PR TITLE
Автоматическое заполнение типов инструментов

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -14,7 +14,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Адаптер для провайдера TwelveData (free).
@@ -46,7 +45,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
         return new ProviderProfile(
                 PROVIDER_CODE,
                 "TwelveData (free)",
-                Set.of(InstrumentType.CURRENCY_PAIR),
+                supportedInstrumentTypes(), // ← Получаем типы инструментов из карты обработчиков
                 DeliveryMode.PULL,
                 AccessMethod.API_POLL,
                 false,

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
@@ -5,6 +5,7 @@ import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.quote.QuoteTick;
 import com.alligator.market.domain.instrument.InstrumentType;
 import java.util.Map;
+import java.util.Set;
 import reactor.core.publisher.Flux;
 
 /**
@@ -17,6 +18,11 @@ public interface MarketDataProvider {
 
     /** Возвращает карту: тип инструмента → обработчик. */
     Map<InstrumentType, InstrumentHandler> instrumentHandlers();
+
+    /** Возвращает множество поддерживаемых типов инструментов. */
+    default Set<InstrumentType> supportedInstrumentTypes() {
+        return instrumentHandlers().keySet();
+    }
 
     /** Возвращает котировку. */
     default Flux<QuoteTick> quote(Instrument instrument) {


### PR DESCRIPTION
## Summary
- Добавлен метод `supportedInstrumentTypes` в `MarketDataProvider` для автоматического извлечения поддерживаемых типов инструментов из карты обработчиков
- Адаптер TwelveData теперь использует `supportedInstrumentTypes()` при формировании `ProviderProfile`

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_688fbe8c0310832db25afc0e657fd8d5