### PR TITLE
refactor(provider-profile): use MapStruct mappers

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/mapper/ProviderProfileEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/jpa/mapper/ProviderProfileEntityMapper.java
@@ -4,26 +4,21 @@ import com.alligator.market.backend.provider.profile.catalog.jpa.ProviderProfile
 import com.alligator.market.backend.provider.profile.model.ProfileParamsEmbeddedMapper;
 import com.alligator.market.domain.provider.profile.context.ProviderProfileStatus;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
- * Маппер сущности и доменной модели профиля провайдера рыночных данных.
- * Использует маппер {@link ProfileParamsEmbeddedMapper}.
+ * Маппер: сущность профиля провайдера ⇄ доменная модель.
  */
-public final class ProviderProfileEntityMapper {
-
-    private ProviderProfileEntityMapper() {
-    }
+@Mapper(componentModel = "spring", uses = ProfileParamsEmbeddedMapper.class)
+public interface ProviderProfileEntityMapper {
 
     /** Преобразует доменную модель в сущность. */
-    public static ProviderProfileEntity toEntity(ProviderProfile profile, ProviderProfileStatus status) {
-        ProviderProfileEntity entity = new ProviderProfileEntity();
-        entity.setStatus(status);
-        entity.setProfile(ProfileParamsEmbeddedMapper.toEmbedded(profile));
-        return entity;
-    }
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "profileParams", source = "profile")
+    ProviderProfileEntity toEntity(ProviderProfile profile, ProviderProfileStatus status);
 
     /** Преобразует сущность в доменную модель. */
-    public static ProviderProfile toDomain(ProviderProfileEntity entity) {
-        return ProfileParamsEmbeddedMapper.toDomain(entity.getProfile());
-    }
+    @Mapping(target = ".", source = "profileParams")
+    ProviderProfile toDomain(ProviderProfileEntity entity);
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/repository/ProviderProfileStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/repository/ProviderProfileStorageAdapter.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
 
     private final ProviderProfileJpaRepository jpaRepository;
+    private final ProviderProfileEntityMapper mapper;
 
     @Override
     @Transactional(readOnly = true)
@@ -29,7 +30,7 @@ public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
         return jpaRepository.findAllByStatus(ProviderProfileStatus.ACTIVE).stream()
                 .collect(Collectors.toMap(
                         ProviderProfileEntity::getId,
-                        ProviderProfileEntityMapper::toDomain
+                        mapper::toDomain
                 ));
     }
 
@@ -38,7 +39,7 @@ public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
     public Map<ProviderProfile, ProviderProfileStatus> findAllWithStatus() {
         return jpaRepository.findAll().stream()
                 .collect(Collectors.toMap(
-                        ProviderProfileEntityMapper::toDomain,
+                        mapper::toDomain,
                         ProviderProfileEntity::getStatus
                 ));
     }
@@ -46,7 +47,7 @@ public class ProviderProfileStorageAdapter implements ProviderProfileStorage {
     @Override
     public void saveAll(Collection<ProviderProfile> profiles) {
         var entities = profiles.stream()
-                .map(p -> ProviderProfileEntityMapper.toEntity(p, ProviderProfileStatus.ACTIVE))
+                .map(p -> mapper.toEntity(p, ProviderProfileStatus.ACTIVE))
                 .toList();
         jpaRepository.saveAll(entities);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/ProviderProfileController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/ProviderProfileController.java
@@ -5,8 +5,7 @@ import com.alligator.market.backend.common.web.ResponseEntityFactory;
 import com.alligator.market.backend.provider.profile.catalog.web.dto.ProviderProfileDto;
 import com.alligator.market.backend.provider.profile.catalog.web.dto.ProviderProfileStatusDto;
 import com.alligator.market.backend.provider.profile.catalog.service.ProviderProfileService;
-import com.alligator.market.domain.provider.profile.model.ProviderProfile;
-import com.alligator.market.domain.provider.profile.context.ProviderProfileStatus;
+import com.alligator.market.backend.provider.profile.catalog.web.mapper.ProviderProfileDtoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +23,7 @@ import java.util.List;
 public class ProviderProfileController {
 
     private final ProviderProfileService service;
+    private final ProviderProfileDtoMapper mapper;
 
     //==============================================
     //                  Операции
@@ -33,7 +33,7 @@ public class ProviderProfileController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<ProviderProfileDto>>> getAll() {
         List<ProviderProfileDto> list = service.findAllActive().values().stream()
-                .map(this::toDto)
+                .map(mapper::toDto)
                 .toList();
         return ResponseEntityFactory.ok(list);
     }
@@ -42,40 +42,9 @@ public class ProviderProfileController {
     @GetMapping("/audit")
     public ResponseEntity<ApiResponse<List<ProviderProfileStatusDto>>> getAllWithStatus() {
         List<ProviderProfileStatusDto> list = service.findAllWithStatus().entrySet().stream()
-                .map(e -> toStatusDto(e.getKey(), e.getValue()))
+                .map(e -> mapper.toStatusDto(e.getKey(), e.getValue()))
                 .toList();
         return ResponseEntityFactory.ok(list);
     }
 
-    //==============================================
-    //                   Утилиты
-    //==============================================
-
-    /** Утилита преобразует доменную модель в DTO. */
-    private ProviderProfileDto toDto(ProviderProfile profile) {
-
-        return new ProviderProfileDto(
-                profile.providerCode(),
-                profile.displayName(),
-                profile.instrumentTypes(),
-                profile.deliveryMode(),
-                profile.accessMethod(),
-                profile.bulkSubscription(),
-                profile.minPollMs()
-        );
-    }
-
-    /** Утилита преобразует доменную модель и статус в DTO. */
-    private ProviderProfileStatusDto toStatusDto(ProviderProfile profile, ProviderProfileStatus status) {
-        return new ProviderProfileStatusDto(
-                status,
-                profile.providerCode(),
-                profile.displayName(),
-                profile.instrumentTypes(),
-                profile.deliveryMode(),
-                profile.accessMethod(),
-                profile.bulkSubscription(),
-                profile.minPollMs()
-        );
-    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/mapper/ProviderProfileDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/mapper/ProviderProfileDtoMapper.java
@@ -1,0 +1,33 @@
+package com.alligator.market.backend.provider.profile.catalog.web.mapper;
+
+import com.alligator.market.backend.provider.profile.catalog.web.dto.ProviderProfileDto;
+import com.alligator.market.backend.provider.profile.catalog.web.dto.ProviderProfileStatusDto;
+import com.alligator.market.domain.provider.profile.context.ProviderProfileStatus;
+import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Маппер: профиль провайдера ⇄ DTO.
+ */
+@Mapper(componentModel = "spring")
+public interface ProviderProfileDtoMapper {
+
+    /** Преобразует доменную модель в DTO. */
+    @Mapping(target = "providerDeliveryMode", source = "deliveryMode")
+    @Mapping(target = "providerAccessMethod", source = "accessMethod")
+    @Mapping(target = "supportsBulkSubscription", source = "bulkSubscription")
+    @Mapping(target = "minPollPeriodMs", source = "minPollMs")
+    ProviderProfileDto toDto(ProviderProfile profile);
+
+    /** Преобразует доменную модель и статус в DTO. */
+    @Mapping(target = "status", source = "status")
+    @Mapping(target = "providerDeliveryMode", source = "profile.deliveryMode")
+    @Mapping(target = "providerAccessMethod", source = "profile.accessMethod")
+    @Mapping(target = "supportsBulkSubscription", source = "profile.bulkSubscription")
+    @Mapping(target = "minPollPeriodMs", source = "profile.minPollMs")
+    @Mapping(target = "providerCode", source = "profile.providerCode")
+    @Mapping(target = "displayName", source = "profile.displayName")
+    @Mapping(target = "instrumentTypes", source = "profile.instrumentTypes")
+    ProviderProfileStatusDto toStatusDto(ProviderProfile profile, ProviderProfileStatus status);
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/model/ProfileParamsEmbeddedMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/model/ProfileParamsEmbeddedMapper.java
@@ -1,39 +1,18 @@
 package com.alligator.market.backend.provider.profile.model;
 
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+import org.mapstruct.Mapper;
 
 /**
- * Маппер встраиваемого компонента профиля провайдера {@link ProfileParamsEmbedded} и
- * доменной модели профиля провайдера рыночных данных {@link ProviderProfile}.
+ * Маппер встраиваемого компонента профиля провайдера {@link ProfileParamsEmbedded}
+ * и доменной модели профиля провайдера рыночных данных {@link ProviderProfile}.
  */
-public final class ProfileParamsEmbeddedMapper {
-
-    private ProfileParamsEmbeddedMapper() {
-    }
+@Mapper(componentModel = "spring")
+public interface ProfileParamsEmbeddedMapper {
 
     /** Преобразует доменную модель во встраиваемый компонент. */
-    public static ProfileParamsEmbedded toEmbedded(ProviderProfile profile) {
-        ProfileParamsEmbedded embedded = new ProfileParamsEmbedded();
-        embedded.setProviderCode(profile.providerCode());
-        embedded.setDisplayName(profile.displayName());
-        embedded.setInstrumentTypes(profile.instrumentTypes());
-        embedded.setDeliveryMode(profile.deliveryMode());
-        embedded.setAccessMethod(profile.accessMethod());
-        embedded.setBulkSubscription(profile.bulkSubscription());
-        embedded.setMinPollMs(profile.minPollMs());
-        return embedded;
-    }
+    ProfileParamsEmbedded toEmbedded(ProviderProfile profile);
 
     /** Преобразует встраиваемый компонент в доменную модель. */
-    public static ProviderProfile toDomain(ProfileParamsEmbedded embedded) {
-        return new ProviderProfile(
-                embedded.getProviderCode(),
-                embedded.getDisplayName(),
-                embedded.getInstrumentTypes(),
-                embedded.getDeliveryMode(),
-                embedded.getAccessMethod(),
-                embedded.isBulkSubscription(),
-                embedded.getMinPollMs()
-        );
-    }
+    ProviderProfile toDomain(ProfileParamsEmbedded embedded);
 }


### PR DESCRIPTION
## Summary
- replace manual profile DTO conversion with MapStruct mapper
- map provider profile entity via MapStruct and inject mapper into storage adapter
- convert embedded profile params mapper to MapStruct interface

## Testing
- `mvn -q -pl backend -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bd540644832d9f5dff76b42e1710