### PR TITLE
refactor: получение профилей как карта

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProfileContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProfileContextScannerAdapter.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Компонент реализует доменный контракт сканера контекста приложения:
@@ -24,9 +27,9 @@ public class ProfileContextScannerAdapter implements ProfileContextScanner {
     // Доменный сервис проверки профилей
     private static final ProfileValidator profileValidator = new ProfileValidator();
 
-    /** Возвращает список профилей провайдеров. */
+    /** Возвращает карту профилей провайдеров. */
     @Override
-    public List<Profile> getProfiles() {
+    public Map<String, Profile> getProfiles() {
 
         List<Profile> profiles = providers.stream()
                 .map(MarketDataProvider::getProfile)
@@ -35,8 +38,8 @@ public class ProfileContextScannerAdapter implements ProfileContextScanner {
         // Проверка на дублирование по кодам и именам провайдеров
         profileValidator.validateNoDuplicates(profiles);
 
-
-
-        return profiles;
+        // Преобразуем список в Map по коду провайдера
+        return profiles.stream()
+                .collect(Collectors.toMap(Profile::providerCode, Function.identity()));
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileContextScanner.java
@@ -2,13 +2,16 @@ package com.alligator.market.domain.provider.reconciliation;
 
 import com.alligator.market.domain.provider.profile.model.Profile;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Контракт сканера контекста приложения, извлекающий профили провайдеров.
  */
 public interface ProfileContextScanner {
 
-    /** Вернуть список профилей из контекста. */
-    List<Profile> getProfiles();
+    /**
+     * Вернуть карту профилей из контекста,
+     * где ключ — код провайдера.
+     */
+    Map<String, Profile> getProfiles();
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileReconciler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileReconciler.java
@@ -5,8 +5,6 @@ import com.alligator.market.domain.provider.profile.model.ProfileStatus;
 import com.alligator.market.domain.provider.profile.repository.ProfileRepository;
 
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Доменный сервис сопоставления профилей провайдеров.
@@ -32,8 +30,7 @@ public final class ProfileReconciler {
 
         ProfileDiff diff = new ProfileDiff();
 
-        Map<String, Profile> contextByCode = contextScanner.getProfiles().stream()
-                .collect(Collectors.toMap(Profile::providerCode, Function.identity()));
+        Map<String, Profile> contextByCode = contextScanner.getProfiles();
 
         repository.findAllActive().forEach((id, repoProfile) -> {
             Profile contextProfile = contextByCode.remove(repoProfile.providerCode());


### PR DESCRIPTION
## Summary
- Возвращать Map профилей из контекста
- Сопоставление профилей использует готовую карту

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b763a7379c832da1f0b1e2e265a34f