### PR TITLE
feat(frontend): ограничить переносы в таблице профилей

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -34,3 +34,14 @@
 .status-missing {
   background: #F44336;
 }
+
+/* Таблица: содержимое ячеек в одну строку, заголовки переносятся */
+.mat-table td {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mat-table th {
+  white-space: normal;
+}


### PR DESCRIPTION
## Summary
- запретить перенос строк в ячейках таблицы профилей, разрешить перенос заголовков

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68973c87fe00832d9b660a441af95fa8