### PR TITLE
feat: использовать InstrumentType в карте обработчиков

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.reconciliation.runner;
 
 import com.alligator.market.backend.provider.reconciliation.adapter.ProfilesReconcilerAdapter;
+import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
@@ -37,8 +38,8 @@ public class ProfilesReconciliationRunner implements ApplicationRunner {
 
 
         // Извлекаем обработчики (handlers) финансовых инструментов,
-        // где первый ключ — код провайдера, второй ключ — тип финансового инструмента
-        Map<String, Map<String, InstrumentHandler>> contextHandlers = providerContextScanner.getHandlers();
+        // где первый ключ — код провайдера, второй ключ — тип финансового инструмента {@link InstrumentType}
+        Map<String, Map<InstrumentType, InstrumentHandler>> contextHandlers = providerContextScanner.getHandlers();
 
 
         ProfileDiff diff = reconciliationAdapter.compareContextAndRepository();

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.provider.reconciliation.scanner;
 
+import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.profile.model.Profile;
@@ -33,13 +34,13 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
     }
 
     @Override
-    public Map<String, Map<String, InstrumentHandler>> getHandlers() {
+    public Map<String, Map<InstrumentType, InstrumentHandler>> getHandlers() {
         return providers.stream()
                 .collect(Collectors.toMap(
                         p -> p.getProfile().providerCode(),
                         p -> p.getHandlers().stream()
                                 .collect(Collectors.toMap(
-                                        h -> h.getSupportedInstrumentType().name(),
+                                        InstrumentHandler::getSupportedInstrumentType,
                                         Function.identity()
                                 ))
                 ));

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.reconciliation;
 
+import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.profile.model.Profile;
 
@@ -18,7 +19,7 @@ public interface ProviderContextScanner {
 
     /**
      * Вернуть карту обработчиков (handlers) финансовых инструментов,
-     * где первый ключ — код провайдера, второй ключ — тип финансового инструмента.
+     * где первый ключ — код провайдера, второй ключ — тип финансового инструмента {@link InstrumentType}.
      */
-    Map<String, Map<String, InstrumentHandler>> getHandlers();
+    Map<String, Map<InstrumentType, InstrumentHandler>> getHandlers();
 }


### PR DESCRIPTION
## Summary
- применить `InstrumentType` в карте обработчиков провайдеров
- собирать карту обработчиков по `getSupportedInstrumentType`
- обновить использование карты обработчиков при сопоставлении профилей

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM for com.alligator:market-parent:1.0-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c355b118832db20900ccb40a2a18