### PR TITLE
Генерация кода для FxOutrightEntity через JPA-колбэк

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
@@ -42,4 +42,12 @@ public class FxOutrightEntity extends InstrumentEntity {
     @Min(0)
     @Max(10)
     private Integer quoteDecimal;
+
+    /* JPA-callback: генерируем внутренний код инструмента. */
+    @PrePersist
+    @PreUpdate
+    protected void __onGenerateCode() {
+        String code = baseCurrency.getCode() + quoteCurrency.getCode() + "_" + valueDateCode;
+        setCode(code);
+    }
 }

--- a/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntityTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntityTest.java
@@ -1,0 +1,30 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.jpa;
+
+import com.alligator.market.backend.instrument.type.forex.outright.reference.currency.catalog.jpa.CurrencyEntity;
+import com.alligator.market.domain.instrument.type.forex.outright.model.ValueDateCode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Модульный тест для {@link FxOutrightEntity}.
+ */
+class FxOutrightEntityTest {
+
+    @Test
+    void shouldGenerateCodeLikeDomainModel() {
+        CurrencyEntity base = new CurrencyEntity();
+        base.setCode("EUR");
+        CurrencyEntity quote = new CurrencyEntity();
+        quote.setCode("USD");
+
+        FxOutrightEntity entity = new FxOutrightEntity();
+        entity.setBaseCurrency(base);
+        entity.setQuoteCurrency(quote);
+        entity.setValueDateCode(ValueDateCode.TOM);
+
+        entity.__onGenerateCode();
+
+        assertEquals("EURUSD_TOM", entity.getCode());
+    }
+}


### PR DESCRIPTION
## Summary
- генерируем внутренний код инструмента в FxOutrightEntity через JPA-колбэк
- добавлен модульный тест на формирование кода

## Testing
- `mvn -q -pl backend -am test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dffb26110832db743a0f2a2fa95ea