### PR TITLE
feat: rename context scanner

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/adapter/ProfilesReconcilerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/adapter/ProfilesReconcilerAdapter.java
@@ -4,7 +4,7 @@ import com.alligator.market.backend.config.audit.AuditContext;
 import com.alligator.market.backend.config.audit.AuditContextHolder;
 import com.alligator.market.domain.provider.profile.repository.ProfileRepository;
 import com.alligator.market.domain.provider.reconciliation.ProfileDiff;
-import com.alligator.market.domain.provider.reconciliation.ProfileContextScanner;
+import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
 import com.alligator.market.domain.provider.reconciliation.ProfileReconciler;
 import org.springframework.stereotype.Component;
 
@@ -22,10 +22,10 @@ public class ProfilesReconcilerAdapter {
 
     // Конструктор
     public ProfilesReconcilerAdapter(
-            ProfileContextScanner contextScanner,
+            ProviderContextScanner providerContextScanner,
             ProfileRepository repository
     ) {
-        this.reconciliation = new ProfileReconciler(contextScanner, repository);
+        this.reconciliation = new ProfileReconciler(providerContextScanner, repository);
     }
 
     /** Сравнить профили и получить расхождения в виде {@link ProfileDiff}. */

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.reconciliation.runner;
 
 import com.alligator.market.backend.provider.reconciliation.adapter.ProfilesReconcilerAdapter;
-import com.alligator.market.domain.provider.reconciliation.ProfileContextScanner;
+import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
 import com.alligator.market.domain.provider.reconciliation.ProfileDiff;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +20,8 @@ public class ProfilesReconciliationRunner implements ApplicationRunner {
 
     // Адаптер доменного сервиса сопоставления профилей провайдеров
     private final ProfilesReconcilerAdapter reconciliationAdapter;
-    private final ProfileContextScanner contextScanner;
+    // Сканер контекста провайдеров
+    private final ProviderContextScanner providerContextScanner;
 
     @Override
     public void run(ApplicationArguments args) {

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.reconciliation.scanner;
 
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
-import com.alligator.market.domain.provider.reconciliation.ProfileContextScanner;
+import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.provider.profile.service.ProfileValidator;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +13,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Компонент реализует доменный контракт сканера контекста приложения:
+ * Компонент реализует доменный контракт сканера контекста провайдеров:
  * 1) ищет в контексте Spring все адаптеры провайдеров рыночных данных, реализующих контракт {@link MarketDataProvider};
  * 2) проверяет, что в контексте нет дублей провайдеров по кодам и именам.
  */
 @Component
 @RequiredArgsConstructor
-public class ProfileContextScannerAdapter implements ProfileContextScanner {
+public class ProviderContextScannerAdapter implements ProviderContextScanner {
 
     // Список всех адаптеров провайдеров
     private final List<MarketDataProvider> providers;

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileReconciler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProfileReconciler.java
@@ -3,6 +3,7 @@ package com.alligator.market.domain.provider.reconciliation;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.provider.profile.model.ProfileStatus;
 import com.alligator.market.domain.provider.profile.repository.ProfileRepository;
+import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
 
 import java.util.Map;
 
@@ -11,13 +12,14 @@ import java.util.Map;
  */
 public final class ProfileReconciler {
 
-    private final ProfileContextScanner contextScanner;
+    // Сканер контекста провайдеров
+    private final ProviderContextScanner providerContextScanner;
     private final ProfileRepository repository;
 
     // Конструктор
-    public ProfileReconciler(ProfileContextScanner contextScanner,
+    public ProfileReconciler(ProviderContextScanner providerContextScanner,
                              ProfileRepository repository) {
-        this.contextScanner = contextScanner;
+        this.providerContextScanner = providerContextScanner;
         this.repository = repository;
     }
 
@@ -30,7 +32,7 @@ public final class ProfileReconciler {
 
         ProfileDiff diff = new ProfileDiff();
 
-        Map<String, Profile> contextByCode = contextScanner.getProfiles();
+        Map<String, Profile> contextByCode = providerContextScanner.getProfiles();
 
         repository.findAllActive().forEach((id, repoProfile) -> {
             Profile contextProfile = contextByCode.remove(repoProfile.providerCode());

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
@@ -5,9 +5,9 @@ import com.alligator.market.domain.provider.profile.model.Profile;
 import java.util.Map;
 
 /**
- * Контракт сканера контекста приложения, извлекающий профили провайдеров.
+ * Контракт сканера контекста провайдеров, извлекающего их профили.
  */
-public interface ProfileContextScanner {
+public interface ProviderContextScanner {
 
     /**
      * Вернуть карту профилей из контекста, где ключ — код провайдера.


### PR DESCRIPTION
## Summary
- rename ProfileContextScanner to ProviderContextScanner
- adjust adapter and runner to new provider context scanner
- implement ProviderContextScannerAdapter

## Testing
- `./mvnw -q -pl domain,backend test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b765eed0b4832d95703c35e2100a50