### PR TITLE
Добавлен EqualsAndHashCode для CurrencyEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,9 +26,11 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CurrencyEntity extends BaseEntity {
 
     /** Суррогатный PK. */
+    @EqualsAndHashCode.Include
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")


### PR DESCRIPTION
## Summary
- добавить EqualsAndHashCode для CurrencyEntity и включить id в сравнение

## Testing
- `mvn -q -DskipTests package` *(failed: Could not resolve parent POM)*
- `mvn -q -o test` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689e9a32f410832db7f3db4f00fe69b4