### PR TITLE
feat: REST для FX Outright

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
@@ -1,0 +1,60 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.adapter;
+
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.jpa.FxOutrightEntity;
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.jpa.FxOutrightEntityMapper;
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.jpa.FxOutrightJpaRepository;
+import com.alligator.market.backend.instrument.type.forex.outright.reference.currency.catalog.jpa.CurrencyEntity;
+import com.alligator.market.backend.instrument.type.forex.outright.reference.currency.catalog.jpa.CurrencyJpaRepository;
+import com.alligator.market.domain.instrument.type.forex.outright.catalog.FxOutrightStorage;
+import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
+import com.alligator.market.domain.instrument.type.forex.outright.reference.currency.catalog.exeption.CurrencyNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Адаптер хранилища FX_OUTRIGHT на Spring Data JPA.
+ */
+@Repository
+@RequiredArgsConstructor
+public class FxOutrightStorageAdapter implements FxOutrightStorage {
+
+    private final FxOutrightJpaRepository jpaRepository;
+    private final CurrencyJpaRepository currencyRepository;
+
+    @Override
+    public void save(FxOutright instrument) {
+        FxOutrightEntity entity = jpaRepository.findByInstrumentCode(instrument.code())
+                .orElseGet(FxOutrightEntity::new);
+
+        CurrencyEntity base = currencyRepository.findByCode(instrument.baseCurrency())
+                .orElseThrow(() -> new CurrencyNotFoundException(instrument.baseCurrency()));
+        CurrencyEntity quote = currencyRepository.findByCode(instrument.quoteCurrency())
+                .orElseThrow(() -> new CurrencyNotFoundException(instrument.quoteCurrency()));
+
+        FxOutrightEntityMapper.toEntity(instrument, entity, base, quote);
+        jpaRepository.save(entity);
+    }
+
+    @Override
+    public void delete(String internalCode) {
+        jpaRepository.findByInstrumentCode(internalCode)
+                .ifPresent(jpaRepository::delete);
+    }
+
+    @Override
+    public Optional<FxOutright> find(String internalCode) {
+        return jpaRepository.findByInstrumentCode(internalCode)
+                .map(FxOutrightEntityMapper::toDomain);
+    }
+
+    @Override
+    public List<FxOutright> findAll() {
+        return jpaRepository.findAll(Sort.by("instrumentCode")).stream()
+                .map(FxOutrightEntityMapper::toDomain)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntityMapper.java
@@ -1,0 +1,36 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.jpa;
+
+import com.alligator.market.backend.instrument.type.forex.outright.reference.currency.catalog.jpa.CurrencyEntity;
+import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
+
+/**
+ * Маппер между сущностью FX_OUTRIGHT и доменной моделью.
+ */
+public final class FxOutrightEntityMapper {
+
+    private FxOutrightEntityMapper() {
+    }
+
+    /** Преобразует сущность в доменную модель. */
+    public static FxOutright toDomain(FxOutrightEntity entity) {
+        return new FxOutright(
+                entity.getBaseCurrency().getCode(),
+                entity.getQuoteCurrency().getCode(),
+                entity.getQuoteDecimal(),
+                entity.getValueDateCode()
+        );
+    }
+
+    /** Заполняет сущность данными из доменной модели. */
+    public static void toEntity(
+            FxOutright model,
+            FxOutrightEntity entity,
+            CurrencyEntity baseCurrency,
+            CurrencyEntity quoteCurrency
+    ) {
+        entity.setBaseCurrency(baseCurrency);
+        entity.setQuoteCurrency(quoteCurrency);
+        entity.setQuoteDecimal(model.quoteDecimal());
+        entity.setValueDateCode(model.valueDateCode());
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightJpaRepository.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * JPA-репозиторий инструментов FX_OUTRIGHT.
+ */
+public interface FxOutrightJpaRepository extends JpaRepository<FxOutrightEntity, Long> {
+
+    /** Найти инструмент по внутреннему коду. */
+    Optional<FxOutrightEntity> findByInstrumentCode(String instrumentCode);
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightService.java
@@ -1,0 +1,20 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.service;
+
+import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
+
+import java.util.List;
+
+/**
+ * Сервис работы с инструментами FX_OUTRIGHT.
+ */
+public interface FxOutrightService {
+
+    /** Сохранить новый инструмент. */
+    String create(FxOutright instrument);
+
+    /** Удалить инструмент по коду. */
+    void delete(String code);
+
+    /** Вернуть все инструменты. */
+    List<FxOutright> findAll();
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImpl.java
@@ -1,0 +1,49 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.service;
+
+import com.alligator.market.domain.instrument.type.forex.outright.catalog.FxOutrightStorage;
+import com.alligator.market.domain.instrument.type.forex.outright.catalog.exeption.DuplicateFxOutrightException;
+import com.alligator.market.domain.instrument.type.forex.outright.catalog.exeption.FxOutrightNotFoundException;
+import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Реализация сервиса FX_OUTRIGHT.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class FxOutrightServiceImpl implements FxOutrightService {
+
+    private final FxOutrightStorage storage;
+
+    @Override
+    public String create(FxOutright instrument) {
+        storage.find(instrument.code()).ifPresent(i -> {
+            throw new DuplicateFxOutrightException(instrument.code());
+        });
+        storage.save(instrument);
+        log.info("FxOutright {} saved", instrument.code());
+        return instrument.code();
+    }
+
+    @Override
+    public void delete(String code) {
+        storage.find(code).orElseThrow(() -> new FxOutrightNotFoundException(code));
+        storage.delete(code);
+        log.info("FxOutright {} deleted", code);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FxOutright> findAll() {
+        List<FxOutright> result = storage.findAll();
+        log.debug("Found {} fx outrights", result.size());
+        return result;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/FxOutrightController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/FxOutrightController.java
@@ -1,0 +1,66 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.web;
+
+import com.alligator.market.backend.common.web.ApiResponse;
+import com.alligator.market.backend.common.web.ResponseEntityFactory;
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.service.FxOutrightService;
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.web.dto.FxOutrightDto;
+import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * REST-контроллер FX_OUTRIGHT.
+ */
+@RestController
+@RequestMapping("/api/v1/fx-outrights")
+@RequiredArgsConstructor
+@Slf4j
+public class FxOutrightController {
+
+    private final FxOutrightService service;
+
+    /** Создать инструмент. */
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid FxOutrightDto dto) {
+        FxOutright model = new FxOutright(
+                dto.baseCurrency(),
+                dto.quoteCurrency(),
+                dto.quoteDecimal(),
+                dto.valueDateCode()
+        );
+        String code = service.create(model);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{code}")
+                .buildAndExpand(code)
+                .toUri();
+        return ResponseEntityFactory.created(location, code);
+    }
+
+    /** Удалить инструмент. */
+    @DeleteMapping("/{code}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String code) {
+        service.delete(code);
+        return ResponseEntityFactory.ok(null);
+    }
+
+    /** Вернуть все инструменты. */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FxOutrightDto>>> getAll() {
+        List<FxOutrightDto> list = service.findAll().stream()
+                .map(i -> new FxOutrightDto(
+                        i.baseCurrency(),
+                        i.quoteCurrency(),
+                        i.quoteDecimal(),
+                        i.valueDateCode()
+                ))
+                .toList();
+        return ResponseEntityFactory.ok(list);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/dto/FxOutrightDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/dto/FxOutrightDto.java
@@ -1,0 +1,24 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.web.dto;
+
+import com.alligator.market.domain.instrument.type.forex.outright.model.ValueDateCode;
+import jakarta.validation.constraints.*;
+
+/**
+ * DTO инструмента FX_OUTRIGHT.
+ */
+public record FxOutrightDto(
+        @NotBlank
+        @Pattern(regexp = "^[A-Z]{3}$")
+        String baseCurrency,
+
+        @NotBlank
+        @Pattern(regexp = "^[A-Z]{3}$")
+        String quoteCurrency,
+
+        @NotNull
+        @Min(0) @Max(10)
+        Integer quoteDecimal,
+
+        @NotNull
+        ValueDateCode valueDateCode
+) {}

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/FxOutrightStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/FxOutrightStorage.java
@@ -10,8 +10,11 @@ import java.util.Optional;
  */
 public interface FxOutrightStorage {
 
-    /** Сохранить инструмент FX SPOT. */
+    /** Сохранить инструмент FX OUTRIGHT. */
     void save(FxOutright instrument);
+
+    /** Удалить инструмент по внутреннему коду. */
+    void delete(String internalCode);
 
     /** Найти инструмент по внутреннему коду. */
     Optional<FxOutright> find(String internalCode);

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/exeption/DuplicateFxOutrightException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/exeption/DuplicateFxOutrightException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.domain.instrument.type.forex.outright.catalog.exeption;
+
+/**
+ * Инструмент уже существует.
+ */
+public class DuplicateFxOutrightException extends RuntimeException {
+    public DuplicateFxOutrightException(String code) {
+        super("FxOutright '%s' already exists".formatted(code));
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/exeption/FxOutrightNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/exeption/FxOutrightNotFoundException.java
@@ -1,0 +1,12 @@
+package com.alligator.market.domain.instrument.type.forex.outright.catalog.exeption;
+
+import com.alligator.market.domain.common.exception.NotFoundException;
+
+/**
+ * Инструмент не найден.
+ */
+public class FxOutrightNotFoundException extends NotFoundException {
+    public FxOutrightNotFoundException(String code) {
+        super("FxOutright '%s' not found".formatted(code));
+    }
+}


### PR DESCRIPTION
## Summary
- реализованы доменные исключения и расширено хранилище FX Outright
- добавлены JPA репозиторий, маппер и адаптер хранения FX Outright
- создан REST-контроллер и сервис для операций с FX Outright

## Testing
- `./mvnw -q -pl domain,backend test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b185ad0832da1d50ccd4cb52090