### PR TITLE
fix(frontend): disable wrapping in material table cells

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -5,12 +5,15 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
 /* Запрещаем перенос строк в ячейках Angular Material */
 .mat-header-cell,
-.mat-cell {
+.mat-cell,
+.mat-mdc-header-cell,
+.mat-mdc-cell {
   white-space: nowrap;
 }
 
 /* Разрешаем прокрутку таблиц по горизонтали */
-.mat-table {
+.mat-table,
+.mat-mdc-table {
   overflow-x: auto;
   display: block;
 }


### PR DESCRIPTION
## Summary
- keep Angular Material table headers and cells on single line by default
- enable horizontal scrolling for MDC-based tables

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a6acd3d24832dbedf8f7076ec76ad