### PR TITLE
Использование кода базовой сущности FX_OUTRIGHT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
@@ -28,7 +28,7 @@ public class FxOutrightStorageAdapter implements FxOutrightStorage {
 
     @Override
     public void save(FxOutright instrument) {
-        FxOutrightEntity entity = jpaRepository.findByInstrumentCode(instrument.code())
+        FxOutrightEntity entity = jpaRepository.findByCode(instrument.code())
                 .orElseGet(FxOutrightEntity::new);
 
         CurrencyEntity base = currencyRepository.findByCode(instrument.baseCurrency())
@@ -42,19 +42,19 @@ public class FxOutrightStorageAdapter implements FxOutrightStorage {
 
     @Override
     public void delete(String internalCode) {
-        jpaRepository.findByInstrumentCode(internalCode)
-                .ifPresent(jpaRepository::delete);
+        jpaRepository.findByCode(internalCode)
+                .ifPresent(e -> jpaRepository.deleteById(e.getId())); // Удаляем по ID
     }
 
     @Override
     public Optional<FxOutright> find(String internalCode) {
-        return jpaRepository.findByInstrumentCode(internalCode)
+        return jpaRepository.findByCode(internalCode)
                 .map(mapper::toDomain);
     }
 
     @Override
     public List<FxOutright> findAll() {
-        return jpaRepository.findAll(Sort.by("instrument.code")).stream()
+        return jpaRepository.findAll(Sort.by("code")).stream()
                 .map(mapper::toDomain)
                 .toList();
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface FxOutrightJpaRepository extends JpaRepository<FxOutrightEntity, Long> {
 
     /** Найти инструмент по внутреннему коду. */
-    Optional<FxOutrightEntity> findByInstrumentCode(String instrumentCode);
+    Optional<FxOutrightEntity> findByCode(String code);
 
     /** Проверить, используется ли валюта в парах. */
     boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(String baseCurrency, String quoteCurrency);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/mapper/FxOutrightEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/mapper/FxOutrightEntityMapper.java
@@ -21,6 +21,8 @@ public interface FxOutrightEntityMapper {
     @Mapping(target = "quoteCurrency", source = "quoteCurrency")
     @Mapping(target = "quoteDecimal", source = "model.quoteDecimal")
     @Mapping(target = "valueDateCode", source = "model.valueDateCode")
+    @Mapping(target = "code", expression = "java(model.code())")
+    @Mapping(target = "type", expression = "java(model.type())")
     void updateEntity(FxOutright model,
                       CurrencyEntity baseCurrency,
                       CurrencyEntity quoteCurrency,


### PR DESCRIPTION
## Summary
- заменить поиск FX_OUTRIGHT по вложенному instrument.code на прямой findByCode
- работать с ID сущности при удалении
- обновлять code и type базовой сущности через маппер

## Testing
- `mvn -q -pl backend -am test` *(failed: Could not resolve artifacts, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2360d0d8c832dbeade07daa442c99