### PR TITLE
feat: validate provider context

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
@@ -3,7 +3,9 @@ package com.alligator.market.backend.provider.reconciliation.runner;
 import com.alligator.market.backend.provider.reconciliation.adapter.ProfilesReconcilerAdapter;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
+import com.alligator.market.domain.provider.handler.service.HandlerValidator;
 import com.alligator.market.domain.provider.profile.model.Profile;
+import com.alligator.market.domain.provider.profile.service.ProfileValidator;
 import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
 import com.alligator.market.domain.provider.reconciliation.ProfileDiff;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,12 @@ public class ProfilesReconciliationRunner implements ApplicationRunner {
         // Извлекаем карту обработчиков (handlers) финансовых инструментов из контекста,
         // где первый ключ — код провайдера, второй ключ — тип финансового инструмента
         Map<String, Map<InstrumentType, InstrumentHandler>> contextHandlers = providerContextScanner.getHandlers();
+
+        // Проверяем корректность профилей и обработчиков
+        ProfileValidator profileValidator = new ProfileValidator();
+        HandlerValidator handlerValidator = new HandlerValidator();
+        profileValidator.validateNoDuplicates(contextProfiles);
+        handlerValidator.validateHandlers(contextHandlers);
 
         ProfileDiff diff = reconciliationAdapter.compareContextAndRepository();
         reconciliationAdapter.applyContextDiffToStorage(diff);

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/service/HandlerValidator.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/service/HandlerValidator.java
@@ -8,6 +8,7 @@ import com.alligator.market.domain.provider.exception.ProviderInstrumentHandlerD
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -41,6 +42,30 @@ public class HandlerValidator {
             InstrumentType instrumentType = handler.getSupportedInstrumentType();
             if (!instrumentTypes.add(instrumentType)) {
                 throw new ProviderInstrumentHandlerDuplicateException(instrumentType);
+            }
+        }
+    }
+
+    /**
+     * Проверяет корректность обработчиков из контекста.
+     */
+    public void validateHandlers(Map<String, Map<InstrumentType, InstrumentHandler>> contextHandlers) {
+        if (contextHandlers == null || contextHandlers.isEmpty()) return; // Нечего проверять
+
+        for (Map.Entry<String, Map<InstrumentType, InstrumentHandler>> entry : contextHandlers.entrySet()) {
+            String providerCode = entry.getKey();
+            Map<InstrumentType, InstrumentHandler> handlers = entry.getValue();
+
+            // Карта обработчиков не должна быть пустой и без null элементов
+            if (handlers == null || handlers.isEmpty() || handlers.values().stream().anyMatch(Objects::isNull)) {
+                throw new ProviderHandlersInvalidException();
+            }
+
+            for (InstrumentHandler handler : handlers.values()) {
+                String codeFromHandler = handler.getProviderCode();
+                if (!providerCode.equals(codeFromHandler)) {
+                    throw new ProviderHandlerMismatchException(providerCode, codeFromHandler);
+                }
             }
         }
     }

--- a/domain/src/main/java/com/alligator/market/domain/provider/profile/service/ProfileValidator.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/profile/service/ProfileValidator.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ProfileValidator {
 
@@ -17,6 +19,17 @@ public class ProfileValidator {
 
         checkForDuplicateByParam(profiles, Profile::providerCode, "providerCode");
         checkForDuplicateByParam(profiles, Profile::displayName, "displayName");
+    }
+
+    /** Проверяет уникальность профилей из контекста. */
+    public void validateNoDuplicates(Map<String, Map<String, Profile>> contextProfiles) {
+        if (contextProfiles == null || contextProfiles.isEmpty()) return; // Нечего проверять
+
+        List<Profile> profiles = contextProfiles.values().stream()
+                .flatMap(m -> m.values().stream())
+                .collect(Collectors.toList());
+
+        validateNoDuplicates(profiles);
     }
 
     /**


### PR DESCRIPTION
## Summary
- validate handler and profile maps from provider context
- add map support to HandlerValidator and ProfileValidator

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.alligator:market-parent:1.0-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c97d0a40832d9698e97903672bbc