### PR TITLE
Добавлен метод pairCode для модели валютной пары

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/fx/reference/currency_pair/model/CurrencyPair.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/fx/reference/currency_pair/model/CurrencyPair.java
@@ -8,4 +8,10 @@ public record CurrencyPair(
         String base,
         String quote,
         Integer decimal
-) {}
+) {
+
+    /** Код валютной пары, составленный из базовой и котируемой валют. */
+    public String pairCode() {
+        return base + quote;
+    }
+}


### PR DESCRIPTION
## Summary
- реализован метод `pairCode()` в модели `CurrencyPair`

## Testing
- `./mvnw -q test` *(ошибка: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6897269d0db0832db2654328e88bc085