### PR TITLE
Уточнены методы репозитория FX_SPOT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -9,7 +9,6 @@ import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotR
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -40,8 +39,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     @Override
     public void delete(String code) {
-        jpaRepository.findByCode(code)
-                .ifPresent(e -> jpaRepository.deleteById(e.getId())); // Удаляем по ID
+        jpaRepository.deleteByCode(code); // Удаляем по коду
     }
 
     @Override
@@ -52,7 +50,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     @Override
     public List<FxSpot> findAll() {
-        return jpaRepository.findAll(Sort.by("code")).stream()
+        return jpaRepository.findAllByOrderByCodeAsc().stream()
                 .map(mapper::toDomain)
                 .toList();
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.persiste
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -9,8 +10,17 @@ import java.util.Optional;
  */
 public interface FxSpotJpaRepository extends JpaRepository<FxSpotEntity, Long> {
 
+    /** Сохранить инструмент. */
+    FxSpotEntity save(FxSpotEntity entity);
+
+    /** Удалить инструмент по коду. */
+    void deleteByCode(String code);
+
     /** Найти инструмент по коду. */
     Optional<FxSpotEntity> findByCode(String code);
+
+    /** Вернуть все инструменты. */
+    List<FxSpotEntity> findAllByOrderByCodeAsc();
 
     /** Проверить, используется ли заданная валюта хотя бы в одном инструменте. */
     boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(String baseCurrency, String quoteCurrency);


### PR DESCRIPTION
## Summary
- Явно объявлены методы JPA-репозитория для соответствия доменному порту FxSpotRepository
- Упрощён адаптер: удаление по коду и чтение всех инструментов через специализированный метод

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68af2216c590832dbdb8e47c3090a21f