### PR TITLE
Move ProfileContextCheck to domain

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProfileContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProfileContextScannerAdapter.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.reconciliation.scanner;
 
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
+import com.alligator.market.domain.provider.reconciliation.ProfileContextCheck;
 import com.alligator.market.domain.provider.reconciliation.ProfileContextScanner;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import lombok.RequiredArgsConstructor;

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileContextCheck.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileContextCheck.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.reconciliation.scanner;
+package com.alligator.market.domain.provider.reconciliation;
 
 import com.alligator.market.domain.provider.profile.exeption.ContextProfileDuplicateException;
 import com.alligator.market.domain.provider.profile.model.Profile;


### PR DESCRIPTION
## Summary
- move ProfileContextCheck to domain layer
- update ProfileContextScannerAdapter imports to use domain check

## Testing
- `mvn -q -pl backend -am compile` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae22e8698c832d8214e4230f167782