### PR TITLE
Удалены методы по умолчанию из FxSpotJpaRepository

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -10,6 +10,7 @@ import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotR
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -51,7 +52,8 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     @Override
     public List<FxSpot> findAll() {
-        return jpaRepository.findAllByOrderByCodeAsc().stream()
+        return jpaRepository.findAll(Sort.by(Sort.Order.asc("code"))) // Сортируем по коду
+                .stream()
                 .map(mapper::toDomain)
                 .toList();
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
@@ -1,9 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.lang.NonNull;
-
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,19 +8,11 @@ import java.util.Optional;
  */
 public interface FxSpotJpaRepository extends JpaRepository<FxSpotEntity, Long> {
 
-    /** Сохранить инструмент. */
-    @Override
-    @NonNull
-    <S extends FxSpotEntity> S save(@NonNull S entity);
-
     /** Удалить инструмент по коду. */
     void deleteByCode(String code);
 
     /** Найти инструмент по коду. */
     Optional<FxSpotEntity> findByCode(String code);
-
-    /** Вернуть все инструменты. */
-    List<FxSpotEntity> findAllByOrderByCodeAsc();
 
     /** Проверить, используется ли заданная валюта хотя бы в одном инструменте. */
     boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(String baseCurrency, String quoteCurrency);


### PR DESCRIPTION
## Summary
- убрать переопределение save и частный метод findAllByOrderByCodeAsc из FxSpotJpaRepository
- использовать встроенный findAll с сортировкой по коду в адаптере

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b03a5a41e4832da02bbb7c95587af6