### PR TITLE
feat(frontend): add status indicator column

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -5,6 +5,18 @@
       <mat-slide-toggle [checked]="showAll" (change)="onToggle($event)" color="primary">Show all Status</mat-slide-toggle>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
+        <ng-container matColumnDef="statusIndicator">
+          <th mat-header-cell *matHeaderCellDef class="status-indicator-cell"></th>
+          <td mat-cell *matCellDef="let p" class="status-indicator-cell">
+            <span class="status-indicator" [ngClass]="getStatusClass(p.status)"></span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let p">{{ p.status }}</td>
+        </ng-container>
+
         <ng-container matColumnDef="providerCode">
           <th mat-header-cell *matHeaderCellDef>Code</th>
           <td mat-cell *matCellDef="let p">{{ p.providerCode }}</td>
@@ -38,13 +50,6 @@
         <ng-container matColumnDef="minPollPeriodMs">
           <th mat-header-cell *matHeaderCellDef>Min Poll, ms</th>
           <td mat-cell *matCellDef="let p">{{ p.minPollPeriodMs }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>Status</th>
-          <td mat-cell *matCellDef="let p">
-            <span class="status-indicator" [ngClass]="getStatusClass(p.status)"></span>
-          </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -15,6 +15,11 @@
   display: inline-block;
 }
 
+/* узкая ячейка для цветового индикатора */
+.status-indicator-cell {
+  width: 24px;
+}
+
 /* цвет активного статуса */
 .status-active {
   background: #4CAF50;

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -15,7 +15,9 @@ import { ProviderProfileStatusDto } from '../../models/provider-profile-status.m
 })
 export class ProfileListComponent implements OnInit {
 
+  /* список колонок таблицы */
   displayed: string[] = [
+    'statusIndicator',
     'status',
     'providerCode',
     'displayName',


### PR DESCRIPTION
## Summary
- show textual provider status and add small color indicator column
- style indicator column with fixed width

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser; tried but apt repositories are not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894f8224c74832d928bccb12b5e4822