### PR TITLE
feat(frontend): add footnote explanations for Bulk and Min Poll

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -43,18 +43,32 @@
         </ng-container>
 
         <ng-container matColumnDef="supportsBulkSubscription">
-          <th mat-header-cell *matHeaderCellDef>Bulk*</th>
+          <th mat-header-cell *matHeaderCellDef>
+            Bulk<sup><a href="#bulk-info">*</a></sup>
+          </th>
           <td mat-cell *matCellDef="let p">{{ p.supportsBulkSubscription }}</td>
         </ng-container>
 
         <ng-container matColumnDef="minPollPeriodMs">
-          <th mat-header-cell *matHeaderCellDef>Min Poll**, ms</th>
+          <th mat-header-cell *matHeaderCellDef>
+            Min Poll<sup><a href="#min-poll-info">**</a></sup>, ms
+          </th>
           <td mat-cell *matCellDef="let p">{{ p.minPollPeriodMs }}</td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>
         <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
       </table>
+
+      <!-- Пояснения к столбцам -->
+      <div class="table-footnotes">
+        <p id="bulk-info" class="mat-body-small">
+          <sup>*</sup> Возможность подписаться на несколько инструментов одним запросом
+        </p>
+        <p id="min-poll-info" class="mat-body-small">
+          <sup>**</sup> Минимально допустимый период опроса в миллисекундах
+        </p>
+      </div>
     </mat-card-content>
   </mat-card>
 </div>


### PR DESCRIPTION
## Summary
- add clickable footnote markers for Bulk and Min Poll columns
- explain Bulk subscriptions and Min Poll interval below the table

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689781afd3d0832d9f6fb8e5bac91f37