### PR TITLE
feat: add handler validation contract

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -69,6 +69,6 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
     /** Проверяет корректность набора обработчиков после создания компонента. */
     @PostConstruct
     public void validateHandlers() {
-        SERVICE.validateHandlers(this);
+        validateHandlers(SERVICE);
     }
 }

--- a/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2Test.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/twelve/free/adapter/TwelveFreeAdapterV2Test.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFr
 import com.alligator.market.domain.instrument.type.forex.outright.model.FxOutright;
 import com.alligator.market.domain.instrument.type.forex.outright.model.ValueDateCode;
 import com.alligator.market.domain.quote.QuoteTick;
+import com.alligator.market.domain.provider.service.MarketDataProviderService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -32,6 +33,7 @@ class TwelveFreeAdapterV2Test {
                 .build();
 
         TwelveFreeAdapterV2 adapter = new TwelveFreeAdapterV2(props, client);
+        adapter.validateHandlers(new MarketDataProviderService());
 
         FxOutright fxOutright = new FxOutright("EUR", "USD", 4, ValueDateCode.TOM);
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -5,6 +5,7 @@ import com.alligator.market.domain.provider.exception.InstrumentNotSupportedExce
 import com.alligator.market.domain.provider.profile.model.ProviderProfile;
 import com.alligator.market.domain.quote.QuoteTick;
 import com.alligator.market.domain.instrument.contract.InstrumentType;
+import com.alligator.market.domain.provider.service.MarketDataProviderService;
 import java.util.Set;
 
 import reactor.core.publisher.Flux;
@@ -30,6 +31,11 @@ public interface MarketDataProvider {
         return getHandlers().stream()
                 .map(InstrumentHandler::supportedInstrument)
                 .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    /** Запускает проверку обработчиков через сервис. */
+    default void validateHandlers(MarketDataProviderService service) {
+        service.validateHandlers(this);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add default handler validation entry point to market data provider contract
- use new contract method in TwelveFree adapter
- adjust adapter test for new contract

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a83c47e904832da10e7302bdd7c42d