### PR TITLE
Перенос исключений валют в модуль domain

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/service/CurrencyServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/service/CurrencyServiceImpl.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.instrument_catalog.currency.service;
 
-import com.alligator.market.backend.instrument_catalog.currency.exception.CurrencyNotFoundException;
-import com.alligator.market.backend.instrument_catalog.currency.exception.CurrencyUsedInPairsException;
-import com.alligator.market.backend.instrument_catalog.currency.exception.DuplicateCurrencyException;
+import com.alligator.market.domain.instrument.currency.exception.CurrencyNotFoundException;
+import com.alligator.market.domain.instrument.currency.exception.CurrencyUsedInPairsException;
+import com.alligator.market.domain.instrument.currency.exception.DuplicateCurrencyException;
 import com.alligator.market.domain.instrument.currency.Currency;
 import com.alligator.market.domain.instrument.currency.CurrencyStorage;
 import com.alligator.market.domain.instrument.currency_pair.CurrencyPairStorage;

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/web/CurrencyExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/web/CurrencyExceptionHandler.java
@@ -2,9 +2,9 @@ package com.alligator.market.backend.instrument_catalog.currency.web;
 
 import com.alligator.market.backend.common.web.ApiResponse;
 import com.alligator.market.backend.common.web.ResponseEntityFactory;
-import com.alligator.market.backend.instrument_catalog.currency.exception.CurrencyNotFoundException;
-import com.alligator.market.backend.instrument_catalog.currency.exception.CurrencyUsedInPairsException;
-import com.alligator.market.backend.instrument_catalog.currency.exception.DuplicateCurrencyException;
+import com.alligator.market.domain.instrument.currency.exception.CurrencyNotFoundException;
+import com.alligator.market.domain.instrument.currency.exception.CurrencyUsedInPairsException;
+import com.alligator.market.domain.instrument.currency.exception.DuplicateCurrencyException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/service/CurrencyPairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/service/CurrencyPairServiceImpl.java
@@ -1,9 +1,9 @@
 package com.alligator.market.backend.instrument_catalog.currency_pair.service;
 
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.CurrencyFromPairNotFoundException;
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.DuplicatePairException;
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.PairNotFoundException;
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.EqualCurrenciesInPairException;
+import com.alligator.market.domain.instrument.currency_pair.exception.CurrencyFromPairNotFoundException;
+import com.alligator.market.domain.instrument.currency_pair.exception.DuplicatePairException;
+import com.alligator.market.domain.instrument.currency_pair.exception.PairNotFoundException;
+import com.alligator.market.domain.instrument.currency_pair.exception.EqualCurrenciesInPairException;
 import com.alligator.market.domain.instrument.currency.CurrencyStorage;
 import com.alligator.market.domain.instrument.currency_pair.CurrencyPair;
 import com.alligator.market.domain.instrument.currency_pair.CurrencyPairStorage;

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/web/PairExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/web/PairExceptionHandler.java
@@ -2,10 +2,10 @@ package com.alligator.market.backend.instrument_catalog.currency_pair.web;
 
 import com.alligator.market.backend.common.web.ApiResponse;
 import com.alligator.market.backend.common.web.ResponseEntityFactory;
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.CurrencyFromPairNotFoundException;
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.DuplicatePairException;
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.PairNotFoundException;
-import com.alligator.market.backend.instrument_catalog.currency_pair.exception.EqualCurrenciesInPairException;
+import com.alligator.market.domain.instrument.currency_pair.exception.CurrencyFromPairNotFoundException;
+import com.alligator.market.domain.instrument.currency_pair.exception.DuplicatePairException;
+import com.alligator.market.domain.instrument.currency_pair.exception.PairNotFoundException;
+import com.alligator.market.domain.instrument.currency_pair.exception.EqualCurrenciesInPairException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
     </dependency>
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/CurrencyNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/CurrencyNotFoundException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument_catalog.currency.exception;
+package com.alligator.market.domain.instrument.currency.exception;
 
 import jakarta.persistence.EntityNotFoundException;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/CurrencyUsedInPairsException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/CurrencyUsedInPairsException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument_catalog.currency.exception;
+package com.alligator.market.domain.instrument.currency.exception;
 
 /**
  * Нельзя удалить валюту, если она используется в валютных парах.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/DuplicateCurrencyException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/DuplicateCurrencyException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument_catalog.currency.exception;
+package com.alligator.market.domain.instrument.currency.exception;
 
 /**
  * Дублирование валюты.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/CurrencyFromPairNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/CurrencyFromPairNotFoundException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument_catalog.currency_pair.exception;
+package com.alligator.market.domain.instrument.currency_pair.exception;
 
 /**
  * Не найдена одна из валют компонент для соответствующей валютной пары.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/DuplicatePairException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/DuplicatePairException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument_catalog.currency_pair.exception;
+package com.alligator.market.domain.instrument.currency_pair.exception;
 
 /**
  * Дублирование валютной пары.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/EqualCurrenciesInPairException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/EqualCurrenciesInPairException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument_catalog.currency_pair.exception;
+package com.alligator.market.domain.instrument.currency_pair.exception;
 
 /**
  * Валютные коды пары не могут совпадать.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/PairNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/PairNotFoundException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument_catalog.currency_pair.exception;
+package com.alligator.market.domain.instrument.currency_pair.exception;
 
 import jakarta.persistence.EntityNotFoundException;
 


### PR DESCRIPTION
## Summary
- перенесены исключения валют и валютных пар в модуль domain
- обновлены импорты сервисов и обработчиков исключений backend
- добавлена зависимость jakarta.persistence-api в domain

## Testing
- `mvn test` *(failed: Non-resolvable parent POM for com.alligator:market-backend:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to confluent (https://packages.confluent.io/maven/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68906fe205a8832d9971daa0242664c7