### PR TITLE
Убрано ограничение уникальности страны валюты

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/adapter/CurrencyStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/adapter/CurrencyStorageAdapter.java
@@ -45,11 +45,6 @@ public class CurrencyStorageAdapter implements CurrencyStorage {
     }
 
     @Override
-    public Optional<Currency> findByCountry(String country) {
-        return jpaRepository.findByCountry(country).map(CurrencyEntityMapper::toDomain);
-    }
-
-    @Override
     public List<Currency> findAll() {
         return jpaRepository.findAll(Sort.by("code")).stream()
                 .map(CurrencyEntityMapper::toDomain)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
@@ -18,8 +18,7 @@ import lombok.Setter;
         name = "currency",
         uniqueConstraints = {
                 @UniqueConstraint(name = "uq_currency_code", columnNames = "code"),
-                @UniqueConstraint(name = "uq_currency_name", columnNames = "name"),
-                @UniqueConstraint(name = "uq_currency_country", columnNames = "country")
+                @UniqueConstraint(name = "uq_currency_name", columnNames = "name")
         }
 )
 @Getter

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyJpaRepository.java
@@ -15,6 +15,4 @@ public interface CurrencyJpaRepository extends JpaRepository<CurrencyEntity, Lon
     /** Найти валюту по имени. */
     Optional<CurrencyEntity> findByName(String name);
 
-    /** Найти валюту по стране обращения. */
-    Optional<CurrencyEntity> findByCountry(String country);
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/service/CurrencyServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/service/CurrencyServiceImpl.java
@@ -34,10 +34,6 @@ public class CurrencyServiceImpl implements CurrencyService {
         storage.findByName(currency.name()).ifPresent(c -> {
             throw new DuplicateCurrencyException("name", currency.name());
         });
-        storage.findByCountry(currency.country()).ifPresent(c -> {
-            throw new DuplicateCurrencyException("country", currency.country());
-        });
-
         String code = storage.save(currency);
         log.info("Currency {} saved", code);
         return code;
@@ -56,12 +52,6 @@ public class CurrencyServiceImpl implements CurrencyService {
                 throw new DuplicateCurrencyException("name", currency.name());
             }
         });
-        storage.findByCountry(currency.country()).ifPresent(c -> {
-            if (!c.code().equals(currency.code())) {
-                throw new DuplicateCurrencyException("country", currency.country());
-            }
-        });
-
         storage.save(currency);
         log.info("Currency {} updated", currency.code());
     }

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -31,9 +31,6 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'uq_currency_name') THEN
         ALTER TABLE currency ADD CONSTRAINT uq_currency_name UNIQUE (name);
     END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'uq_currency_country') THEN
-        ALTER TABLE currency ADD CONSTRAINT uq_currency_country UNIQUE (country);
-    END IF;
 END $$;
 
 -- =============================

--- a/backend/src/main/resources/db/migration/V5__drop_currency_country_unique.sql
+++ b/backend/src/main/resources/db/migration/V5__drop_currency_country_unique.sql
@@ -1,0 +1,7 @@
+-- Удаляем уникальное ограничение на страну валюты.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'uq_currency_country') THEN
+        ALTER TABLE currency DROP CONSTRAINT uq_currency_country;
+    END IF;
+END $$;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/reference/currency/catalog/CurrencyStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/reference/currency/catalog/CurrencyStorage.java
@@ -22,9 +22,6 @@ public interface CurrencyStorage {
     /** Найти валюту по имени. */
     Optional<Currency> findByName(String name);
 
-    /** Найти валюту по стране обращения. */
-    Optional<Currency> findByCountry(String country);
-
     /** Вернуть все валюты. */
     List<Currency> findAll();
 }


### PR DESCRIPTION
## Summary
- убрано уникальное ограничение на поле country в CurrencyEntity и миграциях
- удалён метод поиска по стране и проверка на дубликаты
- добавлена миграция для удаления старого ограничения в БД

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*
- `mvn -q test` *(failed: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e9a38a034832d9fbc2f0a4eb26204