### PR TITLE
feat: вынесена проверка обработчиков провайдера в сервис

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFr
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.TwelveFreeFxOutrightHandler;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
+import com.alligator.market.domain.provider.service.MarketDataProviderService;
 import com.alligator.market.domain.provider.profile.model.ProviderAccessMethod;
 import com.alligator.market.domain.provider.profile.model.ProviderDeliveryMode;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
@@ -28,6 +29,9 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
 
     // Список для набора обработчиков
     private final Set<InstrumentHandler> handlers = new HashSet<>();
+
+    /** Сервис проверки обработчиков. */
+    private static final MarketDataProviderService SERVICE = new MarketDataProviderService();
 
     /**
      * Конструктор адаптера TwelveFreeAdapterV2.
@@ -63,9 +67,8 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
     }
 
     /** Проверяет корректность набора обработчиков после создания компонента. */
-    @Override
     @PostConstruct
     public void validateHandlers() {
-        MarketDataProvider.super.validateHandlers();
+        SERVICE.validateHandlers(this);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -2,16 +2,10 @@ package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
-import com.alligator.market.domain.provider.exception.ProviderHandlersInvalidException;
-import com.alligator.market.domain.provider.exception.ProviderHandlerMismatchException;
-import com.alligator.market.domain.provider.exception.ProviderInstrumentHandlerDuplicateException;
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 import com.alligator.market.domain.quote.QuoteTick;
 import com.alligator.market.domain.instrument.contract.InstrumentType;
-
-import java.util.Objects;
 import java.util.Set;
-import java.util.HashSet;
 
 import reactor.core.publisher.Flux;
 
@@ -66,31 +60,4 @@ public interface MarketDataProvider {
         return handler.instrumentQuote(instrument);
     }
 
-    /**
-     * Вызывает проверки обработчиков провайдера.
-     *
-     * @throws ProviderHandlersInvalidException              некорректный набор обработчиков
-     * @throws ProviderHandlerMismatchException              обработчик относится к другому провайдеру
-     * @throws ProviderInstrumentHandlerDuplicateException   дублирование обработчика по типу инструмента
-     */
-    default void validateHandlers() {
-        // 1) Проверяем, что список обработчиков не пустой и не содержит null элементы
-        if (getHandlers().isEmpty() || getHandlers().stream().anyMatch(Objects::isNull)) {
-            throw new ProviderHandlersInvalidException();
-        }
-        // 2) Проверяем, что все обработчики соответствуют данному провайдеру
-        String codeFromProfile = getProfile().providerCode();
-        Set<InstrumentType> instrumentTypes = new HashSet<>();
-        for (InstrumentHandler handler : getHandlers()) {
-            String codeFromHandler = handler.providerCode();
-            if (!codeFromProfile.equals(codeFromHandler)) {
-                throw new ProviderHandlerMismatchException(codeFromProfile, codeFromHandler);
-            }
-            // 3) Проверяем, что тип инструмента уникален для каждого обработчика
-            InstrumentType instrumentType = handler.supportedInstrument();
-            if (!instrumentTypes.add(instrumentType)) {
-                throw new ProviderInstrumentHandlerDuplicateException(instrumentType);
-            }
-        }
-    }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/service/MarketDataProviderService.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/service/MarketDataProviderService.java
@@ -1,0 +1,51 @@
+package com.alligator.market.domain.provider.service;
+
+import com.alligator.market.domain.instrument.contract.InstrumentType;
+import com.alligator.market.domain.provider.contract.InstrumentHandler;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
+import com.alligator.market.domain.provider.exception.ProviderHandlerMismatchException;
+import com.alligator.market.domain.provider.exception.ProviderHandlersInvalidException;
+import com.alligator.market.domain.provider.exception.ProviderInstrumentHandlerDuplicateException;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Сервис содержит доменную логику для провайдеров рыночных данных.
+ */
+public class MarketDataProviderService {
+
+    /**
+     * Проверяет корректность набора обработчиков указанного провайдера.
+     *
+     * @param provider провайдер для проверки
+     * @throws ProviderHandlersInvalidException            некорректный набор обработчиков
+     * @throws ProviderHandlerMismatchException            обработчик относится к другому провайдеру
+     * @throws ProviderInstrumentHandlerDuplicateException дублирование обработчика по типу инструмента
+     */
+    public void validateHandlers(MarketDataProvider provider) {
+        // 1) Проверяем, что список обработчиков не пустой и не содержит null элементы
+        Set<InstrumentHandler> handlers = provider.getHandlers();
+        if (handlers.isEmpty() || handlers.stream().anyMatch(Objects::isNull)) {
+            throw new ProviderHandlersInvalidException();
+        }
+
+        // 2) Проверяем, что все обработчики соответствуют данному провайдеру
+        String codeFromProfile = provider.getProfile().providerCode();
+        Set<InstrumentType> instrumentTypes = new HashSet<>();
+        for (InstrumentHandler handler : handlers) {
+            String codeFromHandler = handler.providerCode();
+            if (!codeFromProfile.equals(codeFromHandler)) {
+                throw new ProviderHandlerMismatchException(codeFromProfile, codeFromHandler);
+            }
+
+            // 3) Проверяем, что тип инструмента уникален
+            InstrumentType instrumentType = handler.supportedInstrument();
+            if (!instrumentTypes.add(instrumentType)) {
+                throw new ProviderInstrumentHandlerDuplicateException(instrumentType);
+            }
+        }
+    }
+}
+

--- a/domain/src/test/java/com/alligator/market/domain/provider/service/MarketDataProviderServiceTest.java
+++ b/domain/src/test/java/com/alligator/market/domain/provider/service/MarketDataProviderServiceTest.java
@@ -1,0 +1,112 @@
+package com.alligator.market.domain.provider.service;
+
+import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.instrument.contract.InstrumentType;
+import com.alligator.market.domain.provider.contract.InstrumentHandler;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
+import com.alligator.market.domain.provider.exception.ProviderHandlerMismatchException;
+import com.alligator.market.domain.provider.exception.ProviderHandlersInvalidException;
+import com.alligator.market.domain.provider.exception.ProviderInstrumentHandlerDuplicateException;
+import com.alligator.market.domain.provider.profile.model.ProviderAccessMethod;
+import com.alligator.market.domain.provider.profile.model.ProviderDeliveryMode;
+import com.alligator.market.domain.provider.profile.model.ProviderProfile;
+import com.alligator.market.domain.quote.QuoteTick;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/* Тесты для MarketDataProviderService. */
+public class MarketDataProviderServiceTest {
+
+    /* Тестируемый сервис. */
+    private final MarketDataProviderService service = new MarketDataProviderService();
+
+    /* Проверяем, что пустой набор обработчиков вызывает исключение. */
+    @Test
+    void validateHandlersShouldFailOnEmptyHandlers() {
+        MarketDataProvider provider = new TestProvider("P1", Collections.emptySet());
+        assertThrows(ProviderHandlersInvalidException.class, () -> service.validateHandlers(provider));
+    }
+
+    /* Проверяем, что обработчик другого провайдера вызывает исключение. */
+    @Test
+    void validateHandlersShouldFailOnMismatch() {
+        Set<InstrumentHandler> handlers = Set.of(new TestHandler("P2", InstrumentType.FX_OUTRIGHT));
+        MarketDataProvider provider = new TestProvider("P1", handlers);
+        assertThrows(ProviderHandlerMismatchException.class, () -> service.validateHandlers(provider));
+    }
+
+    /* Проверяем, что дублирование типа инструмента вызывает исключение. */
+    @Test
+    void validateHandlersShouldFailOnDuplicateType() {
+        Set<InstrumentHandler> handlers = new HashSet<>();
+        handlers.add(new TestHandler("P1", InstrumentType.FX_OUTRIGHT));
+        handlers.add(new TestHandler("P1", InstrumentType.FX_OUTRIGHT));
+        MarketDataProvider provider = new TestProvider("P1", handlers);
+        assertThrows(ProviderInstrumentHandlerDuplicateException.class, () -> service.validateHandlers(provider));
+    }
+
+    /* Проверяем, что корректные обработчики проходят проверку. */
+    @Test
+    void validateHandlersShouldPass() {
+        Set<InstrumentHandler> handlers = Set.of(new TestHandler("P1", InstrumentType.FX_OUTRIGHT));
+        MarketDataProvider provider = new TestProvider("P1", handlers);
+        assertDoesNotThrow(() -> service.validateHandlers(provider));
+    }
+
+    /* Тестовая реализация провайдера. */
+    private static class TestProvider implements MarketDataProvider {
+
+        private final ProviderProfile profile;
+        private final Set<InstrumentHandler> handlers;
+
+        TestProvider(String code, Set<InstrumentHandler> handlers) {
+            this.profile = new ProviderProfile(code, "", ProviderDeliveryMode.PULL, ProviderAccessMethod.API_POLL, false, 0);
+            this.handlers = handlers;
+        }
+
+        @Override
+        public ProviderProfile getProfile() {
+            return profile;
+        }
+
+        @Override
+        public Set<InstrumentHandler> getHandlers() {
+            return handlers;
+        }
+    }
+
+    /* Тестовая реализация обработчика. */
+    private static class TestHandler implements InstrumentHandler {
+
+        private final String providerCode;
+        private final InstrumentType type;
+
+        TestHandler(String providerCode, InstrumentType type) {
+            this.providerCode = providerCode;
+            this.type = type;
+        }
+
+        @Override
+        public String providerCode() {
+            return providerCode;
+        }
+
+        @Override
+        public InstrumentType supportedInstrument() {
+            return type;
+        }
+
+        @Override
+        public Flux<QuoteTick> instrumentQuote(Instrument instrument) {
+            return Flux.empty();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- вынес проверку обработчиков MarketDataProvider в отдельный сервис
- адаптер TwelveFree теперь использует сервис проверки
- добавлены модульные тесты для проверки корректности обработчиков

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a837a12e04832d9d726c9a8204a1f6