### PR TITLE
Переименование internalCode в code

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/adapter/FxOutrightStorageAdapter.java
@@ -41,14 +41,14 @@ public class FxOutrightStorageAdapter implements FxOutrightStorage {
     }
 
     @Override
-    public void delete(String internalCode) {
-        jpaRepository.findByCode(internalCode)
+    public void delete(String code) {
+        jpaRepository.findByCode(code)
                 .ifPresent(e -> jpaRepository.deleteById(e.getId())); // Удаляем по ID
     }
 
     @Override
-    public Optional<FxOutright> find(String internalCode) {
-        return jpaRepository.findByCode(internalCode)
+    public Optional<FxOutright> find(String code) {
+        return jpaRepository.findByCode(code)
                 .map(mapper::toDomain);
     }
 

--- a/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImplTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/outright/catalog/service/FxOutrightServiceImplTest.java
@@ -25,13 +25,13 @@ class FxOutrightServiceImplTest {
         }
 
         @Override
-        public void delete(String internalCode) {
-            map.remove(internalCode);
+        public void delete(String code) {
+            map.remove(code);
         }
 
         @Override
-        public Optional<FxOutright> find(String internalCode) {
-            return Optional.ofNullable(map.get(internalCode));
+        public Optional<FxOutright> find(String code) {
+            return Optional.ofNullable(map.get(code));
         }
 
         @Override

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/FxOutrightStorage.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/outright/catalog/FxOutrightStorage.java
@@ -13,11 +13,11 @@ public interface FxOutrightStorage {
     /** Сохранить инструмент FX OUTRIGHT. */
     void save(FxOutright instrument);
 
-    /** Удалить инструмент по внутреннему коду. */
-    void delete(String internalCode);
+    /** Удалить инструмент по коду. */
+    void delete(String code);
 
-    /** Найти инструмент по внутреннему коду. */
-    Optional<FxOutright> find(String internalCode);
+    /** Найти инструмент по коду. */
+    Optional<FxOutright> find(String code);
 
     /** Вернуть все инструменты. */
     List<FxOutright> findAll();


### PR DESCRIPTION
## Summary
- replace internalCode parameter with code in FxOutrightStorage and adapter
- align test storage implementation with updated parameter names

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a24fd18e38832d9eb83f3b015188e8