### PR TITLE
feat(fx-spot): add storage abstraction

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/adapter/FxSpotStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/adapter/FxSpotStorageAdapter.java
@@ -1,0 +1,51 @@
+package com.alligator.market.backend.instrument_catalog.fx.spot.adapter;
+
+import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairEntity;
+import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairEntityMapper;
+import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairJpaRepository;
+import com.alligator.market.backend.instrument_catalog.fx.spot.jpa.FxSpotInstrumentEntity;
+import com.alligator.market.backend.instrument_catalog.fx.spot.jpa.FxSpotInstrumentJpaRepository;
+import com.alligator.market.domain.instrument.type.fx.spot.catalog.FxSpotStorage;
+import com.alligator.market.domain.instrument.type.fx.spot.model.FxSpot;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Адаптер хранилища инструментов FX SPOT на Spring Data JPA.
+ */
+@Repository
+@RequiredArgsConstructor
+public class FxSpotStorageAdapter implements FxSpotStorage {
+
+    private final FxSpotInstrumentJpaRepository jpaRepository;
+    private final CurrencyPairJpaRepository currencyPairJpaRepository;
+
+    @Override
+    public String save(FxSpot instrument) {
+        CurrencyPairEntity pair = currencyPairJpaRepository
+                .findByPairCode(instrument.currencyPair().pairCode())
+                .orElseThrow();
+
+        FxSpotInstrumentEntity entity = new FxSpotInstrumentEntity();
+        entity.setInternalCode(instrument.internalCode());
+        entity.setCurrencyPair(pair);
+        entity.setValueDateCode(instrument.valueDateCode());
+        return jpaRepository.save(entity).getInternalCode();
+    }
+
+    @Override
+    public void delete(String pairCode) {
+        jpaRepository.deleteAllByCurrencyPair_PairCode(pairCode);
+    }
+
+    @Override
+    public Optional<FxSpot> find(String internalCode) {
+        return jpaRepository.findById(internalCode)
+                .map(entity -> new FxSpot(
+                        CurrencyPairEntityMapper.toDomain(entity.getCurrencyPair()),
+                        entity.getValueDateCode()
+                ));
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentServiceImpl.java
@@ -1,10 +1,11 @@
 package com.alligator.market.backend.instrument_catalog.fx.spot.service;
 
 import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairEntity;
+import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairEntityMapper;
 import com.alligator.market.backend.instrument_catalog.fx.reference.currency_pair.jpa.CurrencyPairJpaRepository;
-import com.alligator.market.backend.instrument_catalog.fx.spot.jpa.FxSpotInstrumentEntity;
-import com.alligator.market.backend.instrument_catalog.fx.spot.jpa.FxSpotInstrumentJpaRepository;
 import com.alligator.market.domain.instrument.type.fx.reference.currency_pair.catalog.exeption.PairNotFoundException;
+import com.alligator.market.domain.instrument.type.fx.spot.catalog.FxSpotStorage;
+import com.alligator.market.domain.instrument.type.fx.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.fx.spot.model.ValueDateCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,25 +21,22 @@ import java.util.Arrays;
 @Transactional
 public class FxSpotInstrumentServiceImpl implements FxSpotInstrumentService {
 
-    private final FxSpotInstrumentJpaRepository repository;
+    private final FxSpotStorage storage;
     private final CurrencyPairJpaRepository currencyPairRepository;
 
     @Override
     public void createForPair(String pairCode) {
         CurrencyPairEntity pair = currencyPairRepository.findByPairCode(pairCode)
                 .orElseThrow(() -> new PairNotFoundException(pairCode));
-        // Создаем запись для каждого значения кода даты расчетов
-        Arrays.stream(ValueDateCode.values()).forEach(code -> {
-            FxSpotInstrumentEntity entity = new FxSpotInstrumentEntity();
-            entity.setInternalCode(pairCode + "_" + code);
-            entity.setCurrencyPair(pair);
-            entity.setValueDateCode(code);
-            repository.save(entity);
-        });
+        var currencyPair = CurrencyPairEntityMapper.toDomain(pair);
+        // Создаём модель FX SPOT для каждого значения кода даты расчётов
+        Arrays.stream(ValueDateCode.values())
+                .map(code -> new FxSpot(currencyPair, code))
+                .forEach(storage::save);
     }
 
     @Override
     public void deleteForPair(String pairCode) {
-        repository.deleteAllByCurrencyPair_PairCode(pairCode);
+        storage.delete(pairCode);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/fx/spot/catalog/FxSpotStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/fx/spot/catalog/FxSpotStorage.java
@@ -1,0 +1,20 @@
+package com.alligator.market.domain.instrument.type.fx.spot.catalog;
+
+import com.alligator.market.domain.instrument.type.fx.spot.model.FxSpot;
+
+import java.util.Optional;
+
+/**
+ * Хранилище инструментов FX SPOT.
+ */
+public interface FxSpotStorage {
+
+    /** Сохранить инструмент FX SPOT. */
+    String save(FxSpot instrument);
+
+    /** Удалить все инструменты по коду валютной пары. */
+    void delete(String pairCode);
+
+    /** Найти инструмент по внутреннему коду. */
+    Optional<FxSpot> find(String internalCode);
+}


### PR DESCRIPTION
## Summary
- add `FxSpotStorage` interface for FX spot instruments
- implement `FxSpotStorageAdapter` backed by JPA repository
- refactor `FxSpotInstrumentServiceImpl` to use `FxSpotStorage`

## Testing
- `mvn -q -pl domain,backend test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689741fff5e4832dbbbd620171cc2186