### PR TITLE
feat: перегенерация instrument_code при обновлении FX Outright

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/jpa/InstrumentEntity.java
@@ -34,7 +34,7 @@ public abstract class InstrumentEntity extends BaseEntity {
 
     /** Внутренний код инструмента. */
     @NotBlank
-    @Column(name = "instrument_code", nullable = false, updatable = false, length = 32)
+    @Column(name = "instrument_code", nullable = false, updatable = true, length = 32)
     private String instrumentCode;
 
     /** Тип финансового инструмента. */

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
@@ -69,6 +69,25 @@ public class FxOutrightEntity extends InstrumentEntity {
         __generateInstrumentCode();
     }
 
+    /**
+     * JPA-callback код перед обновлением.
+     * Перегенерирует код инструмента при изменении валют или даты расчётов.
+     */
+    @Override
+    protected void onPreUpdate() {
+        // Проверка: разные валюты для пары
+        if (baseCurrency.getCode().equals(quoteCurrency.getCode())) {
+            // TODO: Заменить на собственную ошибку из доменного класса
+            throw new IllegalArgumentException("Base and quote currencies must be different");
+        }
+        // Ожидаемый код на основании текущих параметров
+        String expectedCode = baseCurrency.getCode() + quoteCurrency.getCode() + "_" + valueDateCode;
+        // Пересохраняем код только при изменении
+        if (!expectedCode.equals(getInstrumentCode())) {
+            __generateInstrumentCode(); // → сохраняем новое значение
+        }
+    }
+
     /* Вспомогательный метод генерации кода инструмента. */
     private void __generateInstrumentCode() {
         String instrumentCode = baseCurrency.getCode() + quoteCurrency.getCode() + "_" + valueDateCode;


### PR DESCRIPTION
## Summary
- regenerate instrument_code on FX Outright update
- allow instrument_code column updates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f12e6c1f0832d9de51f0671b2b5c6