### PR TITLE
Fix save method override in FxSpotJpaRepository

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +12,9 @@ import java.util.Optional;
 public interface FxSpotJpaRepository extends JpaRepository<FxSpotEntity, Long> {
 
     /** Сохранить инструмент. */
-    FxSpotEntity save(FxSpotEntity entity);
+    @Override
+    @NonNull
+    <S extends FxSpotEntity> S save(@NonNull S entity);
 
     /** Удалить инструмент по коду. */
     void deleteByCode(String code);


### PR DESCRIPTION
## Summary
- add NonNull import and annotations for save method
- align save method generics with JpaRepository

## Testing
- `mvn -q -pl backend test` *(failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68af24489e94832d89b322b9eb2cbd8b