### PR TITLE
Исправлена версия junit-platform-launcher

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -46,7 +46,7 @@
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.13.4</version>
+            <version>1.10.2</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
## Summary
- корректная версия junit-platform-launcher в плагине surefire

## Testing
- `mvn test` (не удалось получить org.apache.avro:avro-maven-plugin:1.12.0: Network is unreachable)

------
https://chatgpt.com/codex/tasks/task_e_68908b34eb00832db0419f4d67a22f4d