### PR TITLE
feat: implement mapper for currency pair

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/entity/CurrencyPairEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/entity/CurrencyPairEntityMapper.java
@@ -1,0 +1,38 @@
+package com.alligator.market.backend.instrument_catalog.currency_pair.entity;
+
+import com.alligator.market.backend.instrument_catalog.currency.jpa.CurrencyEntity;
+import com.alligator.market.domain.instrument.currency_pair.CurrencyPair;
+
+/**
+ * Утилитарный класс для преобразования между сущностью {@link CurrencyPairEntity}
+ * и доменной моделью {@link CurrencyPair}.
+ */
+public final class CurrencyPairEntityMapper {
+
+    private CurrencyPairEntityMapper() {
+    }
+
+    /** Преобразует сущность в доменную модель. */
+    public static CurrencyPair toDomain(CurrencyPairEntity entity) {
+        return new CurrencyPair(
+                entity.getBase().getCode(),
+                entity.getQuote().getCode(),
+                entity.getDecimal()
+        );
+    }
+
+    /** Заполняет сущность данными из доменной модели. */
+    public static void toEntity(
+            CurrencyPair pair,
+            CurrencyEntity base,
+            CurrencyEntity quote,
+            CurrencyPairEntity entity
+    ) {
+        // Устанавливаем ссылки на валюты и основные параметры пары
+        entity.setBase(base);
+        entity.setQuote(quote);
+        entity.setPairCode(pair.pairCode());
+        entity.setDecimal(pair.decimal());
+    }
+}
+

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/repository/CurrencyPairStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/repository/CurrencyPairStorageAdapter.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.instrument_catalog.currency_pair.repository
 import com.alligator.market.backend.instrument_catalog.currency.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument_catalog.currency.jpa.CurrencyJpaRepository;
 import com.alligator.market.backend.instrument_catalog.currency_pair.entity.CurrencyPairEntity;
+import com.alligator.market.backend.instrument_catalog.currency_pair.entity.CurrencyPairEntityMapper;
 import com.alligator.market.domain.instrument.currency_pair.CurrencyPair;
 import com.alligator.market.domain.instrument.currency_pair.catalog.CurrencyPairStorage;
 import lombok.RequiredArgsConstructor;
@@ -27,10 +28,7 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
         CurrencyEntity c1 = currencyJpaRepository.findByCode(pair.base()).orElseThrow();
         CurrencyEntity c2 = currencyJpaRepository.findByCode(pair.quote()).orElseThrow();
         CurrencyPairEntity entity = new CurrencyPairEntity();
-        entity.setBase(c1);
-        entity.setQuote(c2);
-        entity.setPairCode(pair.pairCode());
-        entity.setDecimal(pair.decimal());
+        CurrencyPairEntityMapper.toEntity(pair, c1, c2, entity);
         return jpaRepository.save(entity).getPairCode();
     }
 
@@ -41,7 +39,7 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
 
     @Override
     public Optional<CurrencyPair> find(String base, String quote) {
-        return jpaRepository.findByPairCode(base+quote).map(this::toDomain);
+        return jpaRepository.findByPairCode(base+quote).map(CurrencyPairEntityMapper::toDomain);
     }
 
     @Override
@@ -52,15 +50,8 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
     @Override
     public List<CurrencyPair> findAll() {
         return jpaRepository.findAll(Sort.by("pairCode")).stream()
-                .map(this::toDomain)
+                .map(CurrencyPairEntityMapper::toDomain)
                 .toList();
     }
 
-    private CurrencyPair toDomain(CurrencyPairEntity entity) {
-        return new CurrencyPair(
-                entity.getBase().getCode(),
-                entity.getQuote().getCode(),
-                entity.getDecimal()
-        );
-    }
 }


### PR DESCRIPTION
## Summary
- add mapper between `CurrencyPairEntity` and domain `CurrencyPair`
- use new mapper inside currency pair storage adapter

## Testing
- `mvn -q -pl backend -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6894d8a086a8832d824d45e58dac9656