### PR TITLE
Обновление JUnit в доменном модуле

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <avro.version>1.12.0</avro.version>
-    <junit-jupiter.version>5.10.2</junit-jupiter.version>
+    <junit-jupiter.version>5.11.0</junit-jupiter.version>
   </properties>
 
   <dependencies>
@@ -46,7 +46,7 @@
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.10.2</version>
+            <version>1.11.0</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
## Summary
- обновлена зависимость `junit-jupiter` до версии 5.11.0
- обновлена версия `junit-platform-launcher` до 1.11.0 в `maven-surefire-plugin`

## Testing
- `mvn clean install` *(ошибка разрешения плагина: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891d8a21fc8832dac96b410edf1a51c