### PR TITLE
Учитываем настройку временной зоны в котировках

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeCurrencyPairHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeCurrencyPairHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
 import java.math.BigDecimal;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 
 /** Handler котировок валютных пар для TwelveData (free). */
 public class TwelveFreeCurrencyPairHandler implements InstrumentHandler {
@@ -68,7 +68,7 @@ public class TwelveFreeCurrencyPairHandler implements InstrumentHandler {
                 instrumentInternalCode,
                 price,
                 price,
-                Instant.now(),
+                OffsetDateTime.now(),
                 providerCode
         );
     }

--- a/domain/src/main/avro/QuoteTickAvro.avsc
+++ b/domain/src/main/avro/QuoteTickAvro.avsc
@@ -6,7 +6,7 @@
     { "name": "internalInstrumentCode", "type": "string" },
     { "name": "bid", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
     { "name": "ask", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
-    { "name": "ts", "type": { "type": "long", "logicalType": "timestamp-millis" } },
+    { "name": "ts", "type": "string" },
     { "name": "provider", "type": "string" }
   ]
 }

--- a/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.quote;
 
 import java.math.BigDecimal;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 
 /**
  * Глобальная модель тика котировки для валютной пары.
@@ -14,6 +14,9 @@ public record QuoteTick(
 
         BigDecimal bid,
         BigDecimal ask,
-        Instant ts,
+
+        // Время тика котировки
+        OffsetDateTime ts,
+
         String provider
 ) {}


### PR DESCRIPTION
## Summary
- использовать `OffsetDateTime` в модели QuoteTick
- изменён Avro‑схема поля `ts`
- handler котировок теперь проставляет `OffsetDateTime` с учётом системной зоны

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc107a10832db08350675d8a76a3