### PR TITLE
feat: добавить базовый NotFoundException

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/GlobalRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/GlobalRestExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.common.web;
 
+import com.alligator.market.domain.common.exception.NotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -63,9 +64,9 @@ public class GlobalRestExceptionHandler {
     }
 
     /** Ресурс не найден 404. */
-    @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<ApiResponse<Void>> handleNotFound(NoSuchElementException ex) {
-        log.warn("NoSuchElementException: {}", ex.getMessage());
+    @ExceptionHandler({NotFoundException.class, NoSuchElementException.class})
+    public ResponseEntity<ApiResponse<Void>> handleNotFound(RuntimeException ex) {
+        log.warn("{}: {}", ex.getClass().getSimpleName(), ex.getMessage());
         return ResponseEntityFactory.notFound(ex.getMessage());
     }
 

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -31,11 +31,6 @@
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
     </dependency>
-    <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.1.0</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/domain/src/main/java/com/alligator/market/domain/common/exception/NotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.domain.common.exception;
+
+/**
+ * Базовое исключение для случаев, когда ресурс не найден.
+ */
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/CurrencyNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency/exception/CurrencyNotFoundException.java
@@ -1,11 +1,11 @@
 package com.alligator.market.domain.instrument.currency.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.alligator.market.domain.common.exception.NotFoundException;
 
 /**
  * Валюта не найдена.
  */
-public class CurrencyNotFoundException extends EntityNotFoundException {
+public class CurrencyNotFoundException extends NotFoundException {
     public CurrencyNotFoundException(String code) {
         super("Currency '%s' not found".formatted(code));
     }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/PairNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/exception/PairNotFoundException.java
@@ -1,11 +1,11 @@
 package com.alligator.market.domain.instrument.currency_pair.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.alligator.market.domain.common.exception.NotFoundException;
 
 /**
  * Валютная пара не найдена.
  */
-public class PairNotFoundException extends EntityNotFoundException {
+public class PairNotFoundException extends NotFoundException {
     public PairNotFoundException(String pairCode) {
         super("Currency pair '%s' not found".formatted(pairCode));
     }


### PR DESCRIPTION
## Summary
- добавить общий NotFoundException в домене
- наследовать от него CurrencyNotFoundException и PairNotFoundException
- удалить зависимость `jakarta.persistence` из domain и обработать NotFoundException в глобальном хэндлере

## Testing
- `mvn test` *(ошибка: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890724b65d0832da5fe693701c39454