### PR TITLE
feat: map fx spot dto to domain

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
@@ -6,6 +6,7 @@ import com.alligator.market.backend.instrument.type.forex.spot.catalog.service.F
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotUpdateDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto.FxSpotDtoMapper;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,8 @@ public class FxSpotController {
     /** Создать инструмент. */
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid FxSpotDto dto) {
-        String code = service.create(dto.baseCurrency(), dto.quoteCurrency(), dto.valueDateCode(), dto.quoteDecimal());
+        FxSpot fxSpot = mapper.toDomain(dto);
+        String code = service.create(fxSpot);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{code}")
                 .buildAndExpand(code)
@@ -41,7 +43,8 @@ public class FxSpotController {
     @PatchMapping("/{code}")
     public ResponseEntity<ApiResponse<Void>> updateQuoteDecimal(@PathVariable String code,
                                                                 @RequestBody @Valid FxSpotUpdateDto dto) {
-        service.updateQuoteDecimal(code, dto.quoteDecimal());
+        FxSpot fxSpot = mapper.toDomain(code, dto);
+        service.updateQuoteDecimal(fxSpot);
         return ResponseEntityFactory.ok(null);
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/dto/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/dto/FxSpotDtoMapper.java
@@ -1,6 +1,8 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.api.dto;
 
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 import org.springframework.stereotype.Component;
 
 /**
@@ -8,6 +10,33 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class FxSpotDtoMapper {
+
+    /** Преобразует основной DTO в доменную модель. */
+    public FxSpot toDomain(FxSpotDto dto) {
+        // Формируем модель из DTO
+        return new FxSpot(
+                new Currency(dto.baseCurrency(), null, null, null),
+                new Currency(dto.quoteCurrency(), null, null, null),
+                dto.valueDateCode(),
+                dto.quoteDecimal()
+        );
+    }
+
+    /** Преобразует DTO обновления и код в доменную модель. */
+    public FxSpot toDomain(String code, FxSpotUpdateDto dto) {
+        // Разбираем код инструмента
+        String[] parts = code.split("_");
+        String pair = parts[0];
+        String base = pair.substring(0, 3);
+        String quote = pair.substring(3, 6);
+        ValueDateCode valueDate = ValueDateCode.valueOf(parts[1]);
+        return new FxSpot(
+                new Currency(base, null, null, null),
+                new Currency(quote, null, null, null),
+                valueDate,
+                dto.quoteDecimal()
+        );
+    }
 
     /** Преобразует доменную модель в основной DTO. */
     public FxSpotDto toDto(FxSpot model) {

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
@@ -1,7 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 
 import java.util.List;
 
@@ -11,10 +10,10 @@ import java.util.List;
 public interface FxSpotUseCase {
 
     /** Сохранить новый инструмент. */
-    String create(String baseCurrency, String quoteCurrency, ValueDateCode valueDateCode, Integer quoteDecimal);
+    String create(FxSpot fxSpot);
 
     /** Обновить точность котировки. */
-    void updateQuoteDecimal(String code, int quoteDecimal);
+    void updateQuoteDecimal(FxSpot fxSpot);
 
     /** Удалить инструмент по коду. */
     void delete(String code);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -6,7 +6,6 @@ import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCu
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotDuplicateException;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,12 +28,14 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
     private final CurrencyRepository currencyRepository;
 
     @Override
-    public String create(String baseCurrency, String quoteCurrency, ValueDateCode valueDateCode, Integer quoteDecimal) {
-        Currency base = currencyRepository.findByCode(baseCurrency)
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(baseCurrency));
-        Currency quote = currencyRepository.findByCode(quoteCurrency)
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(quoteCurrency));
-        FxSpot instrument = new FxSpot(base, quote, valueDateCode, quoteDecimal);
+    public String create(FxSpot fxSpot) {
+        String baseCode = fxSpot.base().code();
+        String quoteCode = fxSpot.quote().code();
+        Currency base = currencyRepository.findByCode(baseCode)
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(baseCode));
+        Currency quote = currencyRepository.findByCode(quoteCode)
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(quoteCode));
+        FxSpot instrument = new FxSpot(base, quote, fxSpot.valueDateCode(), fxSpot.quoteDecimal());
         // Проверяем, что инструмента с таким кодом нет
         fxSpotRepository.find(instrument.getCode()).ifPresent(i -> {
             throw new FxSpotDuplicateException(instrument.getCode());
@@ -45,7 +46,8 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
     }
 
     @Override
-    public void updateQuoteDecimal(String code, int quoteDecimal) {
+    public void updateQuoteDecimal(FxSpot fxSpot) {
+        String code = fxSpot.getCode();
         // Проверяем, что инструмент существует
         FxSpot current = fxSpotRepository.find(code)
                 .orElseThrow(() -> new FxSpotNotFoundException(code));
@@ -53,7 +55,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
                 current.base(),
                 current.quote(),
                 current.valueDateCode(),
-                quoteDecimal
+                fxSpot.quoteDecimal()
         );
         fxSpotRepository.save(updated);
         log.info("FxSpot {} updated", code);


### PR DESCRIPTION
## Summary
- map FxSpot DTOs to domain model for create and update
- pass FxSpot model to use case methods and controller

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68b05217f65c832db25ecd5c7647999d