### PR TITLE
Добавлены маппинги валют для FX Outright

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/mapper/FxOutrightEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/jpa/mapper/FxOutrightEntityMapper.java
@@ -14,6 +14,8 @@ import org.mapstruct.MappingTarget;
 public interface FxOutrightEntityMapper {
 
     /** Преобразует сущность в доменную модель. */
+    @Mapping(target = "baseCurrency", source = "entity.baseCurrency.code")
+    @Mapping(target = "quoteCurrency", source = "entity.quoteCurrency.code")
     FxOutright toDomain(FxOutrightEntity entity);
 
     /** Обновляет сущность данными из доменной модели и валют. */


### PR DESCRIPTION
## Summary
- маппинг кодов валют из сущности в доменную модель FX Outright

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a24dfd70c0832dbdf5ce589c266f71