### PR TITLE
Add FX spot instrument entities and service

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/reference/currency_pair/service/CurrencyPairServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/reference/currency_pair/service/CurrencyPairServiceImpl.java
@@ -7,6 +7,7 @@ import com.alligator.market.domain.instrument.type.fx.reference.currency_pair.ca
 import com.alligator.market.domain.instrument.type.fx.reference.currency.catalog.CurrencyStorage;
 import com.alligator.market.domain.instrument.type.fx.reference.currency_pair.model.CurrencyPair;
 import com.alligator.market.domain.instrument.type.fx.reference.currency_pair.catalog.CurrencyPairStorage;
+import com.alligator.market.backend.instrument_catalog.fx.spot.service.FxSpotInstrumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class CurrencyPairServiceImpl implements CurrencyPairService {
 
     private final CurrencyPairStorage repository;
     private final CurrencyStorage currencyStorage;
+    private final FxSpotInstrumentService fxSpotInstrumentService;
 
     @Override
     public String create(CurrencyPair currencyPair) {
@@ -45,6 +47,7 @@ public class CurrencyPairServiceImpl implements CurrencyPairService {
         });
 
         String pairCode = repository.save(currencyPair);
+        fxSpotInstrumentService.createForPair(pairCode);
         log.info("Currency pair {} saved", pairCode);
         return pairCode;
     }
@@ -67,6 +70,7 @@ public class CurrencyPairServiceImpl implements CurrencyPairService {
         repository.find(base, quote)
                 .orElseThrow(() -> new PairNotFoundException(pairCode));
 
+        fxSpotInstrumentService.deleteForPair(pairCode);
         repository.delete(base, quote);
         log.info("Currency pair {} deleted", pairCode);
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/jpa/FxSpotInstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/jpa/FxSpotInstrumentEntity.java
@@ -1,0 +1,36 @@
+package com.alligator.market.backend.instrument_catalog.fx.spot.jpa;
+
+import com.alligator.market.backend.common.jpa.BaseEntity;
+import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairEntity;
+import com.alligator.market.domain.instrument.type.fx.spot.model.ValueDateCode;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Entity инструмента FX SPOT.
+ */
+@Entity
+@Table(name = "fx_spot_instruments")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FxSpotInstrumentEntity extends BaseEntity {
+
+    /** Внутренний код инструмента. */
+    @Id
+    @Column(name = "internal_code", length = 12)
+    private String internalCode;
+
+    /** Ссылка на валютную пару. */
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "pair_code", referencedColumnName = "pair_code",
+            foreignKey = @ForeignKey(name = "fk_fx_spot_pair"))
+    private CurrencyPairEntity currencyPair;
+
+    /** Код даты расчетов. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "value_date_code", length = 4, nullable = false)
+    private ValueDateCode valueDateCode;
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/jpa/FxSpotInstrumentJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/jpa/FxSpotInstrumentJpaRepository.java
@@ -1,0 +1,12 @@
+package com.alligator.market.backend.instrument_catalog.fx.spot.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * JPA-репозиторий инструментов FX SPOT.
+ */
+public interface FxSpotInstrumentJpaRepository extends JpaRepository<FxSpotInstrumentEntity, String> {
+
+    /** Удаляет все записи по коду валютной пары. */
+    void deleteAllByCurrencyPair_PairCode(String pairCode);
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentService.java
@@ -1,0 +1,13 @@
+package com.alligator.market.backend.instrument_catalog.fx.spot.service;
+
+/**
+ * Сервис работы с инструментами FX SPOT.
+ */
+public interface FxSpotInstrumentService {
+
+    /** Создает записи для указанной валютной пары. */
+    void createForPair(String pairCode);
+
+    /** Удаляет записи для указанной валютной пары. */
+    void deleteForPair(String pairCode);
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentServiceImpl.java
@@ -1,0 +1,44 @@
+package com.alligator.market.backend.instrument_catalog.fx.spot.service;
+
+import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairEntity;
+import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairJpaRepository;
+import com.alligator.market.backend.instrument_catalog.fx.spot.jpa.FxSpotInstrumentEntity;
+import com.alligator.market.backend.instrument_catalog.fx.spot.jpa.FxSpotInstrumentJpaRepository;
+import com.alligator.market.domain.instrument.type.fx.reference.currency_pair.catalog.exeption.PairNotFoundException;
+import com.alligator.market.domain.instrument.type.fx.spot.model.ValueDateCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+
+/**
+ * Реализация сервиса инструментов FX SPOT.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FxSpotInstrumentServiceImpl implements FxSpotInstrumentService {
+
+    private final FxSpotInstrumentJpaRepository repository;
+    private final CurrencyPairJpaRepository currencyPairRepository;
+
+    @Override
+    public void createForPair(String pairCode) {
+        CurrencyPairEntity pair = currencyPairRepository.findByPairCode(pairCode)
+                .orElseThrow(() -> new PairNotFoundException(pairCode));
+        // Создаем запись для каждого значения кода даты расчетов
+        Arrays.stream(ValueDateCode.values()).forEach(code -> {
+            FxSpotInstrumentEntity entity = new FxSpotInstrumentEntity();
+            entity.setInternalCode(pairCode + "_" + code);
+            entity.setCurrencyPair(pair);
+            entity.setValueDateCode(code);
+            repository.save(entity);
+        });
+    }
+
+    @Override
+    public void deleteForPair(String pairCode) {
+        repository.deleteAllByCurrencyPair_PairCode(pairCode);
+    }
+}

--- a/backend/src/main/resources/db/migration/V8__create_fx_spot_instruments_table.sql
+++ b/backend/src/main/resources/db/migration/V8__create_fx_spot_instruments_table.sql
@@ -1,0 +1,12 @@
+-- Создает таблицу fx_spot_instruments
+CREATE TABLE fx_spot_instruments (
+    internal_code VARCHAR(12) PRIMARY KEY,
+    version BIGINT,
+    created_timestamp TIMESTAMP,
+    created_by VARCHAR(255),
+    updated_timestamp TIMESTAMP,
+    updated_by VARCHAR(255),
+    pair_code VARCHAR(6) NOT NULL,
+    value_date_code VARCHAR(4) NOT NULL,
+    CONSTRAINT fk_fx_spot_pair FOREIGN KEY (pair_code) REFERENCES currency_pair(pair_code)
+);


### PR DESCRIPTION
## Summary
- add FX spot instrument entity, repository, and service
- create and remove FX spot instruments when currency pairs change
- add migration for fx_spot_instruments table

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68973cbf9438832db713cd8a2074ecef