### PR TITLE
Унификация стиля entity для инструментов и валют

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/jpa/InstrumentEntity.java
@@ -5,10 +5,14 @@ import com.alligator.market.domain.instrument.model.InstrumentType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Базовая entity финансового инструмента.
+ */
 @Entity
 @Table(
         name = "instrument",
@@ -17,10 +21,12 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Inheritance(strategy = InheritanceType.JOINED)
 public abstract class InstrumentEntity extends BaseEntity {
 
     /** Суррогатный PK. */
+    @EqualsAndHashCode.Include
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,22 +29,24 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 public class FxOutrightEntity extends InstrumentEntity {
-
-
     /** ISO-4217 код базовой валюты (FK на "code" в таблице "currency"). */
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "base_currency", referencedColumnName = "code",
             foreignKey = @ForeignKey(name = "fk_fx_outright_base"), updatable = false, nullable = false)
     private CurrencyEntity baseCurrency;
 
     /** ISO-4217 код котируемой валюты (FK на "code" в таблице "currency"). */
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "quote_currency", referencedColumnName = "code",
             foreignKey = @ForeignKey(name = "fk_fx_outright_quote"), updatable = false, nullable = false)
     private CurrencyEntity quoteCurrency;
 
     /** Код даты расчетов. */
+    @NotNull
     @Enumerated(EnumType.STRING)
     @Column(name = "value_date_code", length = 4, updatable = false, nullable = false)
     private ValueDateCode valueDateCode;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -54,5 +55,6 @@ public class CurrencyEntity extends BaseEntity {
     @Column(name = "decimal_digits", nullable = false)
     @Min(0)
     @Max(10)
+    @NotNull
     private Integer decimalDigits;
 }


### PR DESCRIPTION
### Изменения
- выровнен стиль базовой InstrumentEntity, добавлено `@EqualsAndHashCode`
- FxOutrightEntity и CurrencyEntity получили единые ограничения и аннотации `@NotNull`

### Проверки
- `mvn -q test` — не выполнено: Network is unreachable

------
https://chatgpt.com/codex/tasks/task_e_689e9daa4790832d8f25ede642bb0c72