### PR TITLE
feat: add service auditor context

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/config/audit/ContextAuditorAware.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/audit/ContextAuditorAware.java
@@ -1,0 +1,21 @@
+package com.alligator.market.backend.config.audit;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+
+/**
+ * Реализация AuditorAware, использующая ServiceAuditorContext.
+ */
+@RequiredArgsConstructor
+public class ContextAuditorAware implements AuditorAware<String> {
+
+    private final ServiceAuditorContext context;
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return Optional.of(context.get().orElse("dev_admin"));
+    }
+}
+

--- a/backend/src/main/java/com/alligator/market/backend/config/audit/JpaAuditConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/audit/JpaAuditConfig.java
@@ -5,8 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import java.util.Optional;
-
 /**
  * Конфигурация JPA-аудита.
  */
@@ -14,10 +12,10 @@ import java.util.Optional;
 @EnableJpaAuditing
 public class JpaAuditConfig {
 
+    /** Провайдер аудитора на основе контекста сервиса. */
     @Bean
-    public AuditorAware<String> auditorProvider() {
-        // TODO: временное решение, в дальнейшем брать из контекста Spring Security
-        return () -> Optional.of("dev_admin");
+    public AuditorAware<String> auditorProvider(ServiceAuditorContext context) {
+        return new ContextAuditorAware(context);
     }
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/config/audit/ServiceAuditorContext.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/audit/ServiceAuditorContext.java
@@ -1,0 +1,40 @@
+package com.alligator.market.backend.config.audit;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Контекст аудита, хранящий идентификатор сервиса в ThreadLocal.
+ */
+@Component
+public class ServiceAuditorContext {
+
+    private final ThreadLocal<String> serviceId = new ThreadLocal<>();
+
+    /** Установить идентификатор сервиса для текущего потока. */
+    public void set(String serviceId) {
+        this.serviceId.set(serviceId);
+    }
+
+    /** Очистить идентификатор сервиса в текущем потоке. */
+    public void clear() {
+        serviceId.remove();
+    }
+
+    /** Получить идентификатор сервиса из текущего потока. */
+    public Optional<String> get() {
+        return Optional.ofNullable(serviceId.get());
+    }
+
+    /** Выполнить действие с указанным идентификатором сервиса. */
+    public void runWith(String serviceId, Runnable action) {
+        set(serviceId);
+        try {
+            action.run();
+        } finally {
+            clear();
+        }
+    }
+}
+

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesReconciliationAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/context_sync/ProviderProfilesReconciliationAdapter.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.provider.profile.context_sync;
 
+import com.alligator.market.backend.config.audit.ServiceAuditorContext;
 import com.alligator.market.domain.provider.context_sync.ContextDiff;
 import com.alligator.market.domain.provider.context_sync.ProviderContextScanner;
 import com.alligator.market.domain.provider.context_sync.ProviderProfilesReconciliation;
@@ -17,6 +18,7 @@ public class ProviderProfilesReconciliationAdapter {
 
     private final ProviderContextScanner contextScanner;
     private final ProviderProfileStorage profileStorage;
+    private final ServiceAuditorContext context;
 
     /** Сравнить профили провайдеров и получить расхождения в виде {@link ContextDiff}. */
     public ContextDiff compare() {
@@ -28,6 +30,6 @@ public class ProviderProfilesReconciliationAdapter {
      * информации о профилях провайдеров рыночных данных. */
     public void applyContextDiffToStorage(ContextDiff diff) {
         var domain = new ProviderProfilesReconciliation(contextScanner, profileStorage);
-        domain.applyContextDiffToStorage(diff);
+        context.runWith("provider-sync-service", () -> domain.applyContextDiffToStorage(diff));
     }
 }


### PR DESCRIPTION
## Summary
- add thread-local ServiceAuditorContext
- use ContextAuditorAware in JPA audit configuration
- wrap provider profile reconciliation with service auditor context

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68974768beb0832dbdf4c111b18e1745