### PR TITLE
Добавлена проверка различия валют для FX_OUTRIGHT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
@@ -47,10 +47,14 @@ public class FxOutrightEntity extends InstrumentEntity {
 
     /**
      * JPA-callback код перед вставкой.
-     * Добавляет тип инструмента и генерирует код инструмента.
+     * Добавляет тип инструмента, проверяет валюты и генерирует код инструмента.
      */
     @Override
     protected void onPrePersist() {
+        // Проверяем, что базовая и котируемая валюты различаются
+        if (baseCurrency.getCode().equals(quoteCurrency.getCode())) {
+            throw new IllegalArgumentException("Base and quote currencies must be different");
+        }
         setInstrumentType(InstrumentType.FX_OUTRIGHT);
         __generateInstrumentCode();
     }


### PR DESCRIPTION
## Summary
- added validation in FxOutrightEntity to ensure base and quote currencies differ

## Testing
- `mvn -pl backend test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689e98866ac0832da9d8c5f0374efcd9