### PR TITLE
fix: use getters in FxSpotEntityMapper

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -22,8 +22,8 @@ public interface FxSpotEntityMapper {
     @Mapping(target = "quoteCurrency", source = "quoteCurrency")
     @Mapping(target = "quoteDecimal", source = "model.quoteDecimal")
     @Mapping(target = "valueDateCode", source = "model.valueDateCode")
-    @Mapping(target = "code", expression = "java(model.code())")
-    @Mapping(target = "type", expression = "java(model.type())")
+    @Mapping(target = "code", expression = "java(model.getCode())")
+    @Mapping(target = "type", expression = "java(model.getType())")
     void updateEntity(FxSpot model,
                       CurrencyEntity baseCurrency,
                       CurrencyEntity quoteCurrency,


### PR DESCRIPTION
## Summary
- use getters in `FxSpotEntityMapper` for `code` and `type`

## Testing
- `mvn -q -pl backend -am test` *(fails: Non-resolvable parent POM for com.alligator:market-parent:1.0-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68aef8983364832d90a044483af50565