### PR TITLE
fix: align junit dependencies

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -15,10 +15,11 @@
   </properties>
 
   <dependencies>
+    <!-- JUnit для тестов -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>6.0.0-M1</version>
+      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -39,6 +40,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.3</version>
+        <dependencies>
+          <!-- Совместимый лаунчер JUnit Platform -->
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.10.2</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
## Summary
- align JUnit version to stable 5.10.2
- ensure Surefire uses matching JUnit Platform launcher

## Testing
- `mvn -q test` *(fails: Plugin org.apache.avro:avro-maven-plugin:1.12.0 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6890815275d4832db4cf7c5436d38fbf