### PR TITLE
Rename currency domain service

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/crud/CurrencyServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/crud/CurrencyServiceImpl.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.instrument.type.forex.spot.reference.currency.catalog.service.crud;
 
 import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.model.Currency;
-import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.service.CurrencyDomainService;
+import com.alligator.market.domain.instrument.type.forex.spot.reference.currency.service.CurrencyStorageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,31 +18,31 @@ import java.util.List;
 @Slf4j
 public class CurrencyServiceImpl implements CurrencyService {
 
-    private final CurrencyDomainService domainService;
+    private final CurrencyStorageService storageService;
 
     @Override
     public String createCurrency(Currency currency) {
-        String code = domainService.add(currency);
+        String code = storageService.add(currency);
         log.info("Currency {} saved", code);
         return code;
     }
 
     @Override
     public void updateCurrency(Currency currency) {
-        domainService.update(currency);
+        storageService.update(currency);
         log.info("Currency {} updated", currency.code());
     }
 
     @Override
     public void deleteCurrency(String code) {
-        domainService.remove(code);
+        storageService.remove(code);
         log.info("Currency {} deleted", code);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<Currency> findAll() {
-        List<Currency> result = domainService.getAll();
+        List<Currency> result = storageService.getAll();
         log.debug("Found {} currencies", result.size());
         return result;
     }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/reference/currency/service/CurrencyStorageService.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/reference/currency/service/CurrencyStorageService.java
@@ -11,15 +11,15 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 /**
- * Сервис для операций с валютами.
+ * Сервис работы с хранилищем валют.
  */
 @Service
-public class CurrencyDomainService {
+public class CurrencyStorageService {
 
     private final CurrencyStorage storage;
     private final FxSpotStorage fxSpotStorage;
 
-    public CurrencyDomainService(CurrencyStorage storage, FxSpotStorage fxSpotStorage) {
+    public CurrencyStorageService(CurrencyStorage storage, FxSpotStorage fxSpotStorage) {
         this.storage = storage;
         this.fxSpotStorage = fxSpotStorage;
     }


### PR DESCRIPTION
## Summary
- rename currency service to `CurrencyStorageService`
- adjust backend service

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68ac838f95c4832da53b207f6e17bd8b