### PR TITLE
feat: добавить встраиваемый профиль провайдера

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntity.java
@@ -1,21 +1,14 @@
 package com.alligator.market.backend.provider.profile.catalog.jpa;
 
 import com.alligator.market.backend.common.jpa.BaseEntity;
-import com.alligator.market.domain.instrument.model.InstrumentType;
-import com.alligator.market.domain.provider.profile.model.ProviderAccessMethod;
-import com.alligator.market.domain.provider.profile.model.ProviderDeliveryMode;
-import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+import com.alligator.market.backend.provider.profile.catalog.jpa.embedded.ProviderProfileEmbedded;
 import com.alligator.market.domain.provider.profile.context.ProviderProfileStatus;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.Set;
 
 /**
  * Entity профиля провайдера рыночных данных.
@@ -42,6 +35,8 @@ public class ProviderProfileEntity extends BaseEntity {
     private ProviderProfileStatus status;
 
     /** Профиль провайдера. */
-
+    @NotNull
+    @Embedded
+    private ProviderProfileEmbedded profile;
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/ProviderProfileEntityMapper.java
@@ -1,5 +1,7 @@
 package com.alligator.market.backend.provider.profile.catalog.jpa;
 
+import com.alligator.market.backend.provider.profile.catalog.jpa.embedded.ProviderProfileEmbeddedMapper;
+import com.alligator.market.domain.provider.profile.context.ProviderProfileStatus;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 
 /**
@@ -11,12 +13,15 @@ public final class ProviderProfileEntityMapper {
     }
 
     /** Преобразует доменную модель в сущность. */
-    public static ProviderProfileEntity toEntity(ProviderProfile profile) {
-
+    public static ProviderProfileEntity toEntity(ProviderProfile profile, ProviderProfileStatus status) {
+        ProviderProfileEntity entity = new ProviderProfileEntity();
+        entity.setStatus(status);
+        entity.setProfile(ProviderProfileEmbeddedMapper.toEmbedded(profile));
+        return entity;
     }
 
     /** Преобразует сущность в доменную модель. */
     public static ProviderProfile toDomain(ProviderProfileEntity entity) {
-
+        return ProviderProfileEmbeddedMapper.toDomain(entity.getProfile());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/embedded/ProviderProfileEmbedded.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/embedded/ProviderProfileEmbedded.java
@@ -8,9 +8,19 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Set;
 
+/** Встраиваемый профиль провайдера. */
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode
+@Embeddable
 public class ProviderProfileEmbedded {
 
     /** Технический код провайдера {@link ProviderProfile#providerCode()}. */

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/embedded/ProviderProfileEmbeddedMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/embedded/ProviderProfileEmbeddedMapper.java
@@ -1,4 +1,38 @@
 package com.alligator.market.backend.provider.profile.catalog.jpa.embedded;
 
-public class ProviderProfileEmbeddedMapper {
+import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+
+/**
+ * Маппер доменной модели и встраиваемого профиля.
+ */
+public final class ProviderProfileEmbeddedMapper {
+
+    private ProviderProfileEmbeddedMapper() {
+    }
+
+    /** Преобразует доменную модель во встраиваемый профиль. */
+    public static ProviderProfileEmbedded toEmbedded(ProviderProfile profile) {
+        ProviderProfileEmbedded embedded = new ProviderProfileEmbedded();
+        embedded.setProviderCode(profile.providerCode());
+        embedded.setDisplayName(profile.displayName());
+        embedded.setInstrumentTypes(profile.instrumentTypes());
+        embedded.setDeliveryMode(profile.deliveryMode());
+        embedded.setAccessMethod(profile.accessMethod());
+        embedded.setBulkSubscription(profile.bulkSubscription());
+        embedded.setMinPollMs(profile.minPollMs());
+        return embedded;
+    }
+
+    /** Преобразует встраиваемый профиль в доменную модель. */
+    public static ProviderProfile toDomain(ProviderProfileEmbedded embedded) {
+        return new ProviderProfile(
+                embedded.getProviderCode(),
+                embedded.getDisplayName(),
+                embedded.getInstrumentTypes(),
+                embedded.getDeliveryMode(),
+                embedded.getAccessMethod(),
+                embedded.isBulkSubscription(),
+                embedded.getMinPollMs()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- оформить ProviderProfileEmbedded как JPA embeddable
- встроить профиль провайдера в ProviderProfileEntity
- добавить мапперы для преобразования доменной модели

## Testing
- `./mvnw -q -pl backend test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*
- `mvn -q -pl backend test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e634c3d4832d8598aae10dff9441