### PR TITLE
feat: учёт временной зоны в аудите

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.Instant;
+import java.time.OffsetDateTime;
 
 /**
  * Родительский класс для всех entity в проекте.
@@ -31,7 +31,7 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false, nullable = false)
-    private Instant createdTimestamp;
+    private OffsetDateTime createdTimestamp;
 
     @CreatedBy
     @Column(updatable = false, nullable = false)
@@ -43,7 +43,7 @@ public abstract class BaseEntity {
 
     @LastModifiedDate
     @Column(nullable = false)
-    private Instant updatedTimestamp;
+    private OffsetDateTime updatedTimestamp;
 
     @LastModifiedBy
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/config/audit/AuditConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/audit/AuditConfig.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  *  Конфигурация аудита: включает JPA Auditing и берёт актора из AuditContextHolder.
  */
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "timeZoneDateTimeProvider")
 public class AuditConfig {
 
     /** Поставщик для @CreatedBy/@LastModifiedBy. */

--- a/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneDateTimeProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneDateTimeProvider.java
@@ -1,0 +1,27 @@
+package com.alligator.market.backend.config.time;
+
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.Optional;
+
+/**
+ * Поставщик текущего времени с учётом настроенной временной зоны.
+ */
+@Component
+public class TimeZoneDateTimeProvider implements DateTimeProvider {
+
+    private final AppTimeProps props;
+
+    // Конструктор
+    public TimeZoneDateTimeProvider(AppTimeProps props) {
+        this.props = props;
+    }
+
+    @Override
+    public Optional<TemporalAccessor> getNow() {
+        return Optional.of(OffsetDateTime.now(props.timeZone()));
+    }
+}


### PR DESCRIPTION
## Summary
- добавить TimeZoneDateTimeProvider для получения времени с оффсетом
- подключить TimeZoneDateTimeProvider в JPA-аудите
- хранить createdTimestamp/updatedTimestamp как OffsetDateTime

## Testing
- `./mvnw -q -pl backend test` *(fail: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689b23d7cdb8832d9c08ae64da6dbb35