### PR TITLE
Вынесена доменная логика валют

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
+++ b/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
@@ -3,12 +3,14 @@ package com.alligator.market.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Точка входа backend-приложения.
  */
 @SpringBootApplication
+@ComponentScan("com.alligator.market")
 @EnableScheduling
 @ConfigurationPropertiesScan("com.alligator.market")
 public class BackendApplication {

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/crud/CurrencyServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/crud/CurrencyServiceImpl.java
@@ -1,11 +1,7 @@
 package com.alligator.market.backend.instrument.type.forex.spot.reference.currency.catalog.service.crud;
 
-import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.exception.CurrencyUsedInFxSpotException;
-import com.alligator.market.domain.instrument.type.forex.spot.storage.FxSpotStorage;
-import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.exception.CurrencyDuplicateException;
-import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.model.Currency;
-import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.storage.CurrencyStorage;
+import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.service.CurrencyDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,51 +18,31 @@ import java.util.List;
 @Slf4j
 public class CurrencyServiceImpl implements CurrencyService {
 
-    private final CurrencyStorage storage;
-    private final FxSpotStorage fxSpotStorage;
+    private final CurrencyDomainService domainService;
 
     @Override
     public String createCurrency(Currency currency) {
-        storage.findByCode(currency.code()).ifPresent(c -> {
-            throw new CurrencyDuplicateException("code", currency.code());
-        });
-        storage.findByName(currency.name()).ifPresent(c -> {
-            throw new CurrencyDuplicateException("name", currency.name());
-        });
-        String code = storage.save(currency);
+        String code = domainService.add(currency);
         log.info("Currency {} saved", code);
         return code;
     }
 
     @Override
     public void updateCurrency(Currency currency) {
-        storage.findByCode(currency.code())
-                .orElseThrow(() -> new CurrencyNotFoundException(currency.code()));
-        storage.findByName(currency.name()).ifPresent(c -> {
-            if (!c.code().equals(currency.code())) {
-                throw new CurrencyDuplicateException("name", currency.name());
-            }
-        });
-        storage.save(currency);
+        domainService.update(currency);
         log.info("Currency {} updated", currency.code());
     }
 
     @Override
     public void deleteCurrency(String code) {
-        storage.findByCode(code)
-                .orElseThrow(() -> new CurrencyNotFoundException(code));
-        // Проверяем, что валюта не используется в инструментах FX_SPOT, иначе нельзя удалять
-        if (fxSpotStorage.existsByCurrency(code)) {
-            throw new CurrencyUsedInFxSpotException(code);
-        }
-        storage.deleteByCode(code);
+        domainService.remove(code);
         log.info("Currency {} deleted", code);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<Currency> findAll() {
-        List<Currency> result = storage.findAll();
+        List<Currency> result = domainService.getAll();
         log.debug("Found {} currencies", result.size());
         return result;
     }

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>reactor-core</artifactId>
       <version>${reactor.version}</version>
     </dependency>
+    <!-- Spring context для доменных сервисов -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
     <!-- Avro для генерации классов -->
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/reference/currency/service/CurrencyDomainService.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/reference/currency/service/CurrencyDomainService.java
@@ -1,0 +1,76 @@
+package com.alligator.market.domain.instrument.type.forex.spot.reference.currency.service;
+
+import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.exception.CurrencyDuplicateException;
+import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.exception.CurrencyNotFoundException;
+import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.exception.CurrencyUsedInFxSpotException;
+import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.storage.CurrencyStorage;
+import com.alligator.market.domain.instrument.type.forex.spot.storage.FxSpotStorage;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Сервис для операций с валютами.
+ */
+@Service
+public class CurrencyDomainService {
+
+    private final CurrencyStorage storage;
+    private final FxSpotStorage fxSpotStorage;
+
+    public CurrencyDomainService(CurrencyStorage storage, FxSpotStorage fxSpotStorage) {
+        this.storage = storage;
+        this.fxSpotStorage = fxSpotStorage;
+    }
+
+    /** Добавить валюту. */
+    public String add(Currency currency) {
+        // Проверяем уникальность кода
+        storage.findByCode(currency.code()).ifPresent(c -> {
+            throw new CurrencyDuplicateException("code", currency.code());
+        });
+        // Проверяем уникальность имени
+        storage.findByName(currency.name()).ifPresent(c -> {
+            throw new CurrencyDuplicateException("name", currency.name());
+        });
+        return storage.save(currency);
+    }
+
+    /** Получить валюту по коду. */
+    public Currency get(String code) {
+        return storage.findByCode(code)
+                .orElseThrow(() -> new CurrencyNotFoundException(code));
+    }
+
+    /** Обновить валюту. */
+    public void update(Currency currency) {
+        // Убеждаемся, что валюта существует
+        storage.findByCode(currency.code())
+                .orElseThrow(() -> new CurrencyNotFoundException(currency.code()));
+        // Проверяем, что имя не занято другой валютой
+        storage.findByName(currency.name()).ifPresent(c -> {
+            if (!c.code().equals(currency.code())) {
+                throw new CurrencyDuplicateException("name", currency.name());
+            }
+        });
+        storage.save(currency);
+    }
+
+    /** Удалить валюту по коду. */
+    public void remove(String code) {
+        // Проверяем, что валюта существует
+        get(code);
+        // Нельзя удалять, если используется в FX_SPOT
+        if (fxSpotStorage.existsByCurrency(code)) {
+            throw new CurrencyUsedInFxSpotException(code);
+        }
+        storage.deleteByCode(code);
+    }
+
+    /** Вернуть все валюты. */
+    public List<Currency> getAll() {
+        return storage.findAll();
+    }
+}
+


### PR DESCRIPTION
## Summary
- добавлен доменный сервис валют с проверками уникальности и связей
- CurrencyServiceImpl переведён на использование CurrencyDomainService
- настроено сканирование доменных компонентов и подключён spring-context

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/...)*
- `mvn -q test` *(failed: Network is unreachable when resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4bb9bf74832d83d781db5c614e15