### PR TITLE
feat: добавить маппер для FxOutright

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/FxOutrightController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/FxOutrightController.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.common.web.ApiResponse;
 import com.alligator.market.backend.common.web.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.type.forex.outright.catalog.service.FxOutrightService;
 import com.alligator.market.backend.instrument.type.forex.outright.catalog.web.dto.FxOutrightDto;
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.web.mapper.FxOutrightDtoMapper;
 import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,16 +26,12 @@ import java.util.List;
 public class FxOutrightController {
 
     private final FxOutrightService service;
+    private final FxOutrightDtoMapper mapper;
 
     /** Создать инструмент. */
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid FxOutrightDto dto) {
-        FxOutright model = new FxOutright(
-                dto.baseCurrency(),
-                dto.quoteCurrency(),
-                dto.quoteDecimal(),
-                dto.valueDateCode()
-        );
+        FxOutright model = mapper.toDomain(dto);
         String code = service.create(model);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{code}")
@@ -54,12 +51,7 @@ public class FxOutrightController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<FxOutrightDto>>> getAll() {
         List<FxOutrightDto> list = service.findAll().stream()
-                .map(i -> new FxOutrightDto(
-                        i.baseCurrency(),
-                        i.quoteCurrency(),
-                        i.quoteDecimal(),
-                        i.valueDateCode()
-                ))
+                .map(mapper::toDto)
                 .toList();
         return ResponseEntityFactory.ok(list);
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/mapper/FxOutrightDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/mapper/FxOutrightDtoMapper.java
@@ -1,0 +1,19 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.web.mapper;
+
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.web.dto.FxOutrightDto;
+import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
+import org.mapstruct.Mapper;
+
+/**
+ * Маппер: FX_OUTRIGHT модель ⇄ DTO.
+ */
+@Mapper(componentModel = "spring")
+public interface FxOutrightDtoMapper {
+
+    /** Преобразует основной DTO в доменную модель. */
+    FxOutright toDomain(FxOutrightDto dto);
+
+    /** Преобразует доменную модель в основной DTO. */
+    FxOutrightDto toDto(FxOutright model);
+}
+


### PR DESCRIPTION
## Summary
- добавить MapStruct-маппер FxOutrightDtoMapper
- использовать маппер в FxOutrightController

## Testing
- `mvn -q -pl backend -am test` *(не удалось: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a24084fd2c832dbbc701e99f352e63