### PR TITLE
Централизация настройки временной зоны

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneConfig.java
@@ -1,14 +1,19 @@
 package com.alligator.market.backend.config.time;
 
 import jakarta.annotation.PostConstruct;
+import org.hibernate.cfg.AvailableSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.TimeZone;
 
 /**
  * Конфигурация времени в приложении.
+ * Настраивает временную зону для системы, Jackson и Hibernate.
  */
 @Configuration
 public class TimeZoneConfig {
@@ -27,5 +32,17 @@ public class TimeZoneConfig {
     public void init() {
         TimeZone.setDefault(TimeZone.getTimeZone(props.timeZone()));
         log.info("Default time zone set to {}", props.timeZone());
+    }
+
+    /** Настраивает временную зону для сериализации JSON. */
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jacksonTimeZoneCustomizer() {
+        return builder -> builder.timeZone(TimeZone.getTimeZone(props.timeZone()));
+    }
+
+    /** Настраивает временную зону для Hibernate. */
+    @Bean
+    public HibernatePropertiesCustomizer hibernateTimeZoneCustomizer() {
+        return properties -> properties.put(AvailableSettings.JDBC_TIME_ZONE, props.timeZone());
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -41,5 +41,3 @@ provider.connection-config.twelve-free.api-key=2b8e2659372340d5b922cd6b8d6d2cb2
 # TIME ZONE
 # ===============================
 app.time-zone=Europe/Moscow
-spring.jackson.time-zone=${app.time-zone}
-spring.jpa.properties.hibernate.jdbc.time_zone=${app.time-zone}


### PR DESCRIPTION
## Summary
- Настроена единая точка установки временной зоны через `app.time-zone`
- Добавлены кастомизаторы Jackson и Hibernate для использования временной зоны из настроек приложения

## Testing
- `mvn -q -pl backend test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a3f7551d8832d8a13d463cd0989ad