### PR TITLE
feat: добавить базовый провайдер

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -4,8 +4,8 @@ import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFr
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeWebConfig;
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.TwelveFreeFxSpotHandler;
 import com.alligator.market.domain.instrument.type.InstrumentType;
+import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
-import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.AccessMethod;
 import com.alligator.market.domain.provider.profile.model.DeliveryMode;
 import com.alligator.market.domain.provider.profile.model.Profile;
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,13 +22,10 @@ import java.util.stream.Collectors;
  * Адаптер для провайдера рыночных данных TwelveData (бесплатная подписка).
  */
 @Component
-public class TwelveFreeAdapterV2 implements MarketDataProvider {
+public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
 
     // Переменная с кодом провайдера
     private static final String PROVIDER_CODE = "TWELVE_FREE";
-
-    // Список для набора обработчиков
-    private final Set<InstrumentHandler> handlers = new HashSet<>();
 
     /**
      * Конструктор адаптера TwelveFreeAdapterV2.
@@ -41,6 +37,7 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
             TwelveFreeConnectionProps props,
             @Qualifier("twelveFreeWebClient") WebClient webClient
     ) {
+        super(new HashSet<>()); // Передаём набор обработчиков в базовый класс
         // Добавляем обработчики
         handlers.add(new TwelveFreeFxSpotHandler(webClient, props, PROVIDER_CODE));
     }
@@ -63,10 +60,5 @@ public class TwelveFreeAdapterV2 implements MarketDataProvider {
         );
     }
 
-    /** Возвращает набор обработчиков (handlers) данного провайдера. */
-    @Override
-    public Set<InstrumentHandler> getHandlers() {
-        return Collections.unmodifiableSet(handlers);
-    }
 }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -1,0 +1,29 @@
+package com.alligator.market.domain.provider.contract;
+
+import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Базовый класс провайдеров рыночных данных.
+ */
+public abstract class AbstractMarketDataProvider implements MarketDataProvider {
+
+    // Набор обработчиков инструментов
+    protected final Set<InstrumentHandler> handlers;
+
+    /**
+     * Конструктор базового провайдера.
+     *
+     * @param handlers набор обработчиков
+     */
+    protected AbstractMarketDataProvider(Set<InstrumentHandler> handlers) {
+        this.handlers = handlers;
+    }
+
+    /** Возвращает набор обработчиков. */
+    @Override
+    public Set<InstrumentHandler> getHandlers() {
+        return Collections.unmodifiableSet(handlers);
+    }
+}


### PR DESCRIPTION
## Summary
- добавить абстрактный класс для провайдеров рыночных данных
- упростить адаптер TwelveFree, наследовав его от базового класса

## Testing
- `mvn -q -pl domain,backend -am test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf60fa2a4832d9425cfe6c1aa1292