### PR TITLE
feat: добавить маппер профиля

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/jpa/ProviderEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/jpa/ProviderEntityMapper.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.catalog.jpa;
 
 import com.alligator.market.backend.provider.profile.catalog.jpa.ProfileEmbeddable;
+import com.alligator.market.backend.provider.profile.catalog.jpa.ProfileEmbeddableMapper;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 import com.alligator.market.domain.provider.model.ProviderStatus;
 
@@ -16,14 +17,7 @@ public final class ProviderEntityMapper {
     public static ProviderEntity toEntity(ProviderProfile profile, ProviderStatus status) {
         ProviderEntity entity = new ProviderEntity();
         entity.setStatus(status);
-        ProfileEmbeddable data = new ProfileEmbeddable();
-        data.setProviderCode(profile.providerCode());
-        data.setDisplayName(profile.displayName());
-        data.setInstrumentTypes(profile.instrumentTypes());
-        data.setDeliveryMode(profile.deliveryMode());
-        data.setAccessMethod(profile.accessMethod());
-        data.setSupportsBulkSubscription(profile.supportsBulkSubscription());
-        data.setMinPollPeriodMs(profile.minPollPeriodMs());
+        ProfileEmbeddable data = ProfileEmbeddableMapper.toEmbeddable(profile);
         entity.setProfile(data);
         return entity;
     }
@@ -31,14 +25,6 @@ public final class ProviderEntityMapper {
     /** Преобразует сущность в доменную модель. */
     public static ProviderProfile toDomain(ProviderEntity entity) {
         ProfileEmbeddable data = entity.getProfile();
-        return new ProviderProfile(
-                data.getProviderCode(),
-                data.getDisplayName(),
-                data.getInstrumentTypes(),
-                data.getDeliveryMode(),
-                data.getAccessMethod(),
-                data.isSupportsBulkSubscription(),
-                data.getMinPollPeriodMs()
-        );
+        return ProfileEmbeddableMapper.toDomain(data);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProfileEmbeddableMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProfileEmbeddableMapper.java
@@ -1,0 +1,39 @@
+package com.alligator.market.backend.provider.profile.catalog.jpa;
+
+import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+
+/**
+ * Маппер профиля провайдера между JPA и доменной моделью.
+ */
+public final class ProfileEmbeddableMapper {
+
+    private ProfileEmbeddableMapper() {
+    }
+
+    /** Преобразует доменную модель в JPA-объект. */
+    public static ProfileEmbeddable toEmbeddable(ProviderProfile profile) {
+        ProfileEmbeddable embeddable = new ProfileEmbeddable();
+        embeddable.setProviderCode(profile.providerCode());
+        embeddable.setDisplayName(profile.displayName());
+        embeddable.setInstrumentTypes(profile.instrumentTypes());
+        embeddable.setDeliveryMode(profile.deliveryMode());
+        embeddable.setAccessMethod(profile.accessMethod());
+        embeddable.setSupportsBulkSubscription(profile.supportsBulkSubscription());
+        embeddable.setMinPollPeriodMs(profile.minPollPeriodMs());
+        return embeddable;
+    }
+
+    /** Преобразует JPA-объект в доменную модель. */
+    public static ProviderProfile toDomain(ProfileEmbeddable embeddable) {
+        return new ProviderProfile(
+                embeddable.getProviderCode(),
+                embeddable.getDisplayName(),
+                embeddable.getInstrumentTypes(),
+                embeddable.getDeliveryMode(),
+                embeddable.getAccessMethod(),
+                embeddable.isSupportsBulkSubscription(),
+                embeddable.getMinPollPeriodMs()
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- добавить маппер ProfileEmbeddableMapper
- использовать ProfileEmbeddableMapper в ProviderEntityMapper

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ce1491c0832db4a15d83f11a92a0