### PR TITLE
Уточнён контракт getQuote и исправлен Publisher

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -6,6 +6,7 @@ import com.alligator.market.domain.provider.exception.InstrumentNotSupportedExce
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.quote.QuoteTick;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 import java.util.Collections;
 import java.util.Set;
 
@@ -28,13 +29,11 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
 
     /** Возвращает котировку. */
     @Override
-    public Publisher<QuoteTick> getQuote(Instrument instrument) {
+    public Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException {
         InstrumentType type = instrument.getType();
         InstrumentHandler handler = findHandlerForInstrument(type);
         if (handler == null) {
-            return subscriber -> subscriber.onError(
-                    new InstrumentNotSupportedException(type, getProfile().providerCode())
-            );
+            return Flux.error(new InstrumentNotSupportedException(type, getProfile().providerCode()));
         }
         return handler.getInstrumentQuote(instrument);
     }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -26,7 +26,7 @@ public interface MarketDataProvider {
      *
      * @throws InstrumentNotSupportedException если подходящий обработчик инструмента не найден
      */
-    Publisher<QuoteTick> getQuote(Instrument instrument);
+    Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException;
 
     /**
      * Находит обработчик для указанного типа инструмента.


### PR DESCRIPTION
## Summary
- Добавлено явное объявление `InstrumentNotSupportedException` в контракте `MarketDataProvider.getQuote`
- Заменён лямбда-провайдер на `Flux.error` в `AbstractMarketDataProvider`

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc120cf14c832db91083af24c373bd