### PR TITLE
Использование FxSpotDomainService в backend-сервисе

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotServiceImpl.java
@@ -1,9 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
-import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotDuplicateException;
-import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotSameCurrenciesException;
-import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
-import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotNotFoundException;
+import com.alligator.market.domain.instrument.type.forex.spot.service.FxSpotDomainService;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,46 +19,31 @@ import java.util.List;
 @Slf4j
 public class FxSpotServiceImpl implements FxSpotService {
 
-    private final FxSpotRepository storage;
+    private final FxSpotDomainService domain;
 
     @Override
     public String create(FxSpot instrument) {
-        if (instrument.baseCurrency().equals(instrument.quoteCurrency())) {
-            throw new FxSpotSameCurrenciesException();
-        }
-        storage.find(instrument.getCode()).ifPresent(i -> {
-            throw new FxSpotDuplicateException(instrument.getCode());
-        });
-        storage.save(instrument);
-        log.info("FxSpot {} saved", instrument.getCode());
-        return instrument.getCode();
+        String code = domain.create(instrument);
+        log.info("FxSpot {} created", code);
+        return code;
     }
 
     @Override
     public void updateQuoteDecimal(String code, int quoteDecimal) {
-        FxSpot current = storage.find(code)
-                .orElseThrow(() -> new FxSpotNotFoundException(code));
-        FxSpot updated = new FxSpot(
-                current.baseCurrency(),
-                current.quoteCurrency(),
-                current.valueDateCode(),
-                quoteDecimal
-        );
-        storage.save(updated);
+        domain.updateQuoteDecimal(code, quoteDecimal);
         log.info("FxSpot {} updated", code);
     }
 
     @Override
     public void delete(String code) {
-        storage.find(code).orElseThrow(() -> new FxSpotNotFoundException(code));
-        storage.delete(code);
+        domain.delete(code);
         log.info("FxSpot {} deleted", code);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<FxSpot> findAll() {
-        List<FxSpot> result = storage.findAll();
+        List<FxSpot> result = domain.getAll();
         log.debug("Found {} FX_SPOT instruments", result.size());
         return result;
     }


### PR DESCRIPTION
## Summary
- delegate FX_SPOT operations to domain service

## Testing
- `mvn -q -pl backend -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acd027ca08832dbb3b7ca91d4d0423