### PR TITLE
refactor(currency): align naming across services

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/api/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/api/CurrencyController.java
@@ -66,7 +66,7 @@ public class CurrencyController {
     /** Вернуть все валюты. */
     @GetMapping
     public ResponseEntity<ApiResponse<List<CurrencyDto>>> getAll() {
-        List<CurrencyDto> currencyDtoList = service.findAll()
+        List<CurrencyDto> currencyDtoList = service.getAll()
                 .stream()
                 .map(mapper::toDto)
                 .toList();

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/CurrencyService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/CurrencyService.java
@@ -20,5 +20,5 @@ public interface CurrencyService {
     void deleteCurrency(String code);
 
     /** Вернуть все валюты. */
-    List<Currency> findAll();
+    List<Currency> getAll();
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/CurrencyServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/reference/currency/catalog/service/CurrencyServiceImpl.java
@@ -36,13 +36,13 @@ public class CurrencyServiceImpl implements CurrencyService {
 
     @Override
     public void deleteCurrency(String code) {
-        domain.remove(code);
+        domain.delete(code);
         log.info("Currency {} deleted", code);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<Currency> findAll() {
+    public List<Currency> getAll() {
         List<Currency> result = domain.getAll();
         log.debug("Found {} currencies", result.size());
         return result;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/reference/currency/service/CurrencyDomainService.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/reference/currency/service/CurrencyDomainService.java
@@ -58,7 +58,7 @@ public class CurrencyDomainService {
     }
 
     /** Удалить валюту. */
-    public void remove(String code) {
+    public void delete(String code) {
         // Проверяем, что валюта существует
         get(code);
         // Проверяем, что валюта не используется инструментом FX_SPOT


### PR DESCRIPTION
## Summary
- unify currency service terminology and use getAll consistently
- rename domain remove operation to delete for clarity

## Testing
- `mvn -q -pl domain,backend test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acb7a6fa94832d842b89d49729aa30