### PR TITLE
Упрощён набор обработчиков в TwelveFreeAdapterV2

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -3,7 +3,6 @@ package com.alligator.market.backend.provider.adapter.twelve.free;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeWebConfig;
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.TwelveFreeFxOutrightHandler;
-import com.alligator.market.domain.instrument.contract.InstrumentType;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.ProviderAccessMethod;
@@ -13,8 +12,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.EnumMap;
-import java.util.Map;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -27,7 +26,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
     private static final String PROVIDER_CODE = "TWELVE_FREE";
 
     // Список для набора обработчиков
-    private final Set<InstrumentHandler> handlers = Set.of();
+    private final Set<InstrumentHandler> handlers = new HashSet<>();
 
     /**
      * Конструктор адаптера TwelveFreeAdapterV2.
@@ -59,7 +58,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
     /** Возвращает набор обработчиков (handlers) данного провайдера. */
     @Override
     public Set<InstrumentHandler> handlers() {
-        return Set.copyOf(handlers.values());
+        return Collections.unmodifiableSet(handlers);
     }
 }
 


### PR DESCRIPTION
## Summary
- заменён Map на Set для хранения обработчиков
- конструктор добавляет обработчик через `add`
- метод `handlers()` возвращает неизменяемый набор

## Testing
- `mvn -q -pl backend test` *(не удалось: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e34f1eec832dac94f4ab36c3782c