### PR TITLE
fix(frontend): adjust profile list table cell wrapping

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -36,12 +36,12 @@
 }
 
 /* Таблица: содержимое ячеек в одну строку, заголовки переносятся */
-.mat-table td {
+:host ::ng-deep .mat-mdc-table .mat-mdc-cell {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.mat-table th {
+:host ::ng-deep .mat-mdc-table .mat-mdc-header-cell {
   white-space: normal;
 }


### PR DESCRIPTION
## Summary
- обновлены стили таблицы в профиле провайдера для поддержки компонентов MDC и предотвращения переноса данных в строках

## Testing
- `npm run build -- --configuration development`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(ошибка: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68973f204d0c832d8317c79c8ff655a6