### PR TITLE
feat(audit): enrich auditor info with service

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/config/audit/ContextAuditorAware.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/audit/ContextAuditorAware.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.AuditorAware;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
 
 import java.util.Optional;
 
@@ -14,17 +15,36 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ContextAuditorAware implements AuditorAware<String> {
 
+    /** Имя текущего сервиса. */
     private final String serviceName;
 
+    /** Заглушка для имени пользователя. */
+    private static final String STUB_USER = "admin_dev";
+
+    /** Имя для внутренних сервисов. */
+    private static final String INTERNAL_SERVICE = "internal-service";
+
     /**
-     * Вернуть текущего аудитора из SecurityContext в виде "serviceName-by-user".
+     * Вернуть аудитора в формате "user@service".
      */
     @Override
     @NonNull
     public Optional<String> getCurrentAuditor() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String user = authentication != null ? authentication.getName() : "internal-service";
-        return Optional.of(serviceName + "-by-" + user);
+
+        String user;
+        if (authentication != null) {
+            // Имя пришло из SecurityContext
+            user = authentication.getName();
+        } else if (RequestContextHolder.getRequestAttributes() != null) {
+            // HTTP-запрос без авторизации → используем заглушку
+            user = STUB_USER;
+        } else {
+            // Внутренний сервис
+            user = INTERNAL_SERVICE;
+        }
+
+        return Optional.of(user + "@" + serviceName);
     }
 }
 

--- a/backend/src/test/java/com/alligator/market/backend/config/audit/ContextAuditorAwareTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/config/audit/ContextAuditorAwareTest.java
@@ -1,0 +1,54 @@
+package com.alligator.market.backend.config.audit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Тесты для {@link ContextAuditorAware}.
+ */
+class ContextAuditorAwareTest {
+
+    private final ContextAuditorAware auditorAware = new ContextAuditorAware("test-service");
+
+    @AfterEach
+    void cleanContext() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void returnsUserFromSecurityContext() {
+        // Устанавливаем пользователя в контекст безопасности
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("elon", "N/A")
+        );
+
+        Optional<String> auditor = auditorAware.getCurrentAuditor();
+        assertEquals("elon@test-service", auditor.orElseThrow());
+    }
+
+    @Test
+    void returnsStubUserForHttpRequest() {
+        // Создаем HTTP-запрос без авторизации
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        Optional<String> auditor = auditorAware.getCurrentAuditor();
+        assertEquals("admin_dev@test-service", auditor.orElseThrow());
+    }
+
+    @Test
+    void returnsInternalServiceWithoutRequest() {
+        Optional<String> auditor = auditorAware.getCurrentAuditor();
+        assertEquals("internal-service@test-service", auditor.orElseThrow());
+    }
+}


### PR DESCRIPTION
## Summary
- add stub-based auditor so audit fields store `user@service`
- test auditor behaviour for user, stub, and internal service contexts

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898f4eee1a8832dbc359674b4441a26