### PR TITLE
Добавлен просмотр FX SPOT инструментов

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/adapter/FxSpotInstrumentStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/adapter/FxSpotInstrumentStorageAdapter.java
@@ -12,6 +12,7 @@ import com.alligator.market.backend.config.audit.AuditContextHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -58,5 +59,15 @@ public class FxSpotInstrumentStorageAdapter implements FxSpotInstrumentStorage {
                         CurrencyPairEntityMapper.toDomain(entity.getCurrencyPair()),
                         entity.getValueDateCode()
                 ));
+    }
+
+    @Override
+    public List<FxSpot> findAll() {
+        return jpaRepository.findAll().stream()
+                .map(entity -> new FxSpot(
+                        CurrencyPairEntityMapper.toDomain(entity.getCurrencyPair()),
+                        entity.getValueDateCode()
+                ))
+                .toList();
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentService.java
@@ -1,5 +1,9 @@
 package com.alligator.market.backend.instrument_catalog.fx.spot.service;
 
+import com.alligator.market.domain.instrument.type.fx.spot.model.FxSpot;
+
+import java.util.List;
+
 /**
  * Сервис работы с инструментами FX SPOT.
  */
@@ -10,4 +14,7 @@ public interface FxSpotInstrumentService {
 
     /** Удаляет записи для указанной валютной пары. */
     void deleteForPair(String pairCode);
+
+    /** Вернуть все инструменты. */
+    List<FxSpot> findAll();
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/service/FxSpotInstrumentServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Реализация сервиса инструментов FX SPOT.
@@ -43,5 +44,13 @@ public class FxSpotInstrumentServiceImpl implements FxSpotInstrumentService {
     public void deleteForPair(String pairCode) {
         storage.delete(pairCode);
         log.info("FX Spot instruments for pair {} deleted", pairCode);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FxSpot> findAll() {
+        List<FxSpot> result = storage.findAll();
+        log.debug("Found {} FX Spot instruments", result.size());
+        return result;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/web/FxSpotController.java
@@ -1,0 +1,43 @@
+package com.alligator.market.backend.instrument_catalog.fx.spot.web;
+
+import com.alligator.market.backend.common.web.ApiResponse;
+import com.alligator.market.backend.common.web.ResponseEntityFactory;
+import com.alligator.market.backend.instrument_catalog.fx.spot.service.FxSpotInstrumentService;
+import com.alligator.market.backend.instrument_catalog.fx.spot.web.dto.FxSpotDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST-контроллер инструментов FX SPOT.
+ */
+@RestController
+@RequestMapping("/api/v1/fx-spots")
+@RequiredArgsConstructor
+@Slf4j
+public class FxSpotController {
+
+    private final FxSpotInstrumentService service;
+
+    /** Вернуть все инструменты FX SPOT. */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FxSpotDto>>> getAll() {
+
+        // Извлекаем сервисом список инструментов и преобразуем к DTO
+        List<FxSpotDto> dtoList = service.findAll()
+                .stream()
+                .map(s -> new FxSpotDto(
+                        s.internalCode(),
+                        s.currencyPair().pairCode(),
+                        s.valueDateCode()
+                ))
+                .toList();
+
+        return ResponseEntityFactory.ok(dtoList);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/web/dto/FxSpotDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument_catalog/fx/spot/web/dto/FxSpotDto.java
@@ -1,0 +1,22 @@
+package com.alligator.market.backend.instrument_catalog.fx.spot.web.dto;
+
+import com.alligator.market.domain.instrument.type.fx.spot.model.ValueDateCode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * DTO инструмента FX SPOT.
+ */
+public record FxSpotDto(
+
+        @NotBlank
+        String internalCode,
+
+        @NotBlank
+        @Pattern(regexp = "^[A-Z]{6}$")
+        String pairCode,
+
+        @NotNull
+        ValueDateCode valueDateCode
+) {}

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/fx/spot/catalog/FxSpotInstrumentStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/fx/spot/catalog/FxSpotInstrumentStorage.java
@@ -2,6 +2,7 @@ package com.alligator.market.domain.instrument.type.fx.spot.catalog;
 
 import com.alligator.market.domain.instrument.type.fx.spot.model.FxSpot;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,4 +18,7 @@ public interface FxSpotInstrumentStorage {
 
     /** Найти инструмент по внутреннему коду. */
     Optional<FxSpot> find(String internalCode);
+
+    /** Вернуть все инструменты. */
+    List<FxSpot> findAll();
 }

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,6 +3,7 @@
   <button mat-button routerLink="/">Home</button>
   <button mat-button routerLink="/currencies">Currencies</button>
   <button mat-button routerLink="/pairs">Currency Pairs</button>
+  <button mat-button routerLink="/fx-spots">FX Spots</button>
   <button mat-button routerLink="/providers">Providers</button>
 </mat-toolbar>
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,11 @@ export const routes: Routes = [
       import('./features/currency_pair/pair.module').then(m => m.PairModule)
   },
   {
+    path: 'fx-spots',
+    loadChildren: () =>
+      import('./features/fx_spot/fx-spot.module').then(m => m.FxSpotModule)
+  },
+  {
     path: 'providers',
     loadChildren: () =>
       import('./features/provider_profile/provider-profile.module')

--- a/frontend/src/app/features/fx_spot/fx-spot-routing.module.ts
+++ b/frontend/src/app/features/fx_spot/fx-spot-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/fx-spot-list/fx-spot-list.component')
+        .then(c => c.FxSpotListComponent)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class FxSpotRoutingModule { }

--- a/frontend/src/app/features/fx_spot/fx-spot.module.ts
+++ b/frontend/src/app/features/fx_spot/fx-spot.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { FxSpotRoutingModule } from './fx-spot-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    FxSpotRoutingModule,
+  ]
+})
+export class FxSpotModule { }

--- a/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
@@ -1,0 +1,9 @@
+/** DTO инструмента FX SPOT аналогичный backend. */
+export interface FxSpotDto {
+  /* Внутренний код инструмента */
+  internalCode: string;
+  /* Код валютной пары */
+  pairCode: string;
+  /* Код даты расчётов */
+  valueDateCode: string;
+}

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.html
@@ -1,0 +1,23 @@
+<div class="center-box">
+  <mat-card>
+    <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+      <ng-container matColumnDef="internalCode">
+        <th mat-header-cell *matHeaderCellDef>Internal</th>
+        <td mat-cell *matCellDef="let s">{{s.internalCode}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="pairCode">
+        <th mat-header-cell *matHeaderCellDef>Pair</th>
+        <td mat-cell *matCellDef="let s">{{s.pairCode}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="valueDateCode">
+        <th mat-header-cell *matHeaderCellDef>Value date</th>
+        <td mat-cell *matCellDef="let s">{{s.valueDateCode}}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+    </table>
+  </mat-card>
+</div>

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.scss
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.scss
@@ -1,0 +1,12 @@
+.center-box {
+  max-width: 960px;
+  margin: 32px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 0 16px;
+}
+
+:host ::ng-deep .mat-mdc-card-content {
+  overflow-x: auto;
+}

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatCardModule } from '@angular/material/card';
+import { FxSpotService } from '../../services/fx-spot.service';
+import { FxSpotDto } from '../../models/fx-spot.model';
+
+@Component({
+  selector: 'app-fx-spot-list',
+  standalone: true,
+  imports: [CommonModule, MatTableModule, MatCardModule],
+  templateUrl: './fx-spot-list.component.html',
+  styleUrl: './fx-spot-list.component.scss'
+})
+export class FxSpotListComponent implements OnInit {
+
+  /* список колонок таблицы */
+  displayed: string[] = ['internalCode', 'pairCode', 'valueDateCode'];
+  dataSource = new MatTableDataSource<FxSpotDto>([]);
+
+  constructor(private readonly service: FxSpotService) {}
+
+  /* загрузка списка при открытии страницы */
+  ngOnInit(): void {
+    this.service.list().subscribe({
+      next: list => this.dataSource.data = list,
+      error: err => console.error(err)
+    });
+  }
+}

--- a/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
+++ b/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { ApiResponse } from '../../../shared/api-response.model';
+import { FxSpotDto } from '../models/fx-spot.model';
+
+/* Сервис для чтения инструментов FX SPOT */
+@Injectable({
+  providedIn: 'root'
+})
+export class FxSpotService {
+
+  constructor(private http: HttpClient) { }
+
+  /* Базовый URL (через proxy уйдёт на Spring) */
+  private readonly baseUrl = '/api/v1/fx-spots';
+
+  /* Получить список всех инструментов FX SPOT */
+  list(): Observable<FxSpotDto[]> {
+    return this.http
+      .get<ApiResponse<FxSpotDto[]>>(this.baseUrl)
+      .pipe(map(res => res.data));
+  }
+}


### PR DESCRIPTION
## Summary
- добавить REST-контроллер и сервис для чтения FX SPOT инструментов
- подключить страницу с таблицей FX SPOT во frontend

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*
- `npm test --prefix frontend -- --watch=false` *(failed: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a61a9c2d4832db62d221a1d8d53e8