### PR TITLE
refactor: validate context handlers

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/service/HandlerValidator.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/service/HandlerValidator.java
@@ -1,7 +1,6 @@
 package com.alligator.market.domain.provider.handler.service;
 
 import com.alligator.market.domain.instrument.type.InstrumentType;
-import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.exception.ProviderHandlerMismatchException;
 import com.alligator.market.domain.provider.exception.ProviderHandlersInvalidException;
 import com.alligator.market.domain.provider.exception.ProviderInstrumentHandlerDuplicateException;
@@ -9,63 +8,52 @@ import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 public class HandlerValidator {
 
     /**
-     * Проверяет корректность набора обработчиков указанного провайдера.
+     * Проверяет корректность обработчиков из контекста.
      *
-     * @param provider провайдер для проверки
+     * @param contextHandlers карта обработчиков <providerCode, <InstrumentType, InstrumentHandler>>
      *
      * @throws ProviderHandlersInvalidException              некорректный набор обработчиков
      * @throws ProviderHandlerMismatchException              обработчик относится к другому провайдеру
      * @throws ProviderInstrumentHandlerDuplicateException   дублирование обработчика по типу инструмента
      */
-    public void validateHandlers(MarketDataProvider provider) {
-        // 1) Проверяем, что список обработчиков не пустой и не содержит null элементы
-        Set<InstrumentHandler> handlers = provider.getHandlers();
-        if (handlers.isEmpty() || handlers.stream().anyMatch(Objects::isNull)) {
+    public void validateHandlers(Map<String, Map<InstrumentType, InstrumentHandler>> contextHandlers) {
+        // Карта не должна быть пустой или null
+        if (contextHandlers == null || contextHandlers.isEmpty()) {
             throw new ProviderHandlersInvalidException();
         }
-
-        // 2) Проверяем, что все обработчики соответствуют данному провайдеру
-        String codeFromProfile = provider.getProfile().providerCode();
-        Set<InstrumentType> instrumentTypes = new HashSet<>();
-        for (InstrumentHandler handler : handlers) {
-            String codeFromHandler = handler.getProviderCode();
-            if (!codeFromProfile.equals(codeFromHandler)) {
-                throw new ProviderHandlerMismatchException(codeFromProfile, codeFromHandler);
-            }
-
-            // 3) Проверяем, что тип инструмента уникален
-            InstrumentType instrumentType = handler.getSupportedInstrumentType();
-            if (!instrumentTypes.add(instrumentType)) {
-                throw new ProviderInstrumentHandlerDuplicateException(instrumentType);
-            }
-        }
-    }
-
-    /**
-     * Проверяет корректность обработчиков из контекста.
-     */
-    public void validateHandlers(Map<String, Map<InstrumentType, InstrumentHandler>> contextHandlers) {
-        if (contextHandlers == null || contextHandlers.isEmpty()) return; // Нечего проверять
 
         for (Map.Entry<String, Map<InstrumentType, InstrumentHandler>> entry : contextHandlers.entrySet()) {
             String providerCode = entry.getKey();
             Map<InstrumentType, InstrumentHandler> handlers = entry.getValue();
 
             // 1) Проверяем, что список обработчиков не пустой и не содержит null элементы
-            if (handlers == null || handlers.isEmpty() || handlers.values().stream().anyMatch(Objects::isNull)) {
+            if (handlers == null || handlers.isEmpty() || handlers.values().stream().anyMatch(h -> h == null)) {
                 throw new ProviderHandlersInvalidException();
             }
 
-            for (InstrumentHandler handler : handlers.values()) {
+            Set<InstrumentType> instrumentTypes = new HashSet<>();
+            for (Map.Entry<InstrumentType, InstrumentHandler> handlerEntry : handlers.entrySet()) {
+                InstrumentType instrumentType = handlerEntry.getKey();
+                InstrumentHandler handler = handlerEntry.getValue();
+
+                // 2) Проверяем соответствие провайдеру
                 String codeFromHandler = handler.getProviderCode();
                 if (!providerCode.equals(codeFromHandler)) {
                     throw new ProviderHandlerMismatchException(providerCode, codeFromHandler);
+                }
+
+                // 3) Проверяем уникальность и корректность типа инструмента
+                InstrumentType supportedType = handler.getSupportedInstrumentType();
+                if (supportedType != instrumentType) {
+                    throw new ProviderHandlersInvalidException();
+                }
+                if (!instrumentTypes.add(supportedType)) {
+                    throw new ProviderInstrumentHandlerDuplicateException(supportedType);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- streamline HandlerValidator to work with context handler map only
- add provider and instrument type validation for context handlers

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f5302454832daaa9ab43fb0f34b1