### PR TITLE
feat: handle fx spot dto to domain

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
@@ -30,6 +30,7 @@ public class FxSpotController {
     /** Создать инструмент. */
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid FxSpotDto dto) {
+        // Преобразуем DTO → модель и передаем её в сервис
         FxSpot fxSpot = mapper.toDomain(dto);
         String code = service.create(fxSpot);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -43,6 +44,7 @@ public class FxSpotController {
     @PatchMapping("/{code}")
     public ResponseEntity<ApiResponse<Void>> updateQuoteDecimal(@PathVariable String code,
                                                                 @RequestBody @Valid FxSpotUpdateDto dto) {
+        // Собираем модель из кода и DTO и передаем в сервис
         FxSpot fxSpot = mapper.toDomain(code, dto);
         service.updateQuoteDecimal(fxSpot);
         return ResponseEntityFactory.ok(null);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/dto/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/dto/FxSpotDtoMapper.java
@@ -22,14 +22,17 @@ public class FxSpotDtoMapper {
         );
     }
 
-    /** Преобразует DTO обновления и код в доменную модель. */
+    /**
+     * Преобразует код инструмента и DTO обновления в доменную модель.
+     * Код имеет вид EURUSD_SPOT, где первые 3 символа — базовая валюта,
+     * следующие 3 — котируемая, далее через подчёркивание указан код даты.
+     */
     public FxSpot toDomain(String code, FxSpotUpdateDto dto) {
-        // Разбираем код инструмента
-        String[] parts = code.split("_");
-        String pair = parts[0];
-        String base = pair.substring(0, 3);
-        String quote = pair.substring(3, 6);
-        ValueDateCode valueDate = ValueDateCode.valueOf(parts[1]);
+        // Извлекаем части кода
+        String base = code.substring(0, 3);
+        String quote = code.substring(3, 6);
+        ValueDateCode valueDate = ValueDateCode.valueOf(code.substring(7));
+
         return new FxSpot(
                 new Currency(base, null, null, null),
                 new Currency(quote, null, null, null),

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 /**
  * Application-сервис (use case) для операций с инструментами FX_SPOT.
+ *
+ * Все действия принимают или возвращают доменную модель {@link FxSpot}.
  */
 public interface FxSpotUseCase {
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -29,6 +29,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
     @Override
     public String create(FxSpot fxSpot) {
+        // В модели уже указаны коды валют и дата валютирования
         String baseCode = fxSpot.base().code();
         String quoteCode = fxSpot.quote().code();
         Currency base = currencyRepository.findByCode(baseCode)
@@ -47,6 +48,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
     @Override
     public void updateQuoteDecimal(FxSpot fxSpot) {
+        // Из модели получаем код и новую точность
         String code = fxSpot.getCode();
         // Проверяем, что инструмент существует
         FxSpot current = fxSpotRepository.find(code)


### PR DESCRIPTION
## Summary
- parse FX Spot code and update DTO into domain model
- clarify service API to operate on FxSpot models
- document controller flow converting DTO to domain before service calls

## Testing
- `./mvnw -q -pl backend test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b058047f60832d8f4aaa0d84e18f0b