### PR TITLE
Добавлен маппинг колонок для InstrumentEmbeddable

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/model/InstrumentEmbeddable.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/model/InstrumentEmbeddable.java
@@ -27,12 +27,12 @@ public class InstrumentEmbeddable {
 
     /** Внутренний код инструмента. */
     @NotBlank
-    @Column(length = 32, nullable = false, updatable = false)
+    @Column(name = "instrument_code", length = 32, nullable = false, updatable = false)
     private String code;
 
     /** Тип финансового инструмента. */
     @NotNull
     @Enumerated(EnumType.STRING)
-    @Column(length = 32, nullable = false, updatable = false)
+    @Column(name = "instrument_type", length = 32, nullable = false, updatable = false)
     private InstrumentType type;
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
@@ -32,12 +32,9 @@ public class FxOutrightEntity extends BaseEntity {
     @Column(name = "id")
     private Long id;
 
-    /** Общие атрибуты инструмента. */
+    /** Встраиваемый компонент с атрибутами инструмента. */
+    @NotNull
     @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "code", column = @Column(name = "instrument_code", length = 32, nullable = false, updatable = false)),
-            @AttributeOverride(name = "type", column = @Column(name = "instrument_type", length = 32, nullable = false, updatable = false))
-    })
     private InstrumentEmbeddable instrument = new InstrumentEmbeddable();
 
     /** ISO-4217 код базовой валюты (FK на "code" в таблице "currency"). */


### PR DESCRIPTION
## Summary
- проставлены имена колонок в InstrumentEmbeddable
- упрощено внедрение инструмента в FxOutrightEntity

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ba3b031c832da4edf4fe20e02cb5