### PR TITLE
Переименован метод updateQuoteDecimal в update

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/api/FxSpotController.java
@@ -43,14 +43,14 @@ public class FxSpotController {
         return ResponseEntityFactory.created(location, code);
     }
 
-    /** Обновить точность котировки. */
+    /** Обновить инструмент. */
     @PatchMapping("/{code}")
-    public ResponseEntity<ApiResponse<Void>> updateQuoteDecimal(@PathVariable String code,
-                                                                @RequestBody @Valid FxSpotUpdateDto dto) {
+    public ResponseEntity<ApiResponse<Void>> update(@PathVariable String code,
+                                                    @RequestBody @Valid FxSpotUpdateDto dto) {
         // Преобразуем код инструмента и DTO в модель
         FxSpot fxSpot = assembler.toDomainByCode(code, dto);
         // Передаем модель сервису
-        service.updateQuoteDecimal(fxSpot);
+        service.update(fxSpot);
         return ResponseEntityFactory.ok(null);
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
@@ -12,8 +12,8 @@ public interface FxSpotUseCase {
     /** Сохранить новый инструмент. */
     String create(FxSpot fxSpot);
 
-    /** Обновить точность котировки. */
-    void updateQuoteDecimal(FxSpot fxSpot);
+    /** Обновить инструмент. */
+    void update(FxSpot fxSpot);
 
     /** Удалить инструмент по коду. */
     void delete(String code);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -36,7 +36,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
     }
 
     @Override
-    public void updateQuoteDecimal(FxSpot fxSpot) {
+    public void update(FxSpot fxSpot) {
         // Из модели извлекаем код
         String code = fxSpot.getCode();
         // Ищем текущий инструмент


### PR DESCRIPTION
## Summary
- rename updateQuoteDecimal to update in FX_SPOT use case
- align controller and implementation with new method name

## Testing
- `mvn -q test` *(fail: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c00d3028832da11986e6c3763db3