### PR TITLE
fix: ограничить правило nowrap для таблиц

### DIFF
--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.scss
@@ -35,11 +35,7 @@
   background: #F44336;
 }
 
-/* Таблица: содержимое ячеек и заголовков в одну строку */
-:host ::ng-deep .mat-mdc-table .mat-mdc-cell {
-  white-space: nowrap;
-}
-
-:host ::ng-deep .mat-mdc-table .mat-mdc-header-cell {
-  white-space: nowrap;
+/* Горизонтальная прокрутка при переполнении */
+:host ::ng-deep .mat-mdc-card-content {
+  overflow-x: auto;
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -3,8 +3,8 @@
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
-/* Таблицы: запрещаем перенос строк */
-table {
+/* Таблицы без переноса строк */
+table.no-wrap {
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- ограничено глобальное правило `white-space: nowrap` для таблиц, теперь оно действует только для `.no-wrap`
- удалены `white-space: nowrap` в профиле провайдера и добавлена горизонтальная прокрутка для содержимого карточки

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (не найден бинарник ChromeHeadless)


------
https://chatgpt.com/codex/tasks/task_e_689a1251fde4832db64100c86684fe64