### PR TITLE
feat(provider-profile): include status in profile dto

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/api/dto/ProfileDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/api/dto/ProfileDto.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.profile.catalog.api.dto;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.profile.model.AccessMethod;
 import com.alligator.market.domain.provider.profile.model.DeliveryMode;
+import com.alligator.market.domain.provider.profile.model.ProfileStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
@@ -12,6 +13,7 @@ import java.util.Set;
  */
 public record ProfileDto(
 
+        @NotNull ProfileStatus profileStatus,
         @NotBlank String providerCode,
         @NotBlank String displayName,
         @NotNull Set<InstrumentType> instrumentsSupported,

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/api/dto/ProfileDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/api/dto/ProfileDtoMapper.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.provider.profile.catalog.api.dto;
 
-import com.alligator.market.domain.provider.profile.model.ProfileStatus;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import org.mapstruct.Mapper;
 
@@ -12,4 +11,7 @@ public interface ProfileDtoMapper {
 
     /** Преобразует доменную модель в основной DTO. */
     ProfileDto toDto(Profile profile);
+
+    /** Преобразует основной DTO в доменную модель. */
+    Profile toDomain(ProfileDto dto);
 }


### PR DESCRIPTION
## Summary
- add profile status to provider profile dto
- map dto back to domain

## Testing
- `./mvnw -q -e test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0c9281e4832d8ce4c29f9719e28c