### PR TITLE
Упрощён контракт обработчика инструмента

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -39,7 +39,7 @@ public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
     ) {
         Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlers = Map.of(
                 InstrumentType.FX_SPOT,
-                new TwelveFreeFxSpotHandler(webClient, props, PROVIDER_CODE)
+                new TwelveFreeFxSpotHandler(webClient, props)
         );
         super(
                 handlers,

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
@@ -16,7 +16,7 @@ import java.time.Instant;
 
 /**
  * Обработчик (handler) инструмента FX_SPOT для TwelveData (free).
- * Код провайдера и тип инструмента задаются в родительском классе.
+ * Тип инструмента задаётся в родительском классе.
  */
 public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFreeAdapterV2> {
 
@@ -29,10 +29,9 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
     // Конструктор
     public TwelveFreeFxSpotHandler(
             WebClient webClient,
-            TwelveFreeConnectionProps props,
-            String providerCode
+            TwelveFreeConnectionProps props
     ) {
-        super(providerCode, InstrumentType.FX_SPOT);
+        super(InstrumentType.FX_SPOT);
         this.webClient = webClient;
         this.props = props;
     }
@@ -73,7 +72,7 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
                 price,
                 price,
                 Instant.now(),
-                getProviderCode()
+                getProvider().getProfile().providerCode()
         );
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
@@ -11,15 +11,11 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
     // Ссылка на провайдера
     private P provider;
 
-    // Код провайдера
-    private final String providerCode;
-
     // Поддерживаемый тип инструмента
     private final InstrumentType supportedInstrumentType;
 
     // Конструктор
-    protected AbstractInstrumentHandler(String providerCode, InstrumentType supportedInstrumentType) {
-        this.providerCode = providerCode;
+    protected AbstractInstrumentHandler(InstrumentType supportedInstrumentType) {
         this.supportedInstrumentType = supportedInstrumentType;
     }
 
@@ -32,12 +28,6 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
     @Override
     public P getProvider() {
         return provider;
-    }
-
-    /** Возвращает код провайдера рыночных данных, к которому относится обработчик. */
-    @Override
-    public String getProviderCode() {
-        return providerCode;
     }
 
     /** Возвращает поддерживаемый тип инструмента. */

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
@@ -11,9 +11,6 @@ import org.reactivestreams.Publisher;
  */
 public interface InstrumentHandler<P extends MarketDataProvider> {
 
-    /** Возвращает внутренний код провайдера рыночных данных, к которому относится обработчик. */
-    String getProviderCode();
-
     /** Возвращает провайдера, к которому относится обработчик. */
     P getProvider();
 


### PR DESCRIPTION
## Summary
- удалён `providerCode` из контракта и базового класса обработчика
- обновлён `TwelveFreeFxSpotHandler` с получением кода из профиля провайдера
- адаптер `TwelveFreeAdapterV2` создаёт обработчик без передачи `providerCode`

## Testing
- `mvn -q -pl domain,backend test` *(failed: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6c9c7fa0832d96a40e28c00a2547