### PR TITLE
feat: добавить индикатор статуса профиля поставщика

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -42,7 +42,9 @@
 
         <ng-container matColumnDef="status">
           <th mat-header-cell *matHeaderCellDef>Status</th>
-          <td mat-cell *matCellDef="let p">{{ p.status }}</td>
+          <td mat-cell *matCellDef="let p">
+            <span class="status-indicator" [ngClass]="getStatusClass(p.status)"></span>
+          </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -6,3 +6,26 @@
   gap: 32px;
   padding: 0 16px;
 }
+
+/* базовый стиль индикатора статуса */
+.status-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* цвет активного статуса */
+.status-active {
+  background: #4CAF50;
+}
+
+/* цвет заменённого статуса */
+.status-replaced {
+  background: #9E9E9E;
+}
+
+/* цвет отсутствующего статуса */
+.status-missing {
+  background: #F44336;
+}

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -41,6 +41,20 @@ export class ProfileListComponent implements OnInit {
     this.refresh();
   }
 
+  /* выбор класса для отображения статуса */
+  getStatusClass(status: string): string {
+    switch (status) {
+      case 'ACTIVE':
+        return 'status-active';
+      case 'REPLACED':
+        return 'status-replaced';
+      case 'MISSING':
+        return 'status-missing';
+      default:
+        return 'status-missing';
+    }
+  }
+
   /* обновление таблицы в зависимости от режима */
   private refresh(): void {
     if (this.showAll) {


### PR DESCRIPTION
## Summary
- заменить текстовый статус на цветной индикатор
- добавить стили и вспомогательный метод для классов статуса

## Testing
- `npm test -- --watch=false` (падает: No binary for Chrome browser on your platform)


------
https://chatgpt.com/codex/tasks/task_e_6894e9fea040832da82b0dd90b696711