### PR TITLE
Добавлена типизация обработчиков и провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -20,13 +20,13 @@ import java.util.Map;
  * Адаптер для провайдера рыночных данных (далее - провайдера) TwelveData (бесплатная подписка).
  */
 @Component
-public class TwelveFreeAdapterV2 implements MarketDataProvider {
+public class TwelveFreeAdapterV2 implements MarketDataProvider<InstrumentHandler<TwelveFreeAdapterV2>> {
 
     // Код провайдера
     private static final String PROVIDER_CODE = "TWELVE_FREE";
 
     // Карта: тип инструмента → handler
-    private final Map<InstrumentType, InstrumentHandler> handlers = new EnumMap<>(InstrumentType.class);
+    private final Map<InstrumentType, InstrumentHandler<TwelveFreeAdapterV2>> handlers = new EnumMap<>(InstrumentType.class);
 
     /**
      * Конструктор адаптера TwelveFreeAdapterV2.
@@ -61,7 +61,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
 
     /** Возвращает карту обработчиков инструментов. */
     @Override
-    public Map<InstrumentType, InstrumentHandler> instrumentHandlers() {
+    public Map<InstrumentType, InstrumentHandler<TwelveFreeAdapterV2>> instrumentHandlers() {
         return handlers;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxOutrightHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxOutrightHandler.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex;
 
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
+import com.alligator.market.backend.provider.adapter.twelve.free.TwelveFreeAdapterV2;
 import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.instrument.model.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
@@ -14,7 +15,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 
 /** Обработчик котировок FX-спот для TwelveData (free). */
-public class TwelveFreeFxOutrightHandler implements InstrumentHandler {
+public class TwelveFreeFxOutrightHandler implements InstrumentHandler<TwelveFreeAdapterV2> {
 
     private final WebClient webClient;
     private final TwelveFreeConnectionProps props;

--- a/backend/src/main/java/com/alligator/market/backend/provider/sync/scanner/ProfileContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/sync/scanner/ProfileContextScannerAdapter.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class ProfileContextScannerAdapter implements ProfileContextScanner {
 
     /** Список всех адаптеров провайдеров. */
-    private final List<MarketDataProvider> providers;
+    private final List<MarketDataProvider<?>> providers;
 
     /** Возвращает список профилей провайдеров. */
     @Override

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
@@ -7,8 +7,10 @@ import reactor.core.publisher.Flux;
 
 /**
  * Контракт обработчика (handler) для конкретного инструмента.
+ *
+ * @param <P> провайдер рыночных данных
  */
-public interface InstrumentHandler {
+public interface InstrumentHandler<P extends MarketDataProvider<?>> {
 
     /** Возвращает поддерживаемый тип инструмента. */
     InstrumentType supportedInstrument();

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -1,10 +1,10 @@
 package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.model.Instrument;
+import com.alligator.market.domain.instrument.model.InstrumentType;
 import com.alligator.market.domain.provider.exeption.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 import com.alligator.market.domain.quote.QuoteTick;
-import com.alligator.market.domain.instrument.model.InstrumentType;
 
 import java.util.Map;
 import java.util.Set;
@@ -12,14 +12,16 @@ import reactor.core.publisher.Flux;
 
 /**
  * Контракт провайдера рыночных данных.
+ *
+ * @param <H> обработчик инструмента
  */
-public interface MarketDataProvider {
+public interface MarketDataProvider<H extends InstrumentHandler<?>> {
 
     /** Возвращает профиль провайдера. */
     ProviderProfile profile();
 
     /** Возвращает карту: тип инструмента → обработчик. */
-    Map<InstrumentType, InstrumentHandler> instrumentHandlers();
+    Map<InstrumentType, H> instrumentHandlers();
 
     /**
      * Возвращает котировку.
@@ -30,12 +32,17 @@ public interface MarketDataProvider {
         // Извлекаем тип инструмента
         InstrumentType instrumentType = instrument.type();
         // Подбираем нужный обработчик для данного типа инструмента
-        InstrumentHandler handler = instrumentHandlers().get(instrumentType);
+        H handler = instrumentHandlers().get(instrumentType);
         // Проверка, что обработчик существует
         if (handler == null) {
             return Flux.error(new InstrumentNotSupportedException(instrumentType, profile().providerCode()));
         }
         // Возвращаем котировку инструмента
         return handler.instrumentQuote(instrument);
+    }
+
+    /** Возвращает набор поддерживаемых типов инструментов. */
+    default Set<InstrumentType> supportedInstrumentTypes() {
+        return instrumentHandlers().keySet();
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/quote/feed/model/InstrumentFeed.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/feed/model/InstrumentFeed.java
@@ -13,7 +13,7 @@ import com.alligator.market.domain.provider.contract.MarketDataProvider;
 public record InstrumentFeed(
 
         Instrument instrument,
-        MarketDataProvider provider,
+        MarketDataProvider<?> provider,
         int priority
 ) {}
 


### PR DESCRIPTION
## Summary
- Уточнены дженерики `InstrumentHandler` и `MarketDataProvider`
- Провайдер TwelveFree и его обработчик типизированы собственным адаптером
- Контекстный сканер и модель `InstrumentFeed` адаптированы к новым типам

## Testing
- `mvn -q test` *(ошибка: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d9174c78832d8a7d9997cb885af8