### PR TITLE
Явно отключить вызов super в equals/hashCode CurrencyEntity и InstrumentEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/jpa/InstrumentEntity.java
@@ -21,7 +21,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+// equals/hashCode без учета родителя
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @Inheritance(strategy = InheritanceType.JOINED)
 public abstract class InstrumentEntity extends BaseEntity {
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
@@ -26,7 +26,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+// equals/hashCode без учета родителя
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class CurrencyEntity extends BaseEntity {
 
     /** Суррогатный PK. */


### PR DESCRIPTION
## Summary
- disable Lombok super call in CurrencyEntity
- disable Lombok super call in InstrumentEntity

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ea04d15d0832d90ce4f3b71720c12