### PR TITLE
feat: добавить исключение для одинаковых валют FX Outright

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/FxOutrightEntity.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.instrument.catalog.jpa.InstrumentEntity;
 import com.alligator.market.backend.instrument.type.forex.outright.reference.currency.catalog.jpa.CurrencyEntity;
 import com.alligator.market.domain.instrument.model.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.outright.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.outright.catalog.exception.SameCurrenciesException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -57,7 +58,7 @@ public class FxOutrightEntity extends InstrumentEntity {
     protected void onPrePersist() {
         // 1) Проверяем, что валюты различаются
         if (baseCurrency.getCode().equals(quoteCurrency.getCode())) {
-            throw new IllegalArgumentException("Base and quote currencies must be different");
+            throw new SameCurrenciesException();
         }
         // 2) Устанавливаем тип инструмента
         setType(InstrumentType.FX_OUTRIGHT);

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/exception/SameCurrenciesException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/exception/SameCurrenciesException.java
@@ -1,0 +1,11 @@
+package com.alligator.market.domain.instrument.type.forex.outright.catalog.exception;
+
+/**
+ * Базовая и котируемая валюты совпадают.
+ */
+public class SameCurrenciesException extends RuntimeException {
+    public SameCurrenciesException() {
+        super("Base and quote currencies must be different");
+    }
+}
+


### PR DESCRIPTION
## Summary
- добавить доменное исключение SameCurrenciesException
- использовать SameCurrenciesException в FxOutrightEntity

## Testing
- `mvn -q -pl backend,domain -am test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a23866547c832d8dc4da9360de7f35