### PR TITLE
Переименованы поля профиля провайдера

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDto.java
@@ -15,8 +15,8 @@ public record ProviderProfileDto(
         @NotBlank String providerCode,
         @NotBlank String displayName,
         @NotNull Set<InstrumentType> instrumentTypes,
-        @NotNull ProviderDeliveryMode providerDeliveryMode,
-        @NotNull ProviderAccessMethod providerAccessMethod,
-        boolean supportsBulkSubscription,
-        int minPollPeriodMs
+        @NotNull ProviderDeliveryMode deliveryMode,
+        @NotNull ProviderAccessMethod accessMethod,
+        boolean bulkSubscription,
+        int minPollMs
 ) {}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileStatusDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileStatusDto.java
@@ -17,8 +17,8 @@ public record ProviderProfileStatusDto(
         @NotBlank String providerCode,
         @NotBlank String displayName,
         @NotNull Set<InstrumentType> instrumentTypes,
-        @NotNull ProviderDeliveryMode providerDeliveryMode,
-        @NotNull ProviderAccessMethod providerAccessMethod,
-        boolean supportsBulkSubscription,
-        int minPollPeriodMs
+        @NotNull ProviderDeliveryMode deliveryMode,
+        @NotNull ProviderAccessMethod accessMethod,
+        boolean bulkSubscription,
+        int minPollMs
 ) {}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/mapper/ProviderProfileDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/mapper/ProviderProfileDtoMapper.java
@@ -5,7 +5,6 @@ import com.alligator.market.backend.provider.profile.catalog.web.dto.ProviderPro
 import com.alligator.market.domain.provider.profile.context.ProviderProfileStatus;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 /**
  * Маппер: профиль провайдера ⇄ DTO.
@@ -14,20 +13,8 @@ import org.mapstruct.Mapping;
 public interface ProviderProfileDtoMapper {
 
     /** Преобразует доменную модель в DTO. */
-    @Mapping(target = "providerDeliveryMode", source = "deliveryMode")
-    @Mapping(target = "providerAccessMethod", source = "accessMethod")
-    @Mapping(target = "supportsBulkSubscription", source = "bulkSubscription")
-    @Mapping(target = "minPollPeriodMs", source = "minPollMs")
     ProviderProfileDto toDto(ProviderProfile profile);
 
     /** Преобразует доменную модель и статус в DTO. */
-    @Mapping(target = "status", source = "status")
-    @Mapping(target = "providerDeliveryMode", source = "profile.deliveryMode")
-    @Mapping(target = "providerAccessMethod", source = "profile.accessMethod")
-    @Mapping(target = "supportsBulkSubscription", source = "profile.bulkSubscription")
-    @Mapping(target = "minPollPeriodMs", source = "profile.minPollMs")
-    @Mapping(target = "providerCode", source = "profile.providerCode")
-    @Mapping(target = "displayName", source = "profile.displayName")
-    @Mapping(target = "instrumentTypes", source = "profile.instrumentTypes")
     ProviderProfileStatusDto toStatusDto(ProviderProfile profile, ProviderProfileStatus status);
 }

--- a/backend/src/test/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDtoJsonTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDtoJsonTest.java
@@ -1,0 +1,67 @@
+package com.alligator.market.backend.provider.profile.catalog.web.dto;
+
+import com.alligator.market.domain.instrument.model.InstrumentType;
+import com.alligator.market.domain.provider.profile.context.ProviderProfileStatus;
+import com.alligator.market.domain.provider.profile.model.ProviderAccessMethod;
+import com.alligator.market.domain.provider.profile.model.ProviderDeliveryMode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Тест JSON сериализации и десериализации DTO профиля провайдера.
+ */
+class ProviderProfileDtoJsonTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** Проверяем профиль без статуса. */
+    @Test
+    void shouldSerializeAndDeserializeProfile() throws Exception {
+        ProviderProfileDto dto = new ProviderProfileDto(
+                "code",
+                "name",
+                Set.of(InstrumentType.FOREX),
+                ProviderDeliveryMode.PUSH,
+                ProviderAccessMethod.API_POLL,
+                true,
+                42
+        );
+        String json = mapper.writeValueAsString(dto);
+        assertTrue(json.contains("\"deliveryMode\""));
+        assertTrue(json.contains("\"accessMethod\""));
+        assertTrue(json.contains("\"bulkSubscription\""));
+        assertTrue(json.contains("\"minPollMs\""));
+
+        ProviderProfileDto restored = mapper.readValue(json, ProviderProfileDto.class);
+        assertEquals(dto, restored);
+    }
+
+    /** Проверяем профиль со статусом. */
+    @Test
+    void shouldSerializeAndDeserializeStatusProfile() throws Exception {
+        ProviderProfileStatusDto dto = new ProviderProfileStatusDto(
+                ProviderProfileStatus.ACTIVE,
+                "code",
+                "name",
+                Set.of(InstrumentType.FOREX),
+                ProviderDeliveryMode.PUSH,
+                ProviderAccessMethod.API_POLL,
+                true,
+                42
+        );
+        String json = mapper.writeValueAsString(dto);
+        assertTrue(json.contains("\"status\""));
+        assertTrue(json.contains("\"deliveryMode\""));
+        assertTrue(json.contains("\"accessMethod\""));
+        assertTrue(json.contains("\"bulkSubscription\""));
+        assertTrue(json.contains("\"minPollMs\""));
+
+        ProviderProfileStatusDto restored = mapper.readValue(json, ProviderProfileStatusDto.class);
+        assertEquals(dto, restored);
+    }
+}

--- a/frontend/src/app/features/provider_profile/models/provider-profile-status.model.ts
+++ b/frontend/src/app/features/provider_profile/models/provider-profile-status.model.ts
@@ -4,7 +4,7 @@ export interface ProviderProfileStatusDto {
   instrumentTypes: string[];
   deliveryMode: string;
   accessMethod: string;
-  supportsBulkSubscription: boolean;
-  minPollPeriodMs: number;
+  bulkSubscription: boolean;
+  minPollMs: number;
   status: string;
 }

--- a/frontend/src/app/features/provider_profile/models/provider-profile.model.ts
+++ b/frontend/src/app/features/provider_profile/models/provider-profile.model.ts
@@ -5,6 +5,6 @@ export interface ProviderProfileDto {
   instrumentTypes: string[];
   deliveryMode: string;
   accessMethod: string;
-  supportsBulkSubscription: boolean;
-  minPollPeriodMs: number;
+  bulkSubscription: boolean;
+  minPollMs: number;
 }

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -45,14 +45,14 @@
           <td mat-cell *matCellDef="let p">{{ p.accessMethod }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="supportsBulkSubscription">
+        <ng-container matColumnDef="bulkSubscription">
           <th mat-header-cell *matHeaderCellDef>Bulk Subscription</th>
-          <td mat-cell *matCellDef="let p">{{ p.supportsBulkSubscription }}</td>
+          <td mat-cell *matCellDef="let p">{{ p.bulkSubscription }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="minPollPeriodMs">
+        <ng-container matColumnDef="minPollMs">
           <th mat-header-cell *matHeaderCellDef>Min Poll Interval, ms</th>
-          <td mat-cell *matCellDef="let p">{{ p.minPollPeriodMs }}</td>
+          <td mat-cell *matCellDef="let p">{{ p.minPollMs }}</td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -24,8 +24,8 @@ export class ProfileListComponent implements OnInit {
     'instrumentTypes',
     'deliveryMode',
     'accessMethod',
-    'supportsBulkSubscription',
-    'minPollPeriodMs'
+    'bulkSubscription',
+    'minPollMs'
   ];
   dataSource = new MatTableDataSource<ProviderProfileStatusDto>([]);
   showAll = false;


### PR DESCRIPTION
## Summary
- переименованы поля deliveryMode, accessMethod, bulkSubscription, minPollMs в DTO профиля провайдера и статусе
- упрощён Mapper и обновлены Angular-модели и шаблоны
- добавлен тест на JSON сериализацию/десериализацию DTO

## Testing
- `mvn -q test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*
- `npm test` *(failed: No binary for Chrome browser on your platform.)*

------
https://chatgpt.com/codex/tasks/task_e_68a24fa7fb64832da0e3e30bf814fee5