### PR TITLE
refactor(provider): use map for handlers

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -14,9 +14,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Адаптер для провайдера рыночных данных TwelveData (бесплатная подписка).
@@ -37,27 +36,21 @@ public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
             TwelveFreeConnectionProps props,
             @Qualifier("twelveFreeWebClient") WebClient webClient
     ) {
-        // TODO: узнать как используется super и HashSet<>()
-        super(new HashSet<>()); // Передаём набор обработчиков в базовый класс
-        // Добавляем обработчики
-        handlers.add(new TwelveFreeFxSpotHandler(webClient, props, PROVIDER_CODE));
-    }
-
-    /** Возвращает профиль провайдера. */
-    @Override
-    public Profile getProfile() {
-        Set<InstrumentType> instruments = handlers.stream()
-                .map(InstrumentHandler::getSupportedInstrumentType)
-                .collect(Collectors.toSet());
-        return new Profile(
-                ProfileStatus.ACTIVE,
-                PROVIDER_CODE,
-                "TwelveData Free Plan",
-                instruments,
-                DeliveryMode.PULL,
-                AccessMethod.API_POLL,
-                false,
-                60_000
+        super(
+                Map.<InstrumentType, InstrumentHandler>of(
+                        InstrumentType.FX_SPOT,
+                        new TwelveFreeFxSpotHandler(webClient, props, PROVIDER_CODE)
+                ),
+                new Profile(
+                        ProfileStatus.ACTIVE,
+                        PROVIDER_CODE,
+                        "TwelveData Free Plan",
+                        Set.of(InstrumentType.FX_SPOT),
+                        DeliveryMode.PULL,
+                        AccessMethod.API_POLL,
+                        false,
+                        60_000
+                )
         );
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -29,7 +29,7 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
     @Override
     public List<InstrumentHandler> getHandlers() {
         return providers.stream()
-                .flatMap(p -> p.getHandlers().stream())
+                .flatMap(p -> p.getHandlers().values().stream())
                 .collect(Collectors.toList());
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -8,7 +8,7 @@ import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.quote.QuoteTick;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * Абстрактный каркас провайдера рыночных данных.
@@ -18,13 +18,13 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     // Профиль провайдера
     protected final Profile profile;
 
-    // Набор обработчиков инструментов
-    protected final Set<InstrumentHandler> handlers;
+    // Карта обработчиков инструментов
+    protected final Map<InstrumentType, InstrumentHandler> handlersMap;
 
     // Конструктор
-    protected AbstractMarketDataProvider(Set<InstrumentHandler> handlers, Profile profile) {
+    protected AbstractMarketDataProvider(Map<InstrumentType, InstrumentHandler> handlersMap, Profile profile) {
         this.profile = profile;
-        this.handlers = Set.copyOf(handlers);
+        this.handlersMap = Map.copyOf(handlersMap);
     }
 
     /** Возвращает профиль провайдера. */
@@ -33,10 +33,10 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
         return profile;
     }
 
-    /** Возвращает набор обработчиков. */
+    /** Возвращает карту обработчиков. */
     @Override
-    public Set<InstrumentHandler> getHandlers() {
-        return handlers;
+    public Map<InstrumentType, InstrumentHandler> getHandlers() {
+        return handlersMap;
     }
 
     /**
@@ -47,24 +47,10 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     @Override
     public Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException {
         InstrumentType type = instrument.getType();
-        InstrumentHandler handler = this.findHandlerForInstrument(type);
+        InstrumentHandler handler = handlersMap.get(type);
         if (handler == null) {
             return Flux.error(new InstrumentNotSupportedException(type, getProfile().providerCode()));
         }
         return handler.getInstrumentQuote(instrument);
-    }
-
-    /**
-     * Находит обработчик для указанного типа инструмента.
-     *
-     * @return подходящий обработчик или null
-     */
-    protected InstrumentHandler findHandlerForInstrument(InstrumentType type) {
-        for (InstrumentHandler h : handlers) {
-            if (h.getSupportedInstrumentType() == type) {
-                return h;
-            }
-        }
-        return null;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -5,7 +5,8 @@ import com.alligator.market.domain.provider.exception.InstrumentNotSupportedExce
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.quote.QuoteTick;
-import java.util.Set;
+import com.alligator.market.domain.instrument.type.InstrumentType;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 
@@ -17,8 +18,8 @@ public interface MarketDataProvider {
     /** Возвращает профиль провайдера {@link Profile}. */
     Profile getProfile();
 
-    /** Возвращает набор обработчиков {@link InstrumentHandler}. */
-    Set<InstrumentHandler> getHandlers();
+    /** Возвращает карту обработчиков {@link InstrumentHandler}. */
+    Map<InstrumentType, InstrumentHandler> getHandlers();
 
     /**
      * Возвращает котировку.


### PR DESCRIPTION
## Summary
- store instrument handlers in a map keyed by instrument type
- query handlers directly by instrument type
- adjust TwelveFree adapter and context scanner to new map API

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68bc21e5684c832d8cfd299c978b9f83