### PR TITLE
Перенос исключения дубликатов профиля в домен

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScannerAdapter.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.provider.profile.context_sync;
 import com.alligator.market.domain.provider.model.MarketDataProvider;
 import com.alligator.market.domain.provider.context_sync.ProviderContextScanner;
 import com.alligator.market.domain.provider.profile.ProviderProfile;
-import com.alligator.market.backend.provider.profile.exception.DuplicateProviderProfileException;
+import com.alligator.market.domain.provider.context_sync.DuplicateProviderProfileInContextException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +41,10 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
 
         for (ProviderProfile profile : profiles) {
             if (!codes.add(profile.providerCode())) {
-                throw new DuplicateProviderProfileException("providerCode", profile.providerCode());
+                throw new DuplicateProviderProfileInContextException("providerCode", profile.providerCode());
             }
             if (!names.add(profile.displayName())) {
-                throw new DuplicateProviderProfileException("displayName", profile.displayName());
+                throw new DuplicateProviderProfileInContextException("displayName", profile.displayName());
             }
         }
     }

--- a/backend/src/test/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScannerAdapterValidationTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/profile/context_sync/ProviderContextScannerAdapterValidationTest.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.profile.context_sync;
 
-import com.alligator.market.backend.provider.profile.exception.DuplicateProviderProfileException;
+import com.alligator.market.domain.provider.context_sync.DuplicateProviderProfileInContextException;
 import com.alligator.market.domain.instrument.Instrument;
 import com.alligator.market.domain.instrument.InstrumentType;
 import com.alligator.market.domain.provider.model.InstrumentHandler;
@@ -28,7 +28,7 @@ class ProviderContextScannerAdapterValidationTest {
         MarketDataProvider p1 = provider("A", "Name1");
         MarketDataProvider p2 = provider("A", "Name2");
         ProviderContextScannerAdapter scanner = new ProviderContextScannerAdapter(List.of(p1, p2));
-        assertThrows(DuplicateProviderProfileException.class, scanner::getProviderProfiles);
+        assertThrows(DuplicateProviderProfileInContextException.class, scanner::getProviderProfiles);
     }
 
     @Disabled
@@ -37,7 +37,7 @@ class ProviderContextScannerAdapterValidationTest {
         MarketDataProvider p1 = provider("A", "Same");
         MarketDataProvider p2 = provider("B", "Same");
         ProviderContextScannerAdapter scanner = new ProviderContextScannerAdapter(List.of(p1, p2));
-        assertThrows(DuplicateProviderProfileException.class, scanner::getProviderProfiles);
+        assertThrows(DuplicateProviderProfileInContextException.class, scanner::getProviderProfiles);
     }
 
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/context_sync/DuplicateProviderProfileInContextException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/context_sync/DuplicateProviderProfileInContextException.java
@@ -1,10 +1,10 @@
-package com.alligator.market.backend.provider.profile.exception;
+package com.alligator.market.domain.provider.context_sync;
 
 /**
  * Профиль провайдера с указанным полем уже присутствует в контексте.
  */
-public class DuplicateProviderProfileException extends RuntimeException {
-    public DuplicateProviderProfileException(String field, String value) {
+public class DuplicateProviderProfileInContextException extends RuntimeException {
+    public DuplicateProviderProfileInContextException(String field, String value) {
         super("Provider profile with %s '%s' already exists".formatted(field, value));
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ProviderContextScanner.java
@@ -9,6 +9,10 @@ import java.util.List;
  */
 public interface ProviderContextScanner {
 
-    /** Вернуть список профилей провайдеров. */
+    /**
+     * Вернуть список профилей провайдеров.
+     *
+     * @throws DuplicateProviderProfileInContextException если в контексте обнаружены дубли
+     */
     List<ProviderProfile> getProviderProfiles();
 }


### PR DESCRIPTION
## Summary
- add DuplicateProviderProfileInContextException in domain
- update ProviderContextScannerAdapter and tests to use new exception
- document duplicate profile behavior in ProviderContextScanner

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689063b63264832d9148d7bfb4e1c8a5