### PR TITLE
Переименование внешнего ключа профиля провайдера

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntity.java
@@ -52,7 +52,7 @@ public class ProviderProfileEntity extends BaseEntity {
             joinColumns = @JoinColumn(
                     name = "provider_id",
                     referencedColumnName = "id",
-                    foreignKey = @ForeignKey(name = "fk_provider_instrument_type_provider")
+                    foreignKey = @ForeignKey(name = "fk_provider_profile_instrument_type_provider_profile")
             )
     )
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -128,8 +128,8 @@ CREATE TABLE IF NOT EXISTS provider_profile_instrument_type (
 -- Связь типов инструментов с профилем провайдера
 DO $$
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_provider_instrument_type_provider') THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_provider_profile_instrument_type_provider_profile') THEN
         ALTER TABLE provider_profile_instrument_type
-            ADD CONSTRAINT fk_provider_instrument_type_provider FOREIGN KEY (provider_id) REFERENCES provider_profile(id);
+            ADD CONSTRAINT fk_provider_profile_instrument_type_provider_profile FOREIGN KEY (provider_id) REFERENCES provider_profile(id);
     END IF;
 END $$;

--- a/backend/src/main/resources/db/migration/V4__rename_provider_profile_instrument_type_fk.sql
+++ b/backend/src/main/resources/db/migration/V4__rename_provider_profile_instrument_type_fk.sql
@@ -1,0 +1,8 @@
+-- Переименование внешнего ключа типов инструментов провайдера
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_provider_instrument_type_provider') THEN
+        ALTER TABLE provider_profile_instrument_type
+            RENAME CONSTRAINT fk_provider_instrument_type_provider TO fk_provider_profile_instrument_type_provider_profile;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- rename FK for provider profile instrument types to `fk_provider_profile_instrument_type_provider_profile`
- add migration to rename existing FK

## Testing
- `./mvnw -q test` *(failed: wget failed to fetch Maven, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dcfb56744832d9200f715f369fce3