### PR TITLE
refactor: перенос проверок валют в сервис FX_SPOT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
@@ -6,9 +6,6 @@ import com.alligator.market.backend.instrument.type.forex.spot.catalog.service.F
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotUpdateDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotDtoMapper;
-import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
-import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
-import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,16 +25,11 @@ public class FxSpotController {
 
     private final FxSpotUseCase service;
     private final FxSpotDtoMapper mapper;
-    private final CurrencyRepository currencyRepository;
 
     /** Создать инструмент. */
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid FxSpotDto dto) {
-        Currency base = currencyRepository.findByCode(dto.baseCurrency())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(dto.baseCurrency()));
-        Currency quote = currencyRepository.findByCode(dto.quoteCurrency())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(dto.quoteCurrency()));
-        String code = service.create(base, quote, dto.valueDateCode(), dto.quoteDecimal());
+        String code = service.create(dto.baseCurrency(), dto.quoteCurrency(), dto.valueDateCode(), dto.quoteDecimal());
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{code}")
                 .buildAndExpand(code)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -7,7 +7,6 @@ import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.p
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntityMapper;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
-import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -31,10 +30,11 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     public void save(FxSpot fxSpot) {
         FxSpotEntity entity = jpaRepository.findByCode(fxSpot.getCode())
                 .orElseGet(FxSpotEntity::new);
+        // Получаем валюты (существование проверено в сервисе)
         CurrencyEntity base = currencyRepository.findByCode(fxSpot.base().code())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(fxSpot.base().code()));
+                .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.base().code())));
         CurrencyEntity quote = currencyRepository.findByCode(fxSpot.quote().code())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(fxSpot.quote().code()));
+                .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.quote().code())));
         mapper.updateEntity(fxSpot, base, quote, entity);
         jpaRepository.save(entity);
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
-import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 
@@ -12,7 +11,7 @@ import java.util.List;
 public interface FxSpotUseCase {
 
     /** Сохранить новый инструмент. */
-    String create(Currency base, Currency quote, ValueDateCode valueDateCode, Integer quoteDecimal);
+    String create(String baseCurrency, String quoteCurrency, ValueDateCode valueDateCode, Integer quoteDecimal);
 
     /** Обновить точность котировки. */
     void updateQuoteDecimal(String code, int quoteDecimal);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -1,6 +1,8 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
+import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotDuplicateException;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
@@ -24,9 +26,14 @@ import java.util.List;
 public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
     private final FxSpotRepository fxSpotRepository;
+    private final CurrencyRepository currencyRepository;
 
     @Override
-    public String create(Currency base, Currency quote, ValueDateCode valueDateCode, Integer quoteDecimal) {
+    public String create(String baseCurrency, String quoteCurrency, ValueDateCode valueDateCode, Integer quoteDecimal) {
+        Currency base = currencyRepository.findByCode(baseCurrency)
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(baseCurrency));
+        Currency quote = currencyRepository.findByCode(quoteCurrency)
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(quoteCurrency));
         FxSpot instrument = new FxSpot(base, quote, valueDateCode, quoteDecimal);
         // Проверяем, что инструмента с таким кодом нет
         fxSpotRepository.find(instrument.getCode()).ifPresent(i -> {


### PR DESCRIPTION
## Summary
- убрать проверки валют из контроллера FX_SPOT
- выполнять валидацию и создание инструмента через сервис по кодам валют
- упростить адаптер репозитория FX_SPOT

## Testing
- `mvn -q -ntp test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f19230c832dad128b11b01d8851