### PR TITLE
refactor(jpa): use Instant for audit timestamps

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/jpa/BaseEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 /**
  * Родительский класс для всех entity в проекте.
@@ -32,7 +32,7 @@ public abstract class BaseEntity {
     /* Время создания записи. */
     @CreatedDate
     @Column(updatable = false, nullable = false, columnDefinition = "TIMESTAMP WITH TIME ZONE")
-    private OffsetDateTime createdTimestamp;
+    private Instant createdTimestamp;
 
     @CreatedBy
     @Column(updatable = false, nullable = false)
@@ -45,7 +45,7 @@ public abstract class BaseEntity {
     /* Время последнего обновления записи. */
     @LastModifiedDate
     @Column(nullable = false, columnDefinition = "TIMESTAMP WITH TIME ZONE")
-    private OffsetDateTime updatedTimestamp;
+    private Instant updatedTimestamp;
 
     @LastModifiedBy
     @Column(nullable = false)

--- a/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneDateTimeProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneDateTimeProvider.java
@@ -3,8 +3,7 @@ package com.alligator.market.backend.config.time;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.stereotype.Component;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.Instant;
 import java.time.temporal.TemporalAccessor;
 import java.util.Optional;
 
@@ -16,6 +15,7 @@ public class TimeZoneDateTimeProvider implements DateTimeProvider {
 
     @Override
     public Optional<TemporalAccessor> getNow() {
-        return Optional.of(OffsetDateTime.now(ZoneOffset.UTC));
+        // Instant всегда в UTC
+        return Optional.of(Instant.now());
     }
 }


### PR DESCRIPTION
## Summary
- replace OffsetDateTime with Instant in BaseEntity audit fields
- return Instant from TimeZoneDateTimeProvider

## Testing
- `./mvnw -q -pl backend -am test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689b52825358832dae62ce79a25ba8ae