### PR TITLE
feat: apply base entity mapping config

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/mapper/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/mapper/CurrencyEntityMapper.java
@@ -1,19 +1,22 @@
 package com.alligator.market.backend.instrument.type.forex.outright.reference.currency.catalog.jpa.mapper;
 
+import com.alligator.market.backend.common.jpa.BaseEntityMappingConfig;
 import com.alligator.market.backend.instrument.type.forex.outright.reference.currency.catalog.jpa.CurrencyEntity;
 import com.alligator.market.domain.instrument.type.forex.outright.reference.currency.model.Currency;
+import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 
 /**
  * Маппер: модель валюты ⇄ сущность валюты.
  */
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", config = BaseEntityMappingConfig.class)
 public interface CurrencyEntityMapper {
 
     /** Преобразует сущность в модель. */
     Currency toDomain(CurrencyEntity entity);
 
     /** Обновляет сущность данными модели. */
+    @InheritConfiguration(name = "ignoreBaseFields")
     void updateEntity(Currency currency, @MappingTarget CurrencyEntity entity);
 }


### PR DESCRIPTION
## Summary
- use BaseEntityMappingConfig in CurrencyEntityMapper

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a215b63e18832d8c1d4ae2626a464c