### PR TITLE
fix: validate provider handlers individually

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -58,15 +58,10 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
     @Override
     public Map<String, Map<String, InstrumentHandler>> getHandlers() {
 
-        List<Profile> profiles = providers.stream()
-                .map(MarketDataProvider::getProfile)
-                .toList();
-
-        // Проверка на дублирование по кодам и именам провайдеров
-        handlerValidator.validateHandlers(profiles);
+        // Проверяем обработчики каждого провайдера
+        providers.forEach(handlerValidator::validateHandlers);
 
         return providers.stream()
-                .peek(handlerValidator::validateHandlers)
                 .collect(Collectors.toMap(
                         p -> p.getProfile().providerCode(),
                         p -> p.getHandlers().stream()


### PR DESCRIPTION
## Summary
- validate each provider's handlers instead of passing profile list

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b770c5cce4832dbe429e649e736cc2