### PR TITLE
fix: use timezone in audit columns

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
@@ -29,8 +29,9 @@ public abstract class BaseEntity {
     @Column(nullable = false)
     private Long version;
 
+    /* Время создания записи. */
     @CreatedDate
-    @Column(updatable = false, nullable = false)
+    @Column(updatable = false, nullable = false, columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private OffsetDateTime createdTimestamp;
 
     @CreatedBy
@@ -41,8 +42,9 @@ public abstract class BaseEntity {
     @Column(updatable = false, nullable = false)
     private String createdVia;
 
+    /* Время последнего обновления записи. */
     @LastModifiedDate
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private OffsetDateTime updatedTimestamp;
 
     @LastModifiedBy

--- a/backend/src/main/resources/db/migration/V2__audit_timestamp_timezone.sql
+++ b/backend/src/main/resources/db/migration/V2__audit_timestamp_timezone.sql
@@ -1,0 +1,16 @@
+-- Исправляем временные зоны в колонках аудита.
+ALTER TABLE currency
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITH TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITH TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE currency_pair
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITH TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITH TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE fx_spot_instruments
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITH TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITH TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE provider_profile
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITH TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITH TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';


### PR DESCRIPTION
## Summary
- ensure audit timestamps use TIMESTAMP WITH TIME ZONE
- adjust BaseEntity audit fields to explicit timezone-aware columns

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b33e31580832da47dbe1bb193e76b