### PR TITLE
feat: revert audit timestamps timezone

### DIFF
--- a/backend/src/main/resources/db/migration/V3__audit_timestamp_remove_timezone.sql
+++ b/backend/src/main/resources/db/migration/V3__audit_timestamp_remove_timezone.sql
@@ -1,0 +1,16 @@
+-- Возвращаем типы аудита к TIMESTAMP без указания часового пояса.
+ALTER TABLE currency
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE currency_pair
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE fx_outright_instruments
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE provider_profile
+    ALTER COLUMN created_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING created_timestamp AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_timestamp TYPE TIMESTAMP WITHOUT TIME ZONE USING updated_timestamp AT TIME ZONE 'UTC';


### PR DESCRIPTION
## Summary
- add Flyway migration to change audit columns back to TIMESTAMP

## Testing
- `./mvnw -pl backend -q flyway:clean flyway:migrate` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689b59a897ec832dadd0ad237200a114