### PR TITLE
Добавлена возможность обновлять точность котировки FX_OUTRIGHT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightService.java
@@ -12,6 +12,9 @@ public interface FxOutrightService {
     /** Сохранить новый инструмент. */
     String create(FxOutright instrument);
 
+    /** Обновить точность котировки. */
+    void updateQuoteDecimal(String code, int quoteDecimal);
+
     /** Удалить инструмент по коду. */
     void delete(String code);
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImpl.java
@@ -37,6 +37,23 @@ public class FxOutrightServiceImpl implements FxOutrightService {
     }
 
     @Override
+    public void updateQuoteDecimal(String code, int quoteDecimal) {
+        // Ищем текущий инструмент
+        FxOutright current = storage.find(code)
+                .orElseThrow(() -> new FxOutrightNotFoundException(code));
+        // Создаем модель с новой точностью котировки
+        FxOutright updated = new FxOutright(
+                current.baseCurrency(),
+                current.quoteCurrency(),
+                current.valueDateCode(),
+                quoteDecimal
+        );
+        // Сохраняем обновленную модель
+        storage.save(updated);
+        log.info("FxOutright {} updated", code);
+    }
+
+    @Override
     public void delete(String code) {
         storage.find(code).orElseThrow(() -> new FxOutrightNotFoundException(code));
         storage.delete(code);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/FxOutrightController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/FxOutrightController.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.common.web.ApiResponse;
 import com.alligator.market.backend.common.web.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.type.forex.outright.catalog.service.FxOutrightService;
 import com.alligator.market.backend.instrument.type.forex.outright.catalog.web.dto.FxOutrightDto;
+import com.alligator.market.backend.instrument.type.forex.outright.catalog.web.dto.FxOutrightUpdateDto;
 import com.alligator.market.backend.instrument.type.forex.outright.catalog.web.mapper.FxOutrightDtoMapper;
 import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
 import jakarta.validation.Valid;
@@ -38,6 +39,14 @@ public class FxOutrightController {
                 .buildAndExpand(code)
                 .toUri();
         return ResponseEntityFactory.created(location, code);
+    }
+
+    /** Обновить точность котировки. */
+    @PatchMapping("/{code}")
+    public ResponseEntity<ApiResponse<Void>> updateQuoteDecimal(@PathVariable String code,
+                                                                @RequestBody @Valid FxOutrightUpdateDto dto) {
+        service.updateQuoteDecimal(code, dto.quoteDecimal());
+        return ResponseEntityFactory.ok(null);
     }
 
     /** Удалить инструмент. */

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/dto/FxOutrightUpdateDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/web/dto/FxOutrightUpdateDto.java
@@ -1,0 +1,17 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.web.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * DTO для обновления инструмента FX_OUTRIGHT.
+ */
+public record FxOutrightUpdateDto(
+
+        @NotNull
+        @Min(0) @Max(10)
+        Integer quoteDecimal
+
+) {}
+

--- a/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImplTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImplTest.java
@@ -1,0 +1,73 @@
+package com.alligator.market.backend.instrument.type.forex.outright.catalog.service;
+
+import com.alligator.market.domain.instrument.type.forex.outright.catalog.FxOutrightStorage;
+import com.alligator.market.domain.instrument.type.forex.outright.catalog.exception.FxOutrightNotFoundException;
+import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
+import com.alligator.market.domain.instrument.type.forex.outright.model.ValueDateCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тесты для {@link FxOutrightServiceImpl}.
+ */
+class FxOutrightServiceImplTest {
+
+    /** Простейшее in-memory хранилище. */
+    static class InMemoryFxOutrightStorage implements FxOutrightStorage {
+        private final Map<String, FxOutright> map = new HashMap<>();
+
+        @Override
+        public void save(FxOutright instrument) {
+            map.put(instrument.code(), instrument);
+        }
+
+        @Override
+        public void delete(String internalCode) {
+            map.remove(internalCode);
+        }
+
+        @Override
+        public Optional<FxOutright> find(String internalCode) {
+            return Optional.ofNullable(map.get(internalCode));
+        }
+
+        @Override
+        public List<FxOutright> findAll() {
+            return new ArrayList<>(map.values());
+        }
+
+        @Override
+        public boolean existsByCurrency(String currencyCode) {
+            return map.values().stream()
+                    .anyMatch(i -> i.baseCurrency().equals(currencyCode) || i.quoteCurrency().equals(currencyCode));
+        }
+    }
+
+    @Test
+    void shouldUpdateQuoteDecimalOnly() {
+        InMemoryFxOutrightStorage storage = new InMemoryFxOutrightStorage();
+        FxOutrightServiceImpl service = new FxOutrightServiceImpl(storage);
+        FxOutright original = new FxOutright("EUR", "USD", ValueDateCode.TOM, 4);
+        storage.save(original);
+
+        service.updateQuoteDecimal(original.code(), 6);
+
+        FxOutright updated = storage.find(original.code()).orElseThrow();
+        assertEquals(6, updated.quoteDecimal());
+        assertEquals("EUR", updated.baseCurrency());
+        assertEquals("USD", updated.quoteCurrency());
+        assertEquals(ValueDateCode.TOM, updated.valueDateCode());
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingAbsent() {
+        InMemoryFxOutrightStorage storage = new InMemoryFxOutrightStorage();
+        FxOutrightServiceImpl service = new FxOutrightServiceImpl(storage);
+        assertThrows(FxOutrightNotFoundException.class,
+                () -> service.updateQuoteDecimal("AAA", 1));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add endpoint and service method for FX_OUTRIGHT quote precision update
- cover update logic with unit test

## Testing
- `mvn -q test` *(fails: Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a2465361f4832d9d70f5ab340ed75d