### PR TITLE
Удаление валюты по коду через JPA

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/adapter/CurrencyStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/adapter/CurrencyStorageAdapter.java
@@ -32,7 +32,7 @@ public class CurrencyStorageAdapter implements CurrencyStorage {
 
     @Override
     public void deleteByCode(String code) {
-        jpaRepository.findByCode(code).ifPresent(jpaRepository::delete);
+        jpaRepository.deleteByCode(code);
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/reference/currency/catalog/jpa/CurrencyJpaRepository.java
@@ -15,4 +15,7 @@ public interface CurrencyJpaRepository extends JpaRepository<CurrencyEntity, Lon
     /** Найти валюту по имени. */
     Optional<CurrencyEntity> findByName(String name);
 
+    /** Удалить валюту по ISO-коду. */
+    void deleteByCode(String code);
+
 }


### PR DESCRIPTION
## Summary
- добавлен метод удаления валюты по ISO-коду в JPA-репозитории
- упрощён адаптер хранилища для удаления валюты через вызов репозитория

## Testing
- `./mvnw -q test` *(wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a22890f3d8832d93abeaa9e9b64e9f