### PR TITLE
Добавлено исключение InstrumentNotSupported для неподдерживаемых инструментов

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupported.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupported.java
@@ -1,0 +1,12 @@
+package com.alligator.market.domain.provider.exception;
+
+import com.alligator.market.domain.instrument.InstrumentType;
+
+/**
+ * Неподдерживаемый тип инструмента.
+ */
+public class InstrumentNotSupported extends RuntimeException {
+    public InstrumentNotSupported(InstrumentType type, String providerCode) {
+        super("Instrument type %s not supported by %s".formatted(type, providerCode));
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
@@ -4,6 +4,7 @@ import com.alligator.market.domain.instrument.Instrument;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
 import com.alligator.market.domain.quote.QuoteTick;
 import com.alligator.market.domain.instrument.InstrumentType;
+import com.alligator.market.domain.provider.exception.InstrumentNotSupported;
 import java.util.Map;
 import java.util.Set;
 import reactor.core.publisher.Flux;
@@ -35,11 +36,7 @@ public interface MarketDataProvider {
 
         // Проверка, что обработчик существует
         if (handler == null) {
-            return Flux.error(
-                    new UnsupportedOperationException("Instrument type " + instrumentType +
-                            " not supported by " + profile().providerCode()
-                    )
-            );
+            return Flux.error(new InstrumentNotSupported(instrumentType, profile().providerCode()));
         }
 
         // Возвращаем котировку инструмента


### PR DESCRIPTION
## Summary
- Добавлен класс InstrumentNotSupported для сигнализации о неподдерживаемых инструментах
- MarketDataProvider.quote теперь возвращает ошибку InstrumentNotSupported вместо UnsupportedOperationException

## Testing
- `mvn -q test` *(ошибка: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fd0c11efc832d911bcc31bf825fe0