### PR TITLE
feat: добавить индикатор статуса профиля поставщика

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -40,6 +40,17 @@
           <td mat-cell *matCellDef="let p">{{ p.minPollPeriodMs }}</td>
         </ng-container>
 
+        <ng-container matColumnDef="statusIndicator">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let p">
+            <span
+              class="status-indicator"
+              [ngClass]="getStatusClass(p.status)"
+              aria-label="{{ p.status }}"
+            ></span>
+          </td>
+        </ng-container>
+
         <ng-container matColumnDef="status">
           <th mat-header-cell *matHeaderCellDef>Status</th>
           <td mat-cell *matCellDef="let p">{{ p.status }}</td>

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -6,3 +6,32 @@
   gap: 32px;
   padding: 0 16px;
 }
+
+/* базовый стиль индикатора статуса */
+.status-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* цвет активного статуса */
+.status-active {
+  background: #4CAF50;
+}
+
+/* цвет заменённого статуса */
+.status-replaced {
+  background: #9E9E9E;
+}
+
+/* цвет отсутствующего статуса */
+.status-missing {
+  background: #F44336;
+}
+
+/* ширина колонки индикатора */
+.mat-column-statusIndicator {
+  width: 16px;
+  padding: 0;
+}

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -16,6 +16,7 @@ import { ProviderProfileStatusDto } from '../../models/provider-profile-status.m
 export class ProfileListComponent implements OnInit {
 
   displayed: string[] = [
+    'statusIndicator',
     'status',
     'providerCode',
     'displayName',
@@ -39,6 +40,20 @@ export class ProfileListComponent implements OnInit {
   onToggle(event: MatSlideToggleChange): void {
     this.showAll = event.checked;
     this.refresh();
+  }
+
+  /* выбор класса для отображения статуса */
+  getStatusClass(status: string): string {
+    switch (status) {
+      case 'ACTIVE':
+        return 'status-active';
+      case 'REPLACED':
+        return 'status-replaced';
+      case 'MISSING':
+        return 'status-missing';
+      default:
+        return 'status-missing';
+    }
   }
 
   /* обновление таблицы в зависимости от режима */


### PR DESCRIPTION
## Summary
- заменить текстовый статус на цветной индикатор
- добавить отдельную колонку индикатора и сохранить текст статуса
- добавить стили и вспомогательный метод для классов статуса

## Testing
- `npm test -- --watch=false` (ошибка: sh: 1: ng: not found)
- `npm install` (зависимости не установлены из-за отсутствия сетевого доступа)


------
https://chatgpt.com/codex/tasks/task_e_6894e9fea040832da82b0dd90b696711