### PR TITLE
refactor: корректное наследование ProviderProfileEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
@@ -18,6 +18,7 @@ import java.util.Set;
  */
 @Entity
 @Table(name = "provider")
+@Inheritance(strategy = InheritanceType.JOINED)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -49,5 +50,5 @@ public class ProviderEntity extends BaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     @Column(name = "profile_status", length = 10, nullable = false)
-    private ProviderProfileStatus profile_status;
+    private ProviderProfileStatus status;
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntityMapper.java
@@ -1,0 +1,21 @@
+package com.alligator.market.backend.provider.catalog.persistence.jpa;
+
+import com.alligator.market.domain.provider.model.Provider;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Маппер: сущность провайдера ⇄ доменная модель.
+ */
+@Mapper(componentModel = "spring")
+public interface ProviderEntityMapper {
+
+    /** Преобразует доменную модель в сущность. */
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "status", source = "profileStatus")
+    ProviderEntity toEntity(Provider provider);
+
+    /** Преобразует сущность в доменную модель. */
+    @Mapping(target = "profileStatus", source = "status")
+    Provider toDomain(ProviderEntity entity);
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProviderProfileEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProviderProfileEntity.java
@@ -18,18 +18,12 @@ import lombok.Setter;
  */
 @Entity
 @Table(name = "provider_profile")
+@PrimaryKeyJoinColumn(name = "id")
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 public class ProviderProfileEntity extends ProviderEntity {
-
-    /** Суррогатный PK. */
-    @EqualsAndHashCode.Include
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
 
     /** Технический код провайдера {@link ProviderProfile#providerCode()}. */
     @NotBlank

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProviderProfileEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProviderProfileEntityMapper.java
@@ -8,15 +8,15 @@ import org.mapstruct.Mapping;
 /**
  * Маппер: сущность профиля провайдера ⇄ доменная модель.
  */
-@Mapper(componentModel = "spring", uses = ProviderProfileEmbeddedMapper.class)
+@Mapper(componentModel = "spring")
 public interface ProviderProfileEntityMapper {
 
     /** Преобразует доменную модель в сущность. */
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "profileParams", source = "profile")
+    @Mapping(target = "instrumentsSupported", ignore = true)
+    @Mapping(target = "status", source = "status")
     ProviderProfileEntity toEntity(ProviderProfile profile, ProviderProfileStatus status);
 
     /** Преобразует сущность в доменную модель. */
-    @Mapping(target = ".", source = "profileParams")
     ProviderProfile toDomain(ProviderProfileEntity entity);
 }


### PR DESCRIPTION
## Summary
- исправлено наследование ProviderProfileEntity от ProviderEntity через JOINED
- добавлен маппер для ProviderEntity
- упрощён маппер ProviderProfileEntityMapper

## Testing
- `mvn -q test` *(failed: Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a4815626a0832d95e6b276db7f9171