### PR TITLE
Align ProfileEntity with Profile record

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProfileEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProfileEntity.java
@@ -28,13 +28,6 @@ import java.util.Set;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class ProfileEntity extends BaseEntity {
 
-    /** Суррогатный PK. */
-    @EqualsAndHashCode.Include
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
-
     /** Статус профиля {@link Profile#profileStatus()}. */
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -86,5 +79,12 @@ public class ProfileEntity extends BaseEntity {
     /** Минимально допустимый интервал опроса в миллисекундах {@link Profile#minPollMs()}. */
     @Column(name = "min_poll_ms", nullable = false, updatable = false)
     private int minPollMs;
+
+    /** Суррогатный PK. */
+    @EqualsAndHashCode.Include
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProfileEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/profile/catalog/persistence/jpa/ProfileEntityMapper.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.profile.catalog.persistence.jpa;
 
 import com.alligator.market.backend.common.jpa.BaseEntityMappingConfig;
 import com.alligator.market.domain.provider.profile.model.Profile;
+import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -12,9 +13,18 @@ import org.mapstruct.Mapping;
 public interface ProfileEntityMapper {
 
     /** Преобразует сущность в доменную модель. */
+    @Mapping(target = "profileStatus", source = "profileStatus")
+    @Mapping(target = "providerCode", source = "providerCode")
+    @Mapping(target = "displayName", source = "displayName")
+    @Mapping(target = "instrumentsSupported", source = "instrumentsSupported")
+    @Mapping(target = "deliveryMode", source = "deliveryMode")
+    @Mapping(target = "accessMethod", source = "accessMethod")
+    @Mapping(target = "bulkSubscription", source = "bulkSubscription")
+    @Mapping(target = "minPollMs", source = "minPollMs")
     Profile toDomain(ProfileEntity entity);
 
     /** Преобразует доменную модель в сущность. */
+    @InheritInverseConfiguration
     @Mapping(target = "id", ignore = true)
     ProfileEntity toEntity(Profile profile);
 }


### PR DESCRIPTION
## Summary
- reorder ProfileEntity fields to mirror Profile record and move surrogate key to end
- refine ProfileEntityMapper with explicit field mappings and inverse configuration

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0fb83b2c832d99bfde65e1092241