### PR TITLE
Добавлен метод проверки использования валюты в FX_OUTRIGHT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
@@ -57,4 +57,9 @@ public class FxOutrightStorageAdapter implements FxOutrightStorage {
                 .map(FxOutrightEntityMapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public boolean existsByCurrency(String currencyCode) {
+        return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(currencyCode, currencyCode);
+    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightJpaRepository.java
@@ -11,4 +11,7 @@ public interface FxOutrightJpaRepository extends JpaRepository<FxOutrightEntity,
 
     /** Найти инструмент по внутреннему коду. */
     Optional<FxOutrightEntity> findByInstrumentCode(String instrumentCode);
+
+    /** Проверить, используется ли валюта в парах. */
+    boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(String baseCurrency, String quoteCurrency);
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/FxOutrightStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/FxOutrightStorage.java
@@ -21,4 +21,7 @@ public interface FxOutrightStorage {
 
     /** Вернуть все инструменты. */
     List<FxOutright> findAll();
+
+    /** Проверить, используется ли валюта в инструментах. */
+    boolean existsByCurrency(String currencyCode);
 }


### PR DESCRIPTION
## Summary
- Добавлен метод проверки использования валюты в `FxOutrightStorage`
- Реализована проверка в адаптере и JPA-репозитории

## Testing
- `mvn test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a0d46464832d89293bdee28beb12