### PR TITLE
feat: перенес данные профиля провайдера в embeddable

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEmbeddable.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEmbeddable.java
@@ -1,0 +1,72 @@
+package com.alligator.market.backend.provider.profile.catalog.jpa;
+
+import com.alligator.market.domain.instrument.model.InstrumentType;
+import com.alligator.market.domain.provider.profile.model.AccessMethod;
+import com.alligator.market.domain.provider.profile.model.DeliveryMode;
+import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Встраиваемая часть профиля провайдера рыночных данных.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode
+public class ProviderProfileEmbeddable {
+
+    /** Технический код {@link ProviderProfile#providerCode()}. */
+    @NotBlank
+    @Size(max = 50)
+    @Column(name = "provider_code", length = 50, nullable = false, updatable = false)
+    private String providerCode;
+
+    /** Отображаемое имя {@link ProviderProfile#displayName()}. */
+    @NotBlank
+    @Size(max = 50)
+    @Column(name = "display_name", length = 50, nullable = false)
+    private String displayName;
+
+    /** Поддерживаемые инструменты {@link ProviderProfile#instrumentTypes()}. */
+    @ElementCollection(targetClass = InstrumentType.class)
+    @CollectionTable(
+            name = "provider_profile_instrument_type",
+            joinColumns = @JoinColumn(
+                    name = "provider_id",
+                    referencedColumnName = "id",
+                    foreignKey = @ForeignKey(name = "fk_provider_profile_instrument_type_provider_profile")
+            )
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "instrument_type", length = 20, nullable = false)
+    private Set<InstrumentType> instrumentTypes;
+
+    /** Режим доставки рыночных данных: PULL или PUSH {@link ProviderProfile#deliveryMode()}. */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_mode", length = 10, nullable = false)
+    private DeliveryMode deliveryMode;
+
+    /** Метод доступа к рыночным данным: API_POLL, WEBSOCKET, FIX или другие {@link ProviderProfile#accessMethod()}. */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "access_method", length = 20, nullable = false)
+    private AccessMethod accessMethod;
+
+    /** Поддержка массовой подписки одним запросом {@link ProviderProfile#supportsBulkSubscription()}. */
+    @Column(name = "supports_bulk_subscription", nullable = false)
+    private boolean supportsBulkSubscription;
+
+    /** Минимально допустимый интервал опроса в миллисекундах {@link ProviderProfile#minPollPeriodMs()}. */
+    @Column(name = "min_poll_period_ms", nullable = false)
+    private int minPollPeriodMs;
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntity.java
@@ -1,16 +1,9 @@
 package com.alligator.market.backend.provider.profile.catalog.jpa;
 
 import com.alligator.market.backend.common.jpa.BaseEntity;
-import com.alligator.market.domain.instrument.model.InstrumentType;
-import com.alligator.market.domain.provider.profile.model.AccessMethod;
-import com.alligator.market.domain.provider.profile.model.DeliveryMode;
-import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 import com.alligator.market.domain.provider.profile.model.ProviderProfileStatus;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,51 +39,8 @@ public class ProviderProfileEntity extends BaseEntity {
     //==========================
     // Данные профиля провайдера
     //==========================
-
-    /** Технический код {@link ProviderProfile#providerCode()}. */
-    @NotBlank
-    @Size(max = 50)
-    @Column(name = "provider_code", length = 50, nullable = false, updatable = false)
-    private String providerCode;
-
-    /** Отображаемое имя {@link ProviderProfile#displayName()}. */
-    @NotBlank
-    @Size(max = 50)
-    @Column(name = "display_name", length = 50, nullable = false)
-    private String displayName;
-
-    /** Поддерживаемые инструменты {@link ProviderProfile#instrumentTypes()}. */
-    @ElementCollection(targetClass = InstrumentType.class)
-    @CollectionTable(
-            name = "provider_profile_instrument_type",
-            joinColumns = @JoinColumn(
-                    name = "provider_id",
-                    referencedColumnName = "id",
-                    foreignKey = @ForeignKey(name = "fk_provider_profile_instrument_type_provider_profile")
-            )
-    )
-    @Enumerated(EnumType.STRING)
-    @Column(name = "instrument_type", length = 20, nullable = false)
-    private Set<InstrumentType> instrumentTypes;
-
-    /** Режим доставки рыночных данных: PULL или PUSH {@link ProviderProfile#deliveryMode()}. */
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @Column(name = "delivery_mode", length = 10, nullable = false)
-    private DeliveryMode deliveryMode;
-
-    /** Метод доступа к рыночным данным: API_POLL, WEBSOCKET, FIX или другие {@link ProviderProfile#accessMethod()}. */
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @Column(name = "access_method", length = 20, nullable = false)
-    private AccessMethod accessMethod;
-
-    /** Поддержка массовой подписки одним запросом {@link ProviderProfile#supportsBulkSubscription()}. */
-    @Column(name = "supports_bulk_subscription", nullable = false)
-    private boolean supportsBulkSubscription;
-
-    /** Минимально допустимый интервал опроса в миллисекундах {@link ProviderProfile#minPollPeriodMs()}. */
-    @Column(name = "min_poll_period_ms", nullable = false)
-    private int minPollPeriodMs;
+    /** Данные профиля провайдера. */
+    @Embedded
+    private ProviderProfileEmbeddable profile;
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntityMapper.java
@@ -15,26 +15,29 @@ public final class ProviderProfileEntityMapper {
     public static ProviderProfileEntity toEntity(ProviderProfile profile, ProviderProfileStatus status) {
         ProviderProfileEntity entity = new ProviderProfileEntity();
         entity.setStatus(status);
-        entity.setProviderCode(profile.providerCode());
-        entity.setDisplayName(profile.displayName());
-        entity.setInstrumentTypes(profile.instrumentTypes());
-        entity.setDeliveryMode(profile.deliveryMode());
-        entity.setAccessMethod(profile.accessMethod());
-        entity.setSupportsBulkSubscription(profile.supportsBulkSubscription());
-        entity.setMinPollPeriodMs(profile.minPollPeriodMs());
+        ProviderProfileEmbeddable data = new ProviderProfileEmbeddable();
+        data.setProviderCode(profile.providerCode());
+        data.setDisplayName(profile.displayName());
+        data.setInstrumentTypes(profile.instrumentTypes());
+        data.setDeliveryMode(profile.deliveryMode());
+        data.setAccessMethod(profile.accessMethod());
+        data.setSupportsBulkSubscription(profile.supportsBulkSubscription());
+        data.setMinPollPeriodMs(profile.minPollPeriodMs());
+        entity.setProfile(data);
         return entity;
     }
 
     /** Преобразует сущность в доменную модель, игнорируя статус. */
     public static ProviderProfile toDomain(ProviderProfileEntity entity) {
+        ProviderProfileEmbeddable data = entity.getProfile();
         return new ProviderProfile(
-                entity.getProviderCode(),
-                entity.getDisplayName(),
-                entity.getInstrumentTypes(),
-                entity.getDeliveryMode(),
-                entity.getAccessMethod(),
-                entity.isSupportsBulkSubscription(),
-                entity.getMinPollPeriodMs()
+                data.getProviderCode(),
+                data.getDisplayName(),
+                data.getInstrumentTypes(),
+                data.getDeliveryMode(),
+                data.getAccessMethod(),
+                data.isSupportsBulkSubscription(),
+                data.getMinPollPeriodMs()
         );
     }
 }


### PR DESCRIPTION
## Summary
- introduce ProviderProfileEmbeddable to mirror domain object
- use embedded profile data inside ProviderProfileEntity
- update entity mapper accordingly

## Testing
- `./mvnw -q -pl backend -am test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a04c4ce0c0832da81a962db8158c1c