### PR TITLE
Добавлены JavaDoc для сервисов и хранилищ валют

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/jpa/CurrencyJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/jpa/CurrencyJpaRepository.java
@@ -9,7 +9,12 @@ import java.util.Optional;
  */
 public interface CurrencyJpaRepository extends JpaRepository<CurrencyEntity, Long> {
 
+    /** Найти валюту по ISO-коду. */
     Optional<CurrencyEntity> findByCode(String code);
+
+    /** Найти валюту по имени. */
     Optional<CurrencyEntity> findByName(String name);
+
+    /** Найти валюту по стране обращения. */
     Optional<CurrencyEntity> findByCountry(String country);
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/service/CurrencyService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency/service/CurrencyService.java
@@ -9,8 +9,15 @@ import java.util.List;
  */
 public interface CurrencyService {
 
+    /** Сохранить новую валюту. */
     String createCurrency(Currency currency);
+
+    /** Обновить существующую валюту. */
     void updateCurrency(Currency currency);
+
+    /** Удалить валюту по коду. */
     void deleteCurrency(String code);
+
+    /** Вернуть все валюты. */
     List<Currency> findAll();
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/jpa/CurrencyPairJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/jpa/CurrencyPairJpaRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
  */
 public interface CurrencyPairJpaRepository extends JpaRepository<CurrencyPairEntity, Long> {
 
-
+    /** Найти валютную пару по составному коду. */
     Optional<CurrencyPairEntity> findByPairCode(String pairCode);
 
     /**

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/service/CurrencyPairService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/currency_pair/service/CurrencyPairService.java
@@ -9,8 +9,15 @@ import java.util.List;
  */
 public interface CurrencyPairService {
 
+    /** Создать валютную пару. */
     String create(CurrencyPair pair);
+
+    /** Обновить валютную пару. */
     void update(CurrencyPair pair);
+
+    /** Удалить пару по коду базовой и котируемой валют. */
     void delete(String base, String quote);
+
+    /** Вернуть все валютные пары. */
     List<CurrencyPair> findAll();
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency/catalog/CurrencyStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency/catalog/CurrencyStorage.java
@@ -10,10 +10,21 @@ import java.util.Optional;
  */
 public interface CurrencyStorage {
 
+    /** Сохранить валюту. */
     String save(Currency currency);
+
+    /** Удалить валюту по коду. */
     void deleteByCode(String code);
+
+    /** Найти валюту по коду. */
     Optional<Currency> findByCode(String code);
+
+    /** Найти валюту по имени. */
     Optional<Currency> findByName(String name);
+
+    /** Найти валюту по стране обращения. */
     Optional<Currency> findByCountry(String country);
+
+    /** Вернуть все валюты. */
     List<Currency> findAll();
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/catalog/CurrencyPairStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/currency_pair/catalog/CurrencyPairStorage.java
@@ -10,14 +10,18 @@ import java.util.Optional;
  */
 public interface CurrencyPairStorage {
 
+    /** Сохранить валютную пару. */
     String save(CurrencyPair pair);
 
+    /** Удалить пару по коду базовой и котируемой валют. */
     void delete(String base, String quote);
 
+    /** Найти пару по коду базовой и котируемой валют. */
     Optional<CurrencyPair> find(String base, String quote);
 
-    /** Существует ли хотя бы одна валютная пара, использующая данную валюту. */
+    /** Проверить, используется ли валюта в каких-либо парах. */
     boolean existsByCurrency(String currencyCode);
 
+    /** Вернуть все валютные пары. */
     List<CurrencyPair> findAll();
 }


### PR DESCRIPTION
## Summary
- дополнил методы сервисов валют и валютных пар простыми JavaDoc
- описал операции в хранилищах валют и валютных пар
- добавил пояснения к методам JPA-репозиториев валют и валютных пар

## Testing
- `mvn -q -pl backend,domain test` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6895e9c3e864832d9cd7273afa1786fa