### PR TITLE
feat(fx-spot): добавить заголовок над таблицей

### DIFF
--- a/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.html
@@ -1,23 +1,29 @@
 <div class="center-box">
+  <!-- список инструментов FX Spot -->
   <mat-card>
-    <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
-      <ng-container matColumnDef="internalCode">
-        <th mat-header-cell *matHeaderCellDef>Instrument Code</th>
-        <td mat-cell *matCellDef="let s">{{s.internalCode}}</td>
-      </ng-container>
+    <mat-card-header>
+      <mat-card-title>FX Spot List</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+        <ng-container matColumnDef="internalCode">
+          <th mat-header-cell *matHeaderCellDef>Instrument Code</th>
+          <td mat-cell *matCellDef="let s">{{s.internalCode}}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="pairCode">
-        <th mat-header-cell *matHeaderCellDef>Currency Pair</th>
-        <td mat-cell *matCellDef="let s">{{s.pairCode}}</td>
-      </ng-container>
+        <ng-container matColumnDef="pairCode">
+          <th mat-header-cell *matHeaderCellDef>Currency Pair</th>
+          <td mat-cell *matCellDef="let s">{{s.pairCode}}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="valueDateCode">
-        <th mat-header-cell *matHeaderCellDef>Value date</th>
-        <td mat-cell *matCellDef="let s">{{s.valueDateCode}}</td>
-      </ng-container>
+        <ng-container matColumnDef="valueDateCode">
+          <th mat-header-cell *matHeaderCellDef>Value date</th>
+          <td mat-cell *matCellDef="let s">{{s.valueDateCode}}</td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayed"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
-    </table>
+        <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+      </table>
+    </mat-card-content>
   </mat-card>
 </div>


### PR DESCRIPTION
## Summary
- добавить мат-заголовок для таблицы FX Spot
- обернуть таблицу в `mat-card-content`

## Testing
- `npm test --prefix frontend -- --watch=false --browsers=ChromeHeadless` *(не удалось запустить: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a6be80e34832da9e05eb582afa3d7