### PR TITLE
refactor: заменить timestamp на Instant

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
@@ -12,8 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.Instant;
 
 /** Handler котировок FX-спот для TwelveData (free). */
 public class TwelveFreeFxSpotHandler implements InstrumentHandler {
@@ -72,7 +71,7 @@ public class TwelveFreeFxSpotHandler implements InstrumentHandler {
                 instrumentInternalCode,
                 price,
                 price,
-                OffsetDateTime.now(ZoneOffset.UTC), // Время котировки в UTC
+                Instant.now(), // Время котировки в UTC
                 providerCode
         );
     }

--- a/domain/src/main/avro/QuoteTickAvro.avsc
+++ b/domain/src/main/avro/QuoteTickAvro.avsc
@@ -6,7 +6,7 @@
     { "name": "instrumentCode", "type": "string" },
     { "name": "bid", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
     { "name": "ask", "type": { "type": "bytes", "logicalType": "decimal", "precision": 18, "scale": 6 } },
-    { "name": "timestamp", "type": "string" },
+    { "name": "timestamp", "type": { "type": "long", "logicalType": "timestamp-millis" } },
     { "name": "providerCode", "type": "string" }
   ]
 }

--- a/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
@@ -5,7 +5,7 @@ import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 /**
  * Глобальная модель тика котировки для валютной пары.
@@ -19,6 +19,6 @@ public record QuoteTick(
         String instrumentCode,
         BigDecimal bid,
         BigDecimal ask,
-        OffsetDateTime timestamp,
+        Instant timestamp,
         String providerCode
 ) {}


### PR DESCRIPTION
## Summary
- use `Instant` for quote tick time
- serialize tick time as `timestamp-millis` in Avro schema
- provide UTC quote time via `Instant.now`

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b527fcdd8832d9acda188d770bb8b