### PR TITLE
Добавлены бизнес-исключения для MarketDataProvider

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
@@ -8,6 +8,9 @@ import com.alligator.market.domain.instrument.type.forex.outright.exception.FxOu
 import com.alligator.market.domain.instrument.type.forex.outright.reference.currency.exception.CurrencyUsedInFxOutrightException;
 import com.alligator.market.domain.instrument.type.forex.outright.reference.currency.exception.CurrencyDuplicateException;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
+import com.alligator.market.domain.provider.exception.ProviderHandlersInvalidException;
+import com.alligator.market.domain.provider.exception.ProviderHandlerMismatchException;
+import com.alligator.market.domain.provider.exception.ProviderInstrumentHandlerDuplicateException;
 import com.alligator.market.domain.provider.sync.exeption.ContextProfileDuplicateException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
@@ -79,5 +82,29 @@ public class ApplicationExceptionHandler {
         // 400, неподдерживаемый тип инструмента
         log.warn("InstrumentNotSupportedException: {}", ex.getMessage());
         return ResponseEntityFactory.error(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    /** Некорректный набор обработчиков провайдера. */
+    @ExceptionHandler(ProviderHandlersInvalidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidHandlers(ProviderHandlersInvalidException ex) {
+        // 500, ошибка конфигурации сервера
+        log.error("ProviderHandlersInvalidException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+
+    /** Обработчик относится к другому провайдеру. */
+    @ExceptionHandler(ProviderHandlerMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHandlerMismatch(ProviderHandlerMismatchException ex) {
+        // 500, ошибка конфигурации сервера
+        log.error("ProviderHandlerMismatchException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+
+    /** Дублирование обработчика по типу инструмента. */
+    @ExceptionHandler(ProviderInstrumentHandlerDuplicateException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDuplicateHandler(ProviderInstrumentHandlerDuplicateException ex) {
+        // 500, ошибка конфигурации сервера
+        log.error("ProviderInstrumentHandlerDuplicateException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -2,6 +2,9 @@ package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
+import com.alligator.market.domain.provider.exception.ProviderHandlersInvalidException;
+import com.alligator.market.domain.provider.exception.ProviderHandlerMismatchException;
+import com.alligator.market.domain.provider.exception.ProviderInstrumentHandlerDuplicateException;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 import com.alligator.market.domain.quote.QuoteTick;
 import com.alligator.market.domain.instrument.contract.InstrumentType;
@@ -61,12 +64,14 @@ public interface MarketDataProvider {
     /**
      * Вызывает проверки обработчиков провайдера.
      *
-     * @throws IllegalStateException при нарушении инвариантов
+     * @throws ProviderHandlersInvalidException           некорректный набор обработчиков
+     * @throws ProviderHandlerMismatchException           обработчик относится к другому провайдеру
+     * @throws ProviderInstrumentHandlerDuplicateException дублирование обработчика по типу инструмента
      */
     default void validateHandlers() {
         // 1) Проверяем, что список обработчиков не пустой и не содержит null элементы
         if (handlers().isEmpty() || handlers().stream().anyMatch(Objects::isNull)) {
-            throw new IllegalStateException("Handlers list must be non-empty and contain no null elements");
+            throw new ProviderHandlersInvalidException();
         }
         // 2) Проверяем, что все обработчики соответствуют данному провайдеру
         String codeFromProfile = profile().providerCode();
@@ -74,15 +79,12 @@ public interface MarketDataProvider {
         for (InstrumentHandler handler : handlers()) {
             String codeFromHandler = handler.providerCode();
             if (!codeFromProfile.equals(codeFromHandler)) {
-                throw new IllegalStateException(
-                        "Handlers list of provider with code " + profile().providerCode() + " has at least one " +
-                                "handler for another provider with code " + codeFromHandler
-                );
+                throw new ProviderHandlerMismatchException(codeFromProfile, codeFromHandler);
             }
             // 3) Проверяем, что тип инструмента уникален для каждого обработчика
             InstrumentType instrumentType = handler.supportedInstrument();
             if (!instrumentTypes.add(instrumentType)) {
-                throw new IllegalStateException("Duplicate handler for instrument type: " + instrumentType);
+                throw new ProviderInstrumentHandlerDuplicateException(instrumentType);
             }
         }
     }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderHandlerMismatchException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderHandlerMismatchException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.domain.provider.exception;
+
+/**
+ * Обработчик относится к другому провайдеру.
+ */
+public class ProviderHandlerMismatchException extends RuntimeException {
+    public ProviderHandlerMismatchException(String providerCode, String handlerCode) {
+        super("Handlers list of provider with code %s has at least one handler for another provider with code %s".formatted(providerCode, handlerCode));
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderHandlersInvalidException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderHandlersInvalidException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.domain.provider.exception;
+
+/**
+ * Некорректный набор обработчиков провайдера.
+ */
+public class ProviderHandlersInvalidException extends RuntimeException {
+    public ProviderHandlersInvalidException() {
+        super("Handlers list must be non-empty and contain no null elements");
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderInstrumentHandlerDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderInstrumentHandlerDuplicateException.java
@@ -1,0 +1,12 @@
+package com.alligator.market.domain.provider.exception;
+
+import com.alligator.market.domain.instrument.contract.InstrumentType;
+
+/**
+ * Дублирование обработчика по типу инструмента.
+ */
+public class ProviderInstrumentHandlerDuplicateException extends RuntimeException {
+    public ProviderInstrumentHandlerDuplicateException(InstrumentType type) {
+        super("Duplicate handler for instrument type: %s".formatted(type));
+    }
+}


### PR DESCRIPTION
## Summary
- replaced `IllegalStateException` with dedicated provider handler exceptions
- registered provider handler exceptions in `ApplicationExceptionHandler`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to missing dependencies; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e8b25360832db05f86fea82644a6