### PR TITLE
Add resource in use exception

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
@@ -6,7 +6,7 @@ import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCu
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotDuplicateException;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotSameCurrenciesException;
 import com.alligator.market.domain.common.exception.NotFoundException;
-import com.alligator.market.domain.instrument.reference.currency.exception.CurrencyUsedInFxSpotException;
+import com.alligator.market.domain.common.exception.ResourceInUseException;
 import com.alligator.market.domain.instrument.reference.currency.exception.CurrencyDuplicateException;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.exception.ProviderHandlersInvalidException;
@@ -37,11 +37,11 @@ public class ApplicationExceptionHandler {
         return ResponseEntityFactory.error(HttpStatus.CONFLICT, ex.getMessage());
     }
 
-    /** Валюта используется в инструментах FX_SPOT. */
-    @ExceptionHandler(CurrencyUsedInFxSpotException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyUsedInFxSpot(CurrencyUsedInFxSpotException ex) {
+    /** Ресурс используется. */
+    @ExceptionHandler(ResourceInUseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleResourceInUse(ResourceInUseException ex) {
         // 409, ресурс занят
-        log.warn("CurrencyUsedInFxSpotException: {}", ex.getMessage());
+        log.warn("ResourceInUseException: {}", ex.getMessage());
         return ResponseEntityFactory.error(HttpStatus.CONFLICT, ex.getMessage());
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/reference/currency/catalog/service/CurrencyUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/reference/currency/catalog/service/CurrencyUseCaseImpl.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.instrument.reference.currency.catalog.service;
 
 import com.alligator.market.domain.common.exception.NotFoundException;
+import com.alligator.market.domain.common.exception.ResourceInUseException;
 import com.alligator.market.domain.instrument.reference.currency.exception.CurrencyDuplicateException;
-import com.alligator.market.domain.instrument.reference.currency.exception.CurrencyUsedInFxSpotException;
 import com.alligator.market.domain.instrument.reference.currency.model.Currency;
 import com.alligator.market.domain.instrument.reference.currency.repository.CurrencyRepository;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
@@ -63,7 +63,7 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
                 .orElseThrow(() -> new NotFoundException("Currency '%s' not found".formatted(code)));
         // Проверяем, что валюта не используется инструментами FX_SPOT
         if (fxSpotRepository.existsByCurrency(code)) {
-            throw new CurrencyUsedInFxSpotException(code);
+            throw new ResourceInUseException("Currency '%s'".formatted(code), "FX_SPOT instrument");
         }
         currencyRepository.deleteByCode(code);
         log.info("Currency {} deleted", code);

--- a/domain/src/main/java/com/alligator/market/domain/common/exception/ResourceInUseException.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/ResourceInUseException.java
@@ -1,0 +1,23 @@
+package com.alligator.market.domain.common.exception;
+
+/**
+ * Ресурс используется в другом контексте.
+ */
+public class ResourceInUseException extends RuntimeException {
+    private final String resource;
+    private final String usageContext;
+
+    public ResourceInUseException(String resource, String usageContext) {
+        super("Resource %s is used in %s".formatted(resource, usageContext));
+        this.resource = resource;
+        this.usageContext = usageContext;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public String getUsageContext() {
+        return usageContext;
+    }
+}


### PR DESCRIPTION
## Summary
- add generic ResourceInUseException to describe busy resources
- use ResourceInUseException when deleting currency used in FX_SPOT
- handle ResourceInUseException with HTTP 409 in global handler

## Testing
- `./mvnw -q -pl backend -am test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68af4c5eeae8832da325ae725e428c85