### PR TITLE
refactor: use Currency in FxSpot model

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
@@ -59,10 +59,10 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
     @Override
     public void deleteCurrency(String code) {
         // Проверяем, что валюта с таким кодом существует
-        currencyRepository.findByCode(code)
+        Currency currency = currencyRepository.findByCode(code)
                 .orElseThrow(() -> new NotFoundException("Currency '%s' not found".formatted(code)));
         // Проверяем, что валюта не используется инструментами FX_SPOT
-        if (fxSpotRepository.existsByCurrency(code)) {
+        if (fxSpotRepository.existsByCurrency(currency)) {
             throw new ResourceInUseException("Currency '%s'".formatted(code), "FX_SPOT instrument");
         }
         currencyRepository.deleteByCode(code);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
@@ -6,7 +6,9 @@ import com.alligator.market.backend.instrument.type.forex.spot.catalog.service.F
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotUpdateDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotDtoMapper;
-import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
+import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,12 +28,16 @@ public class FxSpotController {
 
     private final FxSpotUseCase service;
     private final FxSpotDtoMapper mapper;
+    private final CurrencyRepository currencyRepository;
 
     /** Создать инструмент. */
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid FxSpotDto dto) {
-        FxSpot model = mapper.toDomain(dto);
-        String code = service.create(model);
+        Currency base = currencyRepository.findByCode(dto.baseCurrency())
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(dto.baseCurrency()));
+        Currency quote = currencyRepository.findByCode(dto.quoteCurrency())
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(dto.quoteCurrency()));
+        String code = service.create(base, quote, dto.valueDateCode(), dto.quoteDecimal());
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{code}")
                 .buildAndExpand(code)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/dto/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/dto/FxSpotDtoMapper.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto;
 
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * Маппер: модель ⇄ DTO.
@@ -9,10 +10,9 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface FxSpotDtoMapper {
 
-    /** Преобразует основной DTO в доменную модель. */
-    FxSpot toDomain(FxSpotDto dto);
-
     /** Преобразует доменную модель в основной DTO. */
+    @Mapping(target = "baseCurrency", source = "base.code")
+    @Mapping(target = "quoteCurrency", source = "quote.code")
     FxSpotDto toDto(FxSpot model);
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.instrument.type.forex.spot.catalog.persisten
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyJpaRepository;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntityMapper;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
@@ -29,10 +30,10 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     public void save(FxSpot fxSpot) {
         FxSpotEntity entity = jpaRepository.findByCode(fxSpot.getCode())
                 .orElseGet(FxSpotEntity::new);
-        CurrencyEntity base = currencyRepository.findByCode(fxSpot.baseCurrency())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(fxSpot.baseCurrency()));
-        CurrencyEntity quote = currencyRepository.findByCode(fxSpot.quoteCurrency())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(fxSpot.quoteCurrency()));
+        CurrencyEntity base = currencyRepository.findByCode(fxSpot.base().code())
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(fxSpot.base().code()));
+        CurrencyEntity quote = currencyRepository.findByCode(fxSpot.quote().code())
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(fxSpot.quote().code()));
         mapper.updateEntity(fxSpot, base, quote, entity);
         jpaRepository.save(entity);
     }
@@ -56,7 +57,8 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
-    public boolean existsByCurrency(String currencyCode) {
-        return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(currencyCode, currencyCode);
+    public boolean existsByCurrency(Currency currency) {
+        String code = currency.code();
+        return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(code, code);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa;
 
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntity;
+import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntityMapper;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -9,24 +10,24 @@ import org.mapstruct.MappingTarget;
 /**
  * Маппер: модель ⇄ сущность.
  */
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = CurrencyEntityMapper.class)
 public interface FxSpotEntityMapper {
 
     /** Преобразует сущность в доменную модель. */
-    @Mapping(target = "baseCurrency", source = "entity.baseCurrency.code")
-    @Mapping(target = "quoteCurrency", source = "entity.quoteCurrency.code")
+    @Mapping(target = "base", source = "baseCurrency")
+    @Mapping(target = "quote", source = "quoteCurrency")
     FxSpot toDomain(FxSpotEntity entity);
 
     /** Обновляет сущность данными из доменной модели и валют. */
-    @Mapping(target = "baseCurrency", source = "baseCurrency")
-    @Mapping(target = "quoteCurrency", source = "quoteCurrency")
+    @Mapping(target = "baseCurrency", source = "base")
+    @Mapping(target = "quoteCurrency", source = "quote")
     @Mapping(target = "quoteDecimal", source = "model.quoteDecimal")
     @Mapping(target = "valueDateCode", source = "model.valueDateCode")
     @Mapping(target = "code", expression = "java(model.getCode())")
     @Mapping(target = "type", expression = "java(model.getType())")
     void updateEntity(FxSpot model,
-                      CurrencyEntity baseCurrency,
-                      CurrencyEntity quoteCurrency,
+                      CurrencyEntity base,
+                      CurrencyEntity quote,
                       @MappingTarget FxSpotEntity entity);
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
@@ -1,6 +1,8 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 
 import java.util.List;
 
@@ -10,7 +12,7 @@ import java.util.List;
 public interface FxSpotUseCase {
 
     /** Сохранить новый инструмент. */
-    String create(FxSpot instrument);
+    String create(Currency base, Currency quote, ValueDateCode valueDateCode, Integer quoteDecimal);
 
     /** Обновить точность котировки. */
     void updateQuoteDecimal(String code, int quoteDecimal);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -1,10 +1,10 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
-import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
-import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotDuplicateException;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,16 +24,10 @@ import java.util.List;
 public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
     private final FxSpotRepository fxSpotRepository;
-    private final CurrencyRepository currencyRepository;
 
     @Override
-    public String create(FxSpot instrument) {
-        // Проверяем, что базовая валюта существует
-        currencyRepository.findByCode(instrument.baseCurrency())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(instrument.baseCurrency()));
-        // Проверяем, что котируемая валюта существует
-        currencyRepository.findByCode(instrument.quoteCurrency())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(instrument.quoteCurrency()));
+    public String create(Currency base, Currency quote, ValueDateCode valueDateCode, Integer quoteDecimal) {
+        FxSpot instrument = new FxSpot(base, quote, valueDateCode, quoteDecimal);
         // Проверяем, что инструмента с таким кодом нет
         fxSpotRepository.find(instrument.getCode()).ifPresent(i -> {
             throw new FxSpotDuplicateException(instrument.getCode());
@@ -49,8 +43,8 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
         FxSpot current = fxSpotRepository.find(code)
                 .orElseThrow(() -> new FxSpotNotFoundException(code));
         FxSpot updated = new FxSpot(
-                current.baseCurrency(),
-                current.quoteCurrency(),
+                current.base(),
+                current.quote(),
                 current.valueDateCode(),
                 quoteDecimal
         );

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
@@ -53,7 +53,7 @@ public class TwelveFreeFxSpotHandler implements InstrumentHandler {
         FxSpot fxSpot = (FxSpot) instrument;
 
         // Провайдер ожидает именно такой формат запрашиваемого символа инструмента:
-        String symbol = fxSpot.baseCurrency() + "/" + fxSpot.quoteCurrency();
+        String symbol = fxSpot.base().code() + "/" + fxSpot.quote().code();
 
         return webClient.get()
                 .uri(b -> b

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -2,6 +2,7 @@ package com.alligator.market.domain.instrument.type.forex.spot.model;
 
 import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotSameCurrenciesException;
 
 /**
@@ -9,8 +10,8 @@ import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotSa
  */
 public record FxSpot(
 
-        String baseCurrency,
-        String quoteCurrency,
+        Currency base,
+        Currency quote,
         ValueDateCode valueDateCode,
         Integer quoteDecimal
 
@@ -18,14 +19,14 @@ public record FxSpot(
 
     // Проверяем, что валюты отличаются
     public FxSpot {
-        if (baseCurrency.equals(quoteCurrency)) {
+        if (base.code().equals(quote.code())) {
             throw new FxSpotSameCurrenciesException();
         }
     }
 
     @Override
     public String getCode() {
-        return baseCurrency + quoteCurrency + "_" + valueDateCode;
+        return base.code() + quote.code() + "_" + valueDateCode;
     }
 
     @Override

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.instrument.type.forex.spot.repository;
 
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 
 import java.util.List;
@@ -23,5 +24,5 @@ public interface FxSpotRepository {
     List<FxSpot> findAll();
 
     /** Проверить, используется ли заданная валюта хотя бы в одном инструменте. */
-    boolean existsByCurrency(String currencyCode);
+    boolean existsByCurrency(Currency currency);
 }


### PR DESCRIPTION
## Summary
- represent FxSpot currencies with `Currency` objects
- adjust mappers, repository adapter and service to work with new model
- resolve currencies in controller before instrument creation

## Testing
- `mvn -q -pl backend -am test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68af826f6c24832d9fe4ece06d005cf1