### PR TITLE
feat: изменить ориентацию карты профилей провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/repository/ProviderProfileStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/repository/ProviderProfileStorageAdapter.java
@@ -25,11 +25,11 @@ public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
 
     @Override
     @Transactional(readOnly = true)
-    public Map<ProviderProfile, Long> findAllActive() {
+    public Map<Long, ProviderProfile> findAllActive() {
         return jpaRepository.findAllByStatus(ProviderProfileStatus.ACTIVE).stream()
                 .collect(Collectors.toMap(
-                        ProviderProfileEntityMapper::toDomain,
-                        ProviderProfileEntity::getId
+                        ProviderProfileEntity::getId,
+                        ProviderProfileEntityMapper::toDomain
                 ));
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/service/ProviderProfileService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/service/ProviderProfileService.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public interface ProviderProfileService {
 
     /** Вернуть все активные профили вместе с PK. */
-    Map<ProviderProfile, Long> findAllActive();
+    Map<Long, ProviderProfile> findAllActive();
 
     /** Вернуть все профили с их статусами. */
     Map<ProviderProfile, ProviderProfileStatus> findAllWithStatus();

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/service/ProviderProfileServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/service/ProviderProfileServiceImpl.java
@@ -19,7 +19,7 @@ public class ProviderProfileServiceImpl implements ProviderProfileService {
     private final ProviderProfileStorage storage;
 
     @Override
-    public Map<ProviderProfile, Long> findAllActive() {
+    public Map<Long, ProviderProfile> findAllActive() {
         return storage.findAllActive();
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/ProviderProfileController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/ProviderProfileController.java
@@ -32,7 +32,7 @@ public class ProviderProfileController {
     /** Вернуть все активные профили. */
     @GetMapping
     public ResponseEntity<ApiResponse<List<ProviderProfileDto>>> getAll() {
-        List<ProviderProfileDto> list = service.findAllActive().keySet().stream()
+        List<ProviderProfileDto> list = service.findAllActive().values().stream()
                 .map(this::toDto)
                 .toList();
         return ResponseEntityFactory.ok(list);

--- a/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliation.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/context_sync/ProviderProfilesReconciliation.java
@@ -32,8 +32,8 @@ public class ProviderProfilesReconciliation {
 
         // Список контекстных профилей
         List<ProviderProfile> contextProfiles = contextScanner.getProviderProfiles();
-        // Карта <профиль, PK> профилей из БД со статусом ACTIVE
-        Map<ProviderProfile, Long> dbActiveProfiles = profileStorage.findAllActive();
+        // Карта <PK, профиль> профилей из БД со статусом ACTIVE
+        Map<Long, ProviderProfile> dbActiveProfiles = profileStorage.findAllActive();
 
         ContextDiff diff = new ContextDiff();
 
@@ -41,12 +41,12 @@ public class ProviderProfilesReconciliation {
         List<ProviderProfile> restContextProfiles =
                 new ArrayList<>(contextProfiles); // До начала цикла совпадает с полным
 
-        // Перебираем все профили в карте <профиль, PK> из БД
-        for (Map.Entry<ProviderProfile, Long> entry_i : dbActiveProfiles.entrySet()) {
+        // Перебираем все профили в карте <PK, профиль> из БД
+        for (Map.Entry<Long, ProviderProfile> entry_i : dbActiveProfiles.entrySet()) {
 
-            // entry_i это пара <i-ый профиль, PK>
-            ProviderProfile dbProfile = entry_i.getKey();
-            Long id = entry_i.getValue();
+            // entry_i это пара <PK, i-ый профиль>
+            Long id = entry_i.getKey();
+            ProviderProfile dbProfile = entry_i.getValue();
 
             // Совпавший по коду провайдера профиль
             ProviderProfile contextMatch = null;

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/catalog/ProviderProfileStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/catalog/ProviderProfileStorage.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public interface ProviderProfileStorage {
 
     /** Вернуть все активные профили вместе с PK. */
-    Map<ProviderProfile, Long> findAllActive();
+    Map<Long, ProviderProfile> findAllActive();
 
     /** Вернуть все профили с их статусами. */
     Map<ProviderProfile, ProviderProfileStatus> findAllWithStatus();


### PR DESCRIPTION
## Summary
- ориентировать Map активных профилей по ID провайдера
- обновить сервисы, адаптеры и контроллер под новую ориентацию
- поправить доменную синхронизацию профилей

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f3d4078e0832d906552f0322b736d