### PR TITLE
Добавлено логирование кодов провайдеров при сопоставлении профилей

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
@@ -32,7 +32,11 @@ public class ProfilesReconciliationRunner implements ApplicationRunner {
 
         // Извлекаем карту профилей провайдеров из контекста, где ключ — код провайдера
         Map<String, Profile> contextProfiles = providerContextScanner.getProfiles();
-
+        // Логируем коды провайдеров, для которых извлечены профили
+        log.info(
+                "Retrieved profiles for providers with codes: {}",
+                contextProfiles.keySet()
+        );
 
         ProfileDiff diff = reconciliationAdapter.compareContextAndRepository();
         reconciliationAdapter.applyContextDiffToStorage(diff);


### PR DESCRIPTION
## Summary
- log provider profile codes retrieved from context

## Testing
- `./mvnw -q -pl backend test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*
- `mvn -q -pl backend test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b769923fb0832dbae833b3d9e59423