### PR TITLE
feat(provider): track supported instruments

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -4,6 +4,8 @@ import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFr
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeWebConfig;
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.TwelveFreeFxSpotHandler;
 import com.alligator.market.domain.instrument.type.InstrumentType;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
 import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
@@ -32,14 +34,17 @@ public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
      *
      * @param props     конфигурационные настройки подключения {@link TwelveFreeConnectionProps}
      * @param webClient конфигурационный класс веб-клиента {@link TwelveFreeWebConfig}
+     * @param fxSpotRepository репозиторий инструментов FX_SPOT
      */
     public TwelveFreeAdapterV2(
             TwelveFreeConnectionProps props,
-            @Qualifier("twelveFreeWebClient") WebClient webClient
+            @Qualifier("twelveFreeWebClient") WebClient webClient,
+            FxSpotRepository fxSpotRepository
     ) {
+        Set<FxSpot> instruments = Set.copyOf(fxSpotRepository.findAll());
         Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlers = Map.of(
                 InstrumentType.FX_SPOT,
-                new TwelveFreeFxSpotHandler(webClient, props)
+                new TwelveFreeFxSpotHandler(webClient, props, instruments)
         );
         super(
                 handlers,

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
@@ -13,6 +13,7 @@ import reactor.core.publisher.Flux;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Set;
 
 /**
  * Обработчик (handler) инструмента FX_SPOT для TwelveData (free).
@@ -29,9 +30,10 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
     // Конструктор
     public TwelveFreeFxSpotHandler(
             WebClient webClient,
-            TwelveFreeConnectionProps props
+            TwelveFreeConnectionProps props,
+            Set<FxSpot> instruments
     ) {
-        super(InstrumentType.FX_SPOT);
+        super(InstrumentType.FX_SPOT, instruments);
         this.webClient = webClient;
         this.props = props;
     }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
@@ -1,6 +1,10 @@
 package com.alligator.market.domain.provider.contract;
 
+import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Абстрактный каркас обработчика инструмента.
@@ -14,9 +18,24 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
     // Поддерживаемый тип инструмента
     private final InstrumentType supportedInstrumentType;
 
+    // Набор поддерживаемых инструментов
+    private final Set<Instrument> supportedInstruments;
+
     // Конструктор
-    protected AbstractInstrumentHandler(InstrumentType supportedInstrumentType) {
+    protected AbstractInstrumentHandler(InstrumentType supportedInstrumentType,
+                                       Set<? extends Instrument> supportedInstruments) {
         this.supportedInstrumentType = supportedInstrumentType;
+        // Сохраняем инструменты и проверяем их тип
+        this.supportedInstruments = supportedInstruments.stream()
+                .peek(i -> {
+                    if (i.getType() != supportedInstrumentType) {
+                        throw new IllegalArgumentException(
+                                "Instrument type mismatch: %s".formatted(i.getType())
+                        );
+                    }
+                })
+                .map(i -> (Instrument) i)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     // Устанавливаем провайдера
@@ -34,5 +53,17 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
     @Override
     public InstrumentType getSupportedInstrumentType() {
         return supportedInstrumentType;
+    }
+
+    /** Возвращает набор поддерживаемых инструментов. */
+    @Override
+    public Set<Instrument> getSupportedInstruments() {
+        return supportedInstruments;
+    }
+
+    /** Проверяет поддержку указанного инструмента. */
+    @Override
+    public boolean supportsInstrument(Instrument instrument) {
+        return supportedInstruments.contains(instrument);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
@@ -5,6 +5,8 @@ import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.quote.QuoteTick;
 import org.reactivestreams.Publisher;
 
+import java.util.Set;
+
 /**
  * Контракт обработчика (handler) для конкретного финансового инструмента.
  * Каждый провайдер рыночных данных {@link MarketDataProvider} должен иметь как минимум один обработчик.
@@ -16,6 +18,12 @@ public interface InstrumentHandler<P extends MarketDataProvider> {
 
     /** Возвращает тип финансового инструмента, который поддерживает данный обработчик. */
     InstrumentType getSupportedInstrumentType();
+
+    /** Возвращает набор поддерживаемых инструментов. */
+    Set<Instrument> getSupportedInstruments();
+
+    /** Проверяет поддержку указанного инструмента. */
+    boolean supportsInstrument(Instrument instrument);
 
     /** Возвращает котировку для заданного инструмента. */
     Publisher<QuoteTick> getInstrumentQuote(Instrument instrument);


### PR DESCRIPTION
## Summary
- add supported instruments API to instrument handler
- store instruments in abstract handler with type validation
- wire FX Spot handler with repository instruments

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68bd735322c4832daa263db6fa0b7ccb