### PR TITLE
feat(frontend): add global material table styles

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -3,8 +3,15 @@
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
-/* Таблицы без переноса строк */
-table.no-wrap {
+/* Запрещаем перенос строк в ячейках Angular Material */
+.mat-header-cell,
+.mat-cell {
   white-space: nowrap;
+}
+
+/* Разрешаем прокрутку таблиц по горизонтали */
+.mat-table {
+  overflow-x: auto;
+  display: block;
 }
 


### PR DESCRIPTION
## Summary
- remove unused `table.no-wrap` styles
- add global Angular Material table styles to prevent text wrapping and enable horizontal scrolling

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689a6647ad54832db84038b03fc0c11c