### PR TITLE
Переименовано поле валюты в decimalDigits

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
@@ -49,8 +49,8 @@ public class CurrencyEntity extends BaseEntity {
     private String country;
 
     /** Кол-во знаков после запятой для денежных сумм. */
-    @Column(name = "decimal", nullable = false)
+    @Column(name = "decimal_digits", nullable = false)
     @Min(0)
     @Max(10)
-    private Integer decimal;
+    private Integer decimalDigits;
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntityMapper.java
@@ -16,7 +16,7 @@ public final class CurrencyEntityMapper {
                 entity.getCode(),
                 entity.getName(),
                 entity.getCountry(),
-                entity.getDecimal()
+                entity.getDecimalDigits()
         );
     }
 
@@ -25,7 +25,7 @@ public final class CurrencyEntityMapper {
         entity.setCode(currency.code());
         entity.setName(currency.name());
         entity.setCountry(currency.country());
-        entity.setDecimal(currency.decimal());
+        entity.setDecimalDigits(currency.decimalDigits());
     }
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/web/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/web/CurrencyController.java
@@ -95,7 +95,7 @@ public class CurrencyController {
                         c.code(),
                         c.name(),
                         c.country(),
-                        c.decimal()
+                        c.decimalDigits()
                 ))
                 .toList();
 

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS currency (
     code VARCHAR(3) NOT NULL,
     name VARCHAR(50) NOT NULL,
     country VARCHAR(100) NOT NULL,
-    decimal INTEGER NOT NULL,
+    decimal_digits INTEGER NOT NULL,
     version BIGINT NOT NULL,
     created_timestamp TIMESTAMP WITHOUT TIME ZONE NOT NULL,
     created_by VARCHAR(255) NOT NULL,

--- a/backend/src/main/resources/db/migration/V5__rename_currency_decimal_column.sql
+++ b/backend/src/main/resources/db/migration/V5__rename_currency_decimal_column.sql
@@ -1,0 +1,3 @@
+-- Переименование колонки количества знаков после запятой.
+ALTER TABLE currency
+    RENAME COLUMN decimal TO decimal_digits;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/reference/currency/model/Currency.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/reference/currency/model/Currency.java
@@ -8,5 +8,5 @@ public record Currency(
         String code,
         String name,
         String country,
-        Integer decimal
+        Integer decimalDigits
 ) {}


### PR DESCRIPTION
## Summary
- переименовано поле `decimal` в `decimalDigits`
- обновлены мапперы и контроллер валют
- добавлена миграция переименования колонки

## Testing
- `mvn -q test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_689e9a2e2680832d8a86e24fe9cca04d