### PR TITLE
Перевод контрактов на Publisher

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -1,6 +1,11 @@
 package com.alligator.market.domain.provider.contract;
 
+import com.alligator.market.domain.instrument.base.Instrument;
+import com.alligator.market.domain.instrument.type.InstrumentType;
+import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
+import com.alligator.market.domain.quote.QuoteTick;
+import org.reactivestreams.Publisher;
 import java.util.Collections;
 import java.util.Set;
 
@@ -19,6 +24,19 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
      */
     protected AbstractMarketDataProvider(Set<InstrumentHandler> handlers) {
         this.handlers = handlers;
+    }
+
+    /** Возвращает котировку. */
+    @Override
+    public Publisher<QuoteTick> getQuote(Instrument instrument) {
+        InstrumentType type = instrument.getType();
+        InstrumentHandler handler = findHandlerForInstrument(type);
+        if (handler == null) {
+            return subscriber -> subscriber.onError(
+                    new InstrumentNotSupportedException(type, getProfile().providerCode())
+            );
+        }
+        return handler.getInstrumentQuote(instrument);
     }
 
     /** Возвращает набор обработчиков. */

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -8,7 +8,7 @@ import com.alligator.market.domain.quote.QuoteTick;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import java.util.Set;
 
-import reactor.core.publisher.Flux;
+import org.reactivestreams.Publisher;
 
 /**
  * Контракт провайдера рыночных данных.
@@ -26,14 +26,7 @@ public interface MarketDataProvider {
      *
      * @throws InstrumentNotSupportedException если подходящий обработчик инструмента не найден
      */
-    default Flux<QuoteTick> getQuote(Instrument instrument) {
-        InstrumentType type = instrument.getType();
-        InstrumentHandler handler = findHandlerForInstrument(type);
-        if (handler == null) {
-            return Flux.error(new InstrumentNotSupportedException(type, getProfile().providerCode()));
-        }
-        return handler.getInstrumentQuote(instrument);
-    }
+    Publisher<QuoteTick> getQuote(Instrument instrument);
 
     /**
      * Находит обработчик для указанного типа инструмента.

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/contract/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/contract/InstrumentHandler.java
@@ -4,7 +4,7 @@ import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.quote.QuoteTick;
-import reactor.core.publisher.Flux;
+import org.reactivestreams.Publisher;
 
 /**
  * Контракт обработчика (handler) для конкретного финансового инструмента.
@@ -19,5 +19,5 @@ public interface InstrumentHandler {
     InstrumentType getSupportedInstrumentType();
 
     /** Возвращает котировку для заданного инструмента. */
-    Flux<QuoteTick> getInstrumentQuote(Instrument instrument);
+    Publisher<QuoteTick> getInstrumentQuote(Instrument instrument);
 }


### PR DESCRIPTION
## Summary
- Переведены интерфейсы провайдеров и обработчиков котировок на общий `Publisher`
- Логика получения котировок вынесена в абстрактный класс `AbstractMarketDataProvider`

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0ff78798832d809dea5dfd02938d