### PR TITLE
Запрет переносов слов в таблицах фронтенда

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -35,13 +35,11 @@
   background: #F44336;
 }
 
-/* Таблица: содержимое ячеек в одну строку, заголовки переносятся */
+/* Таблица: содержимое ячеек и заголовков в одну строку */
 :host ::ng-deep .mat-mdc-table .mat-mdc-cell {
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 :host ::ng-deep .mat-mdc-table .mat-mdc-header-cell {
-  white-space: normal;
+  white-space: nowrap;
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -3,3 +3,8 @@
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
+/* Таблицы: запрещаем перенос строк */
+table {
+  white-space: nowrap;
+}
+


### PR DESCRIPTION
## Summary
- запретили перенос строк в таблицах на уровне глобальных стилей
- убрали обрезку текста и запретили перенос заголовков в таблице профилей провайдера

## Testing
- `npm test` *(падает: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6897c1300340832dbb728c8e98a6b7c8