### PR TITLE
feat(frontend): add fx spot instruments heading

### DIFF
--- a/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-list/fx-spot-list.component.html
@@ -1,4 +1,7 @@
 <div class="center-box">
+
+  <h1 class="mat-headline-4">FX Spot Instruments</h1>
+
   <!-- список инструментов FX Spot -->
   <mat-card>
     <mat-card-header>


### PR DESCRIPTION
## Summary
- add heading for FX Spot instruments page

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_689a71383b80832da7d3ad86b67b07c3