### PR TITLE
refactor: centralize pom configuration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -2,34 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
-        <relativePath/>
+        <groupId>com.alligator</groupId>
+        <artifactId>market-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
     </parent>
-    <groupId>com.alligator</groupId>
+
     <artifactId>market-backend</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Alligator Market Backend</name>
     <description>Spring Boot backend for Alligator Market</description>
-    <url/>
-    <licenses>
-        <license/>
-    </licenses>
-    <developers>
-        <developer/>
-    </developers>
-    <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
-    </scm>
     <properties>
-        <java.version>17</java.version>
         <flyway.version>11.8.2</flyway.version>
-        <junit-jupiter.version>5.10.2</junit-jupiter.version>
     </properties>
     <dependencies>
         <dependency>
@@ -73,11 +58,6 @@
             <version>${flyway.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-core</artifactId>
-            <version>3.8.0-M3</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
@@ -89,13 +69,6 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>7.6.0</version>
-        </dependency>
-        <!-- JUnit для тестов -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit-jupiter.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -2,53 +2,34 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.alligator</groupId>
+  <parent>
+    <groupId>com.alligator</groupId>
+    <artifactId>market-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
   <artifactId>market-domain</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>Alligator Market Domain</name>
   <description>Domain model for Alligator Market</description>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <avro.version>1.12.0</avro.version>
-    <junit-jupiter.version>5.11.0</junit-jupiter.version>
-  </properties>
 
   <dependencies>
+    <!-- Reactor для реактивных типов домена -->
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
-      <version>3.8.0-M3</version>
+      <version>${reactor.version}</version>
     </dependency>
+    <!-- Avro для генерации классов -->
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
     </dependency>
-    <!-- JUnit для тестов -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit-jupiter.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.3</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <version>1.11.0</version>
-          </dependency>
-        </dependencies>
-      </plugin>
+      <!-- Плагин генерации Avro-схем -->
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,50 @@
-<!-- Корневой pom с перечислением модулей. -->
+<!-- Корневой pom: общие настройки и зависимости для модулей. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/>
+    </parent>
+
     <groupId>com.alligator</groupId>
     <artifactId>market-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <modules>
         <module>backend</module>
         <module>domain</module>
     </modules>
+
+    <properties>
+        <java.version>17</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <avro.version>1.12.0</avro.version>
+        <reactor.version>3.8.0-M3</reactor.version>
+    </properties>
+
+    <dependencies>
+        <!-- JUnit Jupiter для модульных тестов -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
## Summary
- simplify parent POM and share common configuration
- reduce domain POM to essential dependencies and use parent
- cleanup backend POM and rely on shared parent config

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68920d180ee4832d87585dacf4ef1af8