### PR TITLE
Перенесён поиск обработчика в абстрактный провайдер

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -31,7 +31,7 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     @Override
     public Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException {
         InstrumentType type = instrument.getType();
-        InstrumentHandler handler = findHandlerForInstrument(type);
+        InstrumentHandler handler = this.findHandlerForInstrument(type);
         if (handler == null) {
             return Flux.error(new InstrumentNotSupportedException(type, getProfile().providerCode()));
         }
@@ -42,5 +42,19 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     @Override
     public Set<InstrumentHandler> getHandlers() {
         return Collections.unmodifiableSet(handlers);
+    }
+
+    /**
+     * Находит обработчик для указанного типа инструмента.
+     *
+     * @return подходящий обработчик или null
+     */
+    protected InstrumentHandler findHandlerForInstrument(InstrumentType type) {
+        for (InstrumentHandler h : handlers) {
+            if (h.getSupportedInstrumentType() == type) {
+                return h;
+            }
+        }
+        return null;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -5,7 +5,6 @@ import com.alligator.market.domain.provider.exception.InstrumentNotSupportedExce
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.quote.QuoteTick;
-import com.alligator.market.domain.instrument.type.InstrumentType;
 import java.util.Set;
 
 import org.reactivestreams.Publisher;
@@ -28,17 +27,4 @@ public interface MarketDataProvider {
      */
     Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException;
 
-    /**
-     * Находит обработчик для указанного типа инструмента.
-     *
-     * @return подходящий обработчик или null
-     */
-    default InstrumentHandler findHandlerForInstrument(InstrumentType type) {
-        for (InstrumentHandler h : getHandlers()) {
-            if (h.getSupportedInstrumentType() == type) {
-                return h;
-            }
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
## Summary
- убран поиск обработчика из интерфейса `MarketDataProvider`
- реализован защищённый поиск обработчика в `AbstractMarketDataProvider`
- `getQuote` использует внутренний метод для выбора обработчика

## Testing
- `./mvnw -q -pl domain test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68bc163dbfc0832dba1d334380d7261b