### PR TITLE
refactor(twelve-free): rename fxOutright variable and update handler description

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxOutrightHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxOutrightHandler.java
@@ -13,7 +13,7 @@ import reactor.core.publisher.Flux;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-/** Handler котировок FX-спот для TwelveData (free). */
+/** Обработчик котировок FX-спот для TwelveData (free). */
 public class TwelveFreeFxOutrightHandler implements InstrumentHandler {
 
     private final WebClient webClient;
@@ -41,10 +41,10 @@ public class TwelveFreeFxOutrightHandler implements InstrumentHandler {
     @Override
     public Flux<QuoteTick> instrumentQuote(Instrument instrument) {
 
-        FxOutright mustBeFxOutright = (FxOutright) instrument;
+        FxOutright fxOutright = (FxOutright) instrument;
 
         // Провайдер ожидает именно такой формат запроса:
-        String symbol = mustBeFxOutright.baseCurrency() + "/" + mustBeFxOutright.quoteCurrency();
+        String symbol = fxOutright.baseCurrency() + "/" + fxOutright.quoteCurrency();
 
         return webClient.get()
                 .uri(b -> b


### PR DESCRIPTION
## Summary
- rename fxOutright variable in TwelveFreeFxOutrightHandler
- update class description to use "Обработчик"

## Testing
- `mvn -q test` *(fails: Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a24ed86fc4832d8b4646ebab0bc5b9