### PR TITLE
Rename decimalDigits to decimal in currency mappings

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyEntity.java
@@ -52,9 +52,9 @@ public class CurrencyEntity extends BaseEntity {
     private String country;
 
     /** Кол-во знаков после запятой для денежных сумм. */
-    @Column(name = "decimal_digits", nullable = false)
+    @Column(name = "decimal", nullable = false)
     @Min(0)
     @Max(10)
     @NotNull
-    private Integer decimalDigits;
+    private Integer decimal;
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/web/mapper/CurrencyDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/web/mapper/CurrencyDtoMapper.java
@@ -13,16 +13,14 @@ import org.mapstruct.Mapping;
 public interface CurrencyDtoMapper {
 
     /** Преобразует DTO в доменную модель. */
-    @Mapping(target = "decimalDigits", source = "decimal")
     Currency toDomain(CurrencyDto dto);
 
     /** Преобразует DTO обновления и код в доменную модель. */
     @Mapping(target = "code", source = "code")
-    @Mapping(target = "decimalDigits", source = "dto.decimal")
+    @Mapping(target = "decimal", source = "dto.decimal")
     Currency toDomain(String code, CurrencyUpdateDto dto);
 
     /** Преобразует доменную модель в DTO. */
-    @Mapping(target = "decimal", source = "decimalDigits")
     CurrencyDto toDto(Currency currency);
 }
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/reference/currency/model/Currency.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/reference/currency/model/Currency.java
@@ -8,5 +8,5 @@ public record Currency(
         String code,
         String name,
         String country,
-        Integer decimalDigits
+        Integer decimal
 ) {}


### PR DESCRIPTION
## Summary
- rename field `decimalDigits` to `decimal` in currency model and entity
- update CurrencyDtoMapper mapping for new field name

## Testing
- `./mvnw -q test` *(fails: Failed to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fa2f4f68832d89c5ce56726923b6