### PR TITLE
feat: enforce audit fields NOT NULL

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
@@ -26,24 +26,31 @@ import java.time.Instant;
 public abstract class BaseEntity {
 
     @Version
+    @Column(nullable = false)
     private Long version;
 
     @CreatedDate
+    @Column(updatable = false, nullable = false)
     private Instant createdTimestamp;
 
     @CreatedBy
+    @Column(updatable = false, nullable = false)
     private String createdBy;
 
     @Setter(AccessLevel.NONE) // пишем только из колбэка ниже
+    @Column(updatable = false, nullable = false)
     private String createdVia;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private Instant updatedTimestamp;
 
     @LastModifiedBy
+    @Column(nullable = false)
     private String updatedBy;
 
     @Setter(AccessLevel.NONE) // пишем только из колбэка ниже
+    @Column(nullable = false)
     private String updatedVia;
 
     /* JPA-callback: при вставке выставляем из контекста. */

--- a/backend/src/main/resources/db/migration/V1__create_currency_table.sql
+++ b/backend/src/main/resources/db/migration/V1__create_currency_table.sql
@@ -1,11 +1,11 @@
 -- Создает таблицу currency
 CREATE TABLE currency (
     id BIGSERIAL PRIMARY KEY,
-    version BIGINT,
-    created_timestamp TIMESTAMP,
-    created_by VARCHAR(255),
-    updated_timestamp TIMESTAMP,
-    updated_by VARCHAR(255),
+    version BIGINT NOT NULL,
+    created_timestamp TIMESTAMP NOT NULL,
+    created_by VARCHAR(255) NOT NULL,
+    updated_timestamp TIMESTAMP NOT NULL,
+    updated_by VARCHAR(255) NOT NULL,
     code VARCHAR(3) NOT NULL,
     name VARCHAR(50) NOT NULL,
     country VARCHAR(100) NOT NULL,

--- a/backend/src/main/resources/db/migration/V2__create_currency_pair_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_currency_pair_table.sql
@@ -1,11 +1,11 @@
 -- Создает таблицу currency_pair
 CREATE TABLE currency_pair (
     id BIGSERIAL PRIMARY KEY,
-    version BIGINT,
-    created_timestamp TIMESTAMP,
-    created_by VARCHAR(255),
-    updated_timestamp TIMESTAMP,
-    updated_by VARCHAR(255),
+    version BIGINT NOT NULL,
+    created_timestamp TIMESTAMP NOT NULL,
+    created_by VARCHAR(255) NOT NULL,
+    updated_timestamp TIMESTAMP NOT NULL,
+    updated_by VARCHAR(255) NOT NULL,
     code1 VARCHAR(3) NOT NULL,
     code2 VARCHAR(3) NOT NULL,
     pair VARCHAR(6) NOT NULL,

--- a/backend/src/main/resources/db/migration/V3__create_provider_profile_table.sql
+++ b/backend/src/main/resources/db/migration/V3__create_provider_profile_table.sql
@@ -1,11 +1,11 @@
 -- Создает таблицу provider_profile
 CREATE TABLE provider_profile (
     id BIGSERIAL PRIMARY KEY,
-    version BIGINT,
-    created_timestamp TIMESTAMP,
-    created_by VARCHAR(255),
-    updated_timestamp TIMESTAMP,
-    updated_by VARCHAR(255),
+    version BIGINT NOT NULL,
+    created_timestamp TIMESTAMP NOT NULL,
+    created_by VARCHAR(255) NOT NULL,
+    updated_timestamp TIMESTAMP NOT NULL,
+    updated_by VARCHAR(255) NOT NULL,
     status VARCHAR(10) NOT NULL,
     provider_code VARCHAR(50) NOT NULL,
     display_name VARCHAR(50) NOT NULL,

--- a/backend/src/main/resources/db/migration/V8__create_fx_spot_instruments_table.sql
+++ b/backend/src/main/resources/db/migration/V8__create_fx_spot_instruments_table.sql
@@ -1,11 +1,11 @@
 -- Создает таблицу fx_spot_instruments
 CREATE TABLE fx_spot_instruments (
     internal_code VARCHAR(12) PRIMARY KEY,
-    version BIGINT,
-    created_timestamp TIMESTAMP,
-    created_by VARCHAR(255),
-    updated_timestamp TIMESTAMP,
-    updated_by VARCHAR(255),
+    version BIGINT NOT NULL,
+    created_timestamp TIMESTAMP NOT NULL,
+    created_by VARCHAR(255) NOT NULL,
+    updated_timestamp TIMESTAMP NOT NULL,
+    updated_by VARCHAR(255) NOT NULL,
     pair_code VARCHAR(6) NOT NULL,
     value_date_code VARCHAR(4) NOT NULL,
     CONSTRAINT fk_fx_spot_pair FOREIGN KEY (pair_code) REFERENCES currency_pair(pair_code)

--- a/backend/src/main/resources/db/migration/V9__add_created_updated_via_columns.sql
+++ b/backend/src/main/resources/db/migration/V9__add_created_updated_via_columns.sql
@@ -1,9 +1,9 @@
 -- Добавляет столбцы created_via и updated_via во все таблицы
-ALTER TABLE currency ADD COLUMN created_via VARCHAR(255);
-ALTER TABLE currency ADD COLUMN updated_via VARCHAR(255);
-ALTER TABLE currency_pair ADD COLUMN created_via VARCHAR(255);
-ALTER TABLE currency_pair ADD COLUMN updated_via VARCHAR(255);
-ALTER TABLE provider_profile ADD COLUMN created_via VARCHAR(255);
-ALTER TABLE provider_profile ADD COLUMN updated_via VARCHAR(255);
-ALTER TABLE fx_spot_instruments ADD COLUMN created_via VARCHAR(255);
-ALTER TABLE fx_spot_instruments ADD COLUMN updated_via VARCHAR(255);
+ALTER TABLE currency ADD COLUMN created_via VARCHAR(255) NOT NULL;
+ALTER TABLE currency ADD COLUMN updated_via VARCHAR(255) NOT NULL;
+ALTER TABLE currency_pair ADD COLUMN created_via VARCHAR(255) NOT NULL;
+ALTER TABLE currency_pair ADD COLUMN updated_via VARCHAR(255) NOT NULL;
+ALTER TABLE provider_profile ADD COLUMN created_via VARCHAR(255) NOT NULL;
+ALTER TABLE provider_profile ADD COLUMN updated_via VARCHAR(255) NOT NULL;
+ALTER TABLE fx_spot_instruments ADD COLUMN created_via VARCHAR(255) NOT NULL;
+ALTER TABLE fx_spot_instruments ADD COLUMN updated_via VARCHAR(255) NOT NULL;


### PR DESCRIPTION
## Summary
- mark audit columns in BaseEntity as not nullable and non-updatable
- require NOT NULL for audit columns in migration scripts

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689933c03e90832db1dbd2fa26817cbf