### PR TITLE
Rename instrumentTypes field to instrumentsSupported

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDto.java
@@ -14,7 +14,7 @@ public record ProviderProfileDto(
 
         @NotBlank String providerCode,
         @NotBlank String displayName,
-        @NotNull Set<InstrumentType> instrumentTypes,
+        @NotNull Set<InstrumentType> instrumentsSupported,
         @NotNull ProviderDeliveryMode deliveryMode,
         @NotNull ProviderAccessMethod accessMethod,
         boolean bulkSubscription,

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileStatusDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileStatusDto.java
@@ -16,7 +16,7 @@ public record ProviderProfileStatusDto(
         @NotNull ProviderProfileStatus status,
         @NotBlank String providerCode,
         @NotBlank String displayName,
-        @NotNull Set<InstrumentType> instrumentTypes,
+        @NotNull Set<InstrumentType> instrumentsSupported,
         @NotNull ProviderDeliveryMode deliveryMode,
         @NotNull ProviderAccessMethod accessMethod,
         boolean bulkSubscription,

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/model/ProviderProfileEmbedded.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/model/ProviderProfileEmbedded.java
@@ -38,19 +38,19 @@ public class ProviderProfileEmbedded {
     @Column(name = "display_name", length = 50, nullable = false, updatable = false)
     private String displayName;
 
-    /** Поддерживаемые инструменты {@link ProviderProfile#instrumentTypes()}. */
+    /** Поддерживаемые инструменты {@link ProviderProfile#instrumentsSupported()}. */
     @ElementCollection(targetClass = InstrumentType.class)
     @CollectionTable(
-            name = "provider_profile_instrument_type",
+            name = "provider_profile_supported_instrument",
             joinColumns = @JoinColumn(
                     name = "provider_id",
                     referencedColumnName = "id",
-                    foreignKey = @ForeignKey(name = "fk_provider_profile_instrument_type_provider_profile")
+                    foreignKey = @ForeignKey(name = "fk_provider_profile_supported_instrument_provider_profile")
             )
     )
     @Enumerated(EnumType.STRING)
-    @Column(name = "instrument_types", length = 20, nullable = false, updatable = false)
-    private Set<InstrumentType> instrumentTypes;
+    @Column(name = "instruments_supported", length = 20, nullable = false, updatable = false)
+    private Set<InstrumentType> instrumentsSupported;
 
     /** Режим доставки рыночных данных: PULL или PUSH {@link ProviderProfile#deliveryMode()}. */
     @NotNull

--- a/backend/src/test/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDtoJsonTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/profile/catalog/web/dto/ProviderProfileDtoJsonTest.java
@@ -32,6 +32,7 @@ class ProviderProfileDtoJsonTest {
                 42
         );
         String json = mapper.writeValueAsString(dto);
+        assertTrue(json.contains("\"instrumentsSupported\""));
         assertTrue(json.contains("\"deliveryMode\""));
         assertTrue(json.contains("\"accessMethod\""));
         assertTrue(json.contains("\"bulkSubscription\""));
@@ -56,6 +57,7 @@ class ProviderProfileDtoJsonTest {
         );
         String json = mapper.writeValueAsString(dto);
         assertTrue(json.contains("\"status\""));
+        assertTrue(json.contains("\"instrumentsSupported\""));
         assertTrue(json.contains("\"deliveryMode\""));
         assertTrue(json.contains("\"accessMethod\""));
         assertTrue(json.contains("\"bulkSubscription\""));

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/model/ProviderProfile.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/model/ProviderProfile.java
@@ -9,7 +9,7 @@ import java.util.Set;
  *
  * @param providerCode        Технический код провайдера
  * @param displayName         Отображаемое имя провайдера (user friendly)
- * @param instrumentTypes     Поддерживаемые инструменты
+ * @param instrumentsSupported Поддерживаемые инструменты
  * @param deliveryMode        Режим доставки рыночных данных: PULL или PUSH
  * @param accessMethod        Метод доступа к рыночным данным: API_POLL, WEBSOCKET, FIX или другие
  * @param bulkSubscription    Поддержка массовой подписки одним запросом
@@ -19,7 +19,7 @@ public record ProviderProfile(
 
         String providerCode,
         String displayName,
-        Set<InstrumentType> instrumentTypes,
+        Set<InstrumentType> instrumentsSupported,
         ProviderDeliveryMode deliveryMode,
         ProviderAccessMethod accessMethod,
         boolean bulkSubscription,

--- a/frontend/src/app/features/provider_profile/models/provider-profile-status.model.ts
+++ b/frontend/src/app/features/provider_profile/models/provider-profile-status.model.ts
@@ -1,7 +1,7 @@
 export interface ProviderProfileStatusDto {
   providerCode: string;
   displayName: string;
-  instrumentTypes: string[];
+  instrumentsSupported: string[];
   deliveryMode: string;
   accessMethod: string;
   bulkSubscription: boolean;

--- a/frontend/src/app/features/provider_profile/models/provider-profile.model.ts
+++ b/frontend/src/app/features/provider_profile/models/provider-profile.model.ts
@@ -2,7 +2,7 @@
 export interface ProviderProfileDto {
   providerCode: string;
   displayName: string;
-  instrumentTypes: string[];
+  instrumentsSupported: string[];
   deliveryMode: string;
   accessMethod: string;
   bulkSubscription: boolean;

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.html
@@ -30,9 +30,9 @@
           <td mat-cell *matCellDef="let p">{{ p.displayName }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="instrumentTypes">
+        <ng-container matColumnDef="instrumentsSupported">
           <th mat-header-cell *matHeaderCellDef>Instruments</th>
-          <td mat-cell *matCellDef="let p">{{ p.instrumentTypes.join(', ') }}</td>
+          <td mat-cell *matCellDef="let p">{{ p.instrumentsSupported.join(', ') }}</td>
         </ng-container>
 
         <ng-container matColumnDef="deliveryMode">

--- a/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
+++ b/frontend/src/app/features/provider_profile/pages/profile-list/profile-list.component.ts
@@ -21,7 +21,7 @@ export class ProfileListComponent implements OnInit {
     'status',
     'providerCode',
     'displayName',
-    'instrumentTypes',
+    'instrumentsSupported',
     'deliveryMode',
     'accessMethod',
     'bulkSubscription',


### PR DESCRIPTION
## Summary
- rename ProviderProfile field instrumentTypes to instrumentsSupported across backend, domain and frontend
- adjust persistence mapping and DTOs
- update JSON serialization tests and Angular profile list

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3494dbdfc832da4dd75e35270756e