### PR TITLE
fix: adjust profile context and add handler logging

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
@@ -32,15 +32,15 @@ public class ProfilesReconciliationRunner implements ApplicationRunner {
     public void run(ApplicationArguments args) {
         log.info("Start provider profiles reconciliation");
 
-        // Извлекаем карту профилей провайдеров из контекста, где ключ — код провайдера
-        Map<String, Profile> contextProfiles = providerContextScanner.getProfiles();
+        // Извлекаем карту профилей провайдеров из контекста,
+        // где первый ключ — код провайдера, второй — имя провайдера
+        Map<String, Map<String, Profile>> contextProfiles = providerContextScanner.getProfiles();
         log.info("Retrieved profiles for providers with codes: {}", contextProfiles.keySet());
-
 
         // Извлекаем обработчики (handlers) финансовых инструментов,
         // где первый ключ — код провайдера, второй ключ — тип финансового инструмента {@link InstrumentType}
         Map<String, Map<InstrumentType, InstrumentHandler>> contextHandlers = providerContextScanner.getHandlers();
-
+        log.info("Retrieved handlers for providers with codes: {}", contextHandlers.keySet());
 
         ProfileDiff diff = reconciliationAdapter.compareContextAndRepository();
         reconciliationAdapter.applyContextDiffToStorage(diff);


### PR DESCRIPTION
## Summary
- fix profile context map type
- add handler logging in ProfilesReconciliationRunner

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c557df20832d95dacc863f65046b