### PR TITLE
feat: add provider reference to instrument handlers

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -5,6 +5,8 @@ import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFr
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.TwelveFreeFxSpotHandler;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
+import com.alligator.market.domain.provider.contract.InstrumentHandler;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.AccessMethod;
 import com.alligator.market.domain.provider.profile.model.DeliveryMode;
 import com.alligator.market.domain.provider.profile.model.Profile;
@@ -35,11 +37,12 @@ public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
             TwelveFreeConnectionProps props,
             @Qualifier("twelveFreeWebClient") WebClient webClient
     ) {
+        Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlers = Map.of(
+                InstrumentType.FX_SPOT,
+                new TwelveFreeFxSpotHandler(webClient, props, PROVIDER_CODE)
+        );
         super(
-                Map.of(
-                        InstrumentType.FX_SPOT,
-                        new TwelveFreeFxSpotHandler(webClient, props, PROVIDER_CODE)
-                ),
+                handlers,
                 new Profile(
                         ProfileStatus.ACTIVE,
                         PROVIDER_CODE,

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex;
 
+import com.alligator.market.backend.provider.adapter.twelve.free.TwelveFreeAdapterV2;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
 import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
@@ -17,7 +18,7 @@ import java.time.Instant;
  * Обработчик (handler) инструмента FX_SPOT для TwelveData (free).
  * Код провайдера и тип инструмента задаются в родительском классе.
  */
-public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler {
+public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFreeAdapterV2> {
 
     // Веб-клиент для запросов к провайдеру
     private final WebClient webClient;

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.reconciliation.runner;
 
 import com.alligator.market.backend.provider.reconciliation.adapter.ProfilesReconcilerAdapter;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.provider.profile.service.ProfileValidator;
 import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
@@ -40,7 +41,7 @@ public class ProfilesReconciliationRunner implements ApplicationRunner {
 
         // Извлекаем список обработчиков из контекста
         // TODO: вероятно не нужен метод getHandlers так как теперь есть абстрактная модель провайдера, в которой есть карта обработчиков
-        List<InstrumentHandler> contextHandlers = providerContextScanner.getHandlers();
+        List<InstrumentHandler<? extends MarketDataProvider>> contextHandlers = providerContextScanner.getHandlers();
 
         ProfileDiff diff = reconciliationAdapter.compareContextAndRepository();
         reconciliationAdapter.applyContextDiffToStorage(diff);

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.reconciliation.scanner;
 
-import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
     }
 
     @Override
-    public List<InstrumentHandler> getHandlers() {
+    public List<InstrumentHandler<? extends MarketDataProvider>> getHandlers() {
         return providers.stream()
                 .flatMap(p -> p.getHandlers().values().stream())
                 .collect(Collectors.toList());

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
@@ -5,7 +5,11 @@ import com.alligator.market.domain.instrument.type.InstrumentType;
 /**
  * Абстрактный каркас обработчика инструмента.
  */
-public abstract class AbstractInstrumentHandler implements InstrumentHandler {
+public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
+        implements InstrumentHandler<P> {
+
+    // Ссылка на провайдера
+    private P provider;
 
     // Код провайдера
     private final String providerCode;
@@ -17,6 +21,17 @@ public abstract class AbstractInstrumentHandler implements InstrumentHandler {
     protected AbstractInstrumentHandler(String providerCode, InstrumentType supportedInstrumentType) {
         this.providerCode = providerCode;
         this.supportedInstrumentType = supportedInstrumentType;
+    }
+
+    // Устанавливаем провайдера
+    void setProvider(P provider) {
+        this.provider = provider;
+    }
+
+    /** Возвращает ссылку на провайдера. */
+    @Override
+    public P getProvider() {
+        return provider;
     }
 
     /** Возвращает код провайдера рыночных данных, к которому относится обработчик. */

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -18,12 +18,21 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     protected final Profile profile;
 
     // Карта обработчиков инструментов
-    protected final Map<InstrumentType, InstrumentHandler> handlersMap;
+    protected final Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlersMap;
 
     // Конструктор
-    protected AbstractMarketDataProvider(Map<InstrumentType, InstrumentHandler> handlersMap, Profile profile) {
+    protected AbstractMarketDataProvider(
+            Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlersMap,
+            Profile profile
+    ) {
         this.profile = profile;
         this.handlersMap = Map.copyOf(handlersMap);
+        this.handlersMap.values().forEach(h -> {
+            if (h instanceof AbstractInstrumentHandler<?> handler) {
+                // Передаем ссылку на провайдера
+                ((AbstractInstrumentHandler) handler).setProvider(this);
+            }
+        });
     }
 
     /** Возвращает профиль провайдера. */
@@ -34,7 +43,7 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
 
     /** Возвращает карту обработчиков. */
     @Override
-    public Map<InstrumentType, InstrumentHandler> getHandlers() {
+    public Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> getHandlers() {
         return handlersMap;
     }
 
@@ -46,7 +55,7 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     @Override
     public Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException {
         InstrumentType type = instrument.getType();
-        InstrumentHandler handler = handlersMap.get(type);
+        InstrumentHandler<? extends MarketDataProvider> handler = handlersMap.get(type);
         if (handler == null) {
             return Flux.error(new InstrumentNotSupportedException(type, getProfile().providerCode()));
         }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
@@ -9,10 +9,13 @@ import org.reactivestreams.Publisher;
  * Контракт обработчика (handler) для конкретного финансового инструмента.
  * Каждый провайдер рыночных данных {@link MarketDataProvider} должен иметь как минимум один обработчик.
  */
-public interface InstrumentHandler {
+public interface InstrumentHandler<P extends MarketDataProvider> {
 
     /** Возвращает внутренний код провайдера рыночных данных, к которому относится обработчик. */
     String getProviderCode();
+
+    /** Возвращает провайдера, к которому относится обработчик. */
+    P getProvider();
 
     /** Возвращает тип финансового инструмента, который поддерживает данный обработчик. */
     InstrumentType getSupportedInstrumentType();

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -18,7 +18,7 @@ public interface MarketDataProvider {
     Profile getProfile();
 
     /** Возвращает карту обработчиков {@link InstrumentHandler}. */
-    Map<InstrumentType, InstrumentHandler> getHandlers();
+    Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> getHandlers();
 
     /**
      * Возвращает котировку.

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.provider.reconciliation;
 
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.Profile;
 
 import java.util.List;
@@ -14,5 +15,5 @@ public interface ProviderContextScanner {
     List<Profile> getProfiles();
 
     /** Вернуть список обработчиков финансовых инструментов из контекста. */
-    List<InstrumentHandler> getHandlers();
+    List<InstrumentHandler<? extends MarketDataProvider>> getHandlers();
 }


### PR DESCRIPTION
## Summary
- expand InstrumentHandler with provider generics and add provider getter
- wire provider instances into instrument handlers and map
- adapt TwelveFree provider/handler to new typed contracts

## Testing
- `mvn -q -pl backend,domain,infra -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bd677fa7dc832dade56f81fec559a4