### PR TITLE
Перевод параметра тайм‑зоны на ZoneId и тест

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/config/time/AppTimeProps.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/time/AppTimeProps.java
@@ -1,8 +1,10 @@
 package com.alligator.market.backend.config.time;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.time.ZoneId;
 
 /**
  * Настройка временной зоны.
@@ -12,6 +14,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties("app")
 public record AppTimeProps(
 
-        @NotBlank
-        String timeZone
+        /** Тайм-зона приложения. */
+        @NotNull
+        ZoneId timeZone
 ) {}

--- a/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneConfig.java
@@ -1,9 +1,10 @@
 package com.alligator.market.backend.config.time;
 
 import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.ZoneId;
 import java.util.TimeZone;
 
 /**
@@ -11,6 +12,8 @@ import java.util.TimeZone;
  */
 @Configuration
 public class TimeZoneConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(TimeZoneConfig.class);
 
     private final AppTimeProps props;
 
@@ -22,7 +25,8 @@ public class TimeZoneConfig {
     /** Устанавливает дефолтную временную зону. */
     @PostConstruct
     public void init() {
-        ZoneId zoneId = ZoneId.of(props.timeZone());
-        TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+        TimeZone.setDefault(TimeZone.getTimeZone(props.timeZone()));
+        // Логируем успешную установку зоны
+        log.info("Default time zone set to {}", props.timeZone());
     }
 }

--- a/backend/src/test/java/com/alligator/market/backend/config/time/TimeZoneConfigTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/config/time/TimeZoneConfigTest.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.config.time;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Тест конфигурации временной зоны.
+ */
+@SpringBootTest
+@TestPropertySource(properties = "app.time-zone=UTC")
+class TimeZoneConfigTest {
+
+    @Autowired
+    private AppTimeProps props;
+
+    // Проверяем, что дефолтная зона устанавливается из настроек
+    @Test
+    void setsDefaultZone() {
+        assertEquals(ZoneId.of("UTC"), props.timeZone());
+        assertEquals(ZoneId.of("UTC"), TimeZone.getDefault().toZoneId());
+    }
+}


### PR DESCRIPTION
## Summary
- использовать `ZoneId` и `@NotNull` для `app.time-zone`
- убрать `ZoneId.of` в конфигурации и логировать установку зоны
- добавить тест, проверяющий привязку свойства и установку тайм‑зоны

## Testing
- `mvn -pl backend -am test` *(ошибка: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a0e9042b4832dbf9772fe33961c49