### PR TITLE
Fix currency mapper and pair storage adapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/jpa/CurrencyEntityMapper.java
@@ -6,7 +6,7 @@ import com.alligator.market.domain.instrument.currency.Currency;
  * Утилитарный класс для преобразования между сущностью {@link CurrencyEntity}
  * и доменной моделью {@link Currency}.
  */
-public final class CurrencyEntityMapper {
+ public final class CurrencyEntityMapper {
 
     private CurrencyEntityMapper() {
     }
@@ -19,6 +19,15 @@ public final class CurrencyEntityMapper {
                 entity.getCountry(),
                 entity.getDecimal()
         );
+    }
+
+    /** Заполняет сущность данными из доменной модели. */
+    public static void toEntity(Currency currency, CurrencyEntity entity) {
+        // Переносим основные поля из модели в сущность
+        entity.setCode(currency.code());
+        entity.setName(currency.name());
+        entity.setCountry(currency.country());
+        entity.setDecimal(currency.decimal());
     }
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/adapter/CurrencyPairStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/adapter/CurrencyPairStorageAdapter.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.instrument_catalog.currency_pair.adapter;
 import com.alligator.market.backend.instrument_catalog.currency.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument_catalog.currency.jpa.CurrencyJpaRepository;
 import com.alligator.market.backend.instrument_catalog.currency_pair.jpa.CurrencyPairEntity;
+import com.alligator.market.backend.instrument_catalog.currency_pair.jpa.CurrencyPairEntityMapper;
 import com.alligator.market.backend.instrument_catalog.currency_pair.jpa.CurrencyPairJpaRepository;
 import com.alligator.market.domain.instrument.currency_pair.CurrencyPair;
 import com.alligator.market.domain.instrument.currency_pair.catalog.CurrencyPairStorage;
@@ -25,24 +26,29 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
 
     @Override
     public String save(CurrencyPair pair) {
-        CurrencyEntity c1 = currencyJpaRepository.findByCode(pair.base()).orElseThrow();
-        CurrencyEntity c2 = currencyJpaRepository.findByCode(pair.quote()).orElseThrow();
-        CurrencyPairEntity entity = new CurrencyPairEntity();
-        entity.setBase(c1);
-        entity.setQuote(c2);
-        entity.setPairCode(pair.pairCode());
-        entity.setDecimal(pair.decimal());
+        // Находим связанные валюты
+        CurrencyEntity base = currencyJpaRepository.findByCode(pair.base()).orElseThrow();
+        CurrencyEntity quote = currencyJpaRepository.findByCode(pair.quote()).orElseThrow();
+
+        // Загружаем сущность пары или создаём новую
+        CurrencyPairEntity entity = jpaRepository.findByPairCode(pair.pairCode())
+                .orElseGet(CurrencyPairEntity::new);
+
+        // Наполняем сущность данными из модели
+        CurrencyPairEntityMapper.toEntity(pair, base, quote, entity);
+
         return jpaRepository.save(entity).getPairCode();
     }
 
     @Override
     public void delete(String base, String quote) {
-        jpaRepository.findByPairCode(base+quote).ifPresent(jpaRepository::delete);
+        jpaRepository.findByPairCode(base + quote).ifPresent(jpaRepository::delete);
     }
 
     @Override
     public Optional<CurrencyPair> find(String base, String quote) {
-        return jpaRepository.findByPairCode(base+quote).map(this::toDomain);
+        return jpaRepository.findByPairCode(base + quote)
+                .map(CurrencyPairEntityMapper::toDomain);
     }
 
     @Override
@@ -53,15 +59,7 @@ public class CurrencyPairStorageAdapter implements CurrencyPairStorage {
     @Override
     public List<CurrencyPair> findAll() {
         return jpaRepository.findAll(Sort.by("pairCode")).stream()
-                .map(this::toDomain)
+                .map(CurrencyPairEntityMapper::toDomain)
                 .toList();
-    }
-
-    private CurrencyPair toDomain(CurrencyPairEntity entity) {
-        return new CurrencyPair(
-                entity.getBase().getCode(),
-                entity.getQuote().getCode(),
-                entity.getDecimal()
-        );
     }
 }


### PR DESCRIPTION
## Summary
- add entity mapping from domain in CurrencyEntityMapper
- refactor CurrencyPairStorageAdapter to use mapper and update pairs correctly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_6894dc89b5f0832d903cd2958dbb1f4d