### PR TITLE
feat: add instrument generics

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -6,9 +6,9 @@ import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.T
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
+import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
-import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.AccessMethod;
 import com.alligator.market.domain.provider.profile.model.DeliveryMode;
 import com.alligator.market.domain.provider.profile.model.Profile;
@@ -42,7 +42,7 @@ public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
             FxSpotRepository fxSpotRepository
     ) {
         Set<FxSpot> instruments = Set.copyOf(fxSpotRepository.findAll());
-        Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlers = Map.of(
+        Map<InstrumentType, InstrumentHandler<TwelveFreeAdapterV2, ? extends Instrument>> handlers = Map.of(
                 InstrumentType.FX_SPOT,
                 new TwelveFreeFxSpotHandler(webClient, props, instruments)
         );

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/TwelveFreeFxSpotHandler.java
@@ -2,7 +2,6 @@ package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex;
 
 import com.alligator.market.backend.provider.adapter.twelve.free.TwelveFreeAdapterV2;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
-import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.provider.contract.AbstractInstrumentHandler;
@@ -19,7 +18,7 @@ import java.util.Set;
  * Обработчик (handler) инструмента FX_SPOT для TwelveData (free).
  * Тип инструмента задаётся в родительском классе.
  */
-public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFreeAdapterV2> {
+public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFreeAdapterV2, FxSpot> {
 
     // Веб-клиент для запросов к провайдеру
     private final WebClient webClient;
@@ -41,12 +40,10 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
 
     /** Возвращает котировку для указанного инструмента. */
     @Override
-    public Flux<QuoteTick> getInstrumentQuote(Instrument instrument) {
-
-        FxSpot fxSpot = (FxSpot) instrument;
+    public Flux<QuoteTick> getInstrumentQuote(FxSpot instrument) {
 
         // Провайдер ожидает именно такой формат запрашиваемого символа инструмента:
-        String symbol = fxSpot.base().code() + "/" + fxSpot.quote().code();
+        String symbol = instrument.base().code() + "/" + instrument.quote().code();
 
         return webClient.get()
                 .uri(b -> b

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/runner/ProfilesReconciliationRunner.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.reconciliation.runner;
 
 import com.alligator.market.backend.provider.reconciliation.adapter.ProfilesReconcilerAdapter;
+import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.Profile;
@@ -41,7 +42,7 @@ public class ProfilesReconciliationRunner implements ApplicationRunner {
 
         // Извлекаем список обработчиков из контекста
         // TODO: вероятно не нужен метод getHandlers так как теперь есть абстрактная модель провайдера, в которой есть карта обработчиков
-        List<InstrumentHandler<? extends MarketDataProvider>> contextHandlers = providerContextScanner.getHandlers();
+        List<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> contextHandlers = providerContextScanner.getHandlers();
 
         ProfileDiff diff = reconciliationAdapter.compareContextAndRepository();
         reconciliationAdapter.applyContextDiffToStorage(diff);

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.provider.reconciliation.scanner;
 
+import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.Profile;
@@ -27,7 +28,7 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
     }
 
     @Override
-    public List<InstrumentHandler<? extends MarketDataProvider>> getHandlers() {
+    public List<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers() {
         return providers.stream()
                 .flatMap(p -> p.getHandlers().values().stream())
                 .collect(Collectors.toList());

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractInstrumentHandler.java
@@ -9,8 +9,8 @@ import java.util.stream.Collectors;
 /**
  * Абстрактный каркас обработчика инструмента.
  */
-public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
-        implements InstrumentHandler<P> {
+public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
+        implements InstrumentHandler<P, I> {
 
     // Ссылка на провайдера
     private P provider;
@@ -19,11 +19,11 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
     private final InstrumentType supportedInstrumentType;
 
     // Набор поддерживаемых инструментов
-    private final Set<Instrument> supportedInstruments;
+    private final Set<I> supportedInstruments;
 
     // Конструктор
     protected AbstractInstrumentHandler(InstrumentType supportedInstrumentType,
-                                       Set<? extends Instrument> supportedInstruments) {
+                                       Set<I> supportedInstruments) {
         this.supportedInstrumentType = supportedInstrumentType;
         // Сохраняем инструменты и проверяем их тип
         this.supportedInstruments = supportedInstruments.stream()
@@ -34,7 +34,6 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
                         );
                     }
                 })
-                .map(i -> (Instrument) i)
                 .collect(Collectors.toUnmodifiableSet());
     }
 
@@ -57,13 +56,13 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider>
 
     /** Возвращает набор поддерживаемых инструментов. */
     @Override
-    public Set<Instrument> getSupportedInstruments() {
+    public Set<I> getSupportedInstruments() {
         return supportedInstruments;
     }
 
     /** Проверяет поддержку указанного инструмента. */
     @Override
-    public boolean supportsInstrument(Instrument instrument) {
+    public boolean supportsInstrument(I instrument) {
         return supportedInstruments.contains(instrument);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -18,17 +18,17 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     protected final Profile profile;
 
     // Карта обработчиков инструментов
-    protected final Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlersMap;
+    protected final Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlersMap;
 
     // Конструктор
     protected AbstractMarketDataProvider(
-            Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> handlersMap,
+            Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlersMap,
             Profile profile
     ) {
         this.profile = profile;
         this.handlersMap = Map.copyOf(handlersMap);
         this.handlersMap.values().forEach(h -> {
-            if (h instanceof AbstractInstrumentHandler<?> handler) {
+            if (h instanceof AbstractInstrumentHandler<?, ?> handler) {
                 // Передаем ссылку на провайдера
                 ((AbstractInstrumentHandler) handler).setProvider(this);
             }
@@ -43,7 +43,7 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
 
     /** Возвращает карту обработчиков. */
     @Override
-    public Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> getHandlers() {
+    public Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers() {
         return handlersMap;
     }
 
@@ -55,10 +55,13 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     @Override
     public Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException {
         InstrumentType type = instrument.getType();
-        InstrumentHandler<? extends MarketDataProvider> handler = handlersMap.get(type);
+        InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> handler = handlersMap.get(type);
         if (handler == null) {
             return Flux.error(new InstrumentNotSupportedException(type, getProfile().providerCode()));
         }
-        return handler.getInstrumentQuote(instrument);
+        @SuppressWarnings("unchecked")
+        InstrumentHandler<? extends MarketDataProvider, Instrument> casted =
+                (InstrumentHandler<? extends MarketDataProvider, Instrument>) handler;
+        return casted.getInstrumentQuote(instrument);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/InstrumentHandler.java
@@ -10,7 +10,7 @@ import java.util.Set;
 /**
  * Контракт обработчика (handler) для конкретного набора финансовых инструментов одного типа.
  */
-public interface InstrumentHandler<P extends MarketDataProvider> {
+public interface InstrumentHandler<P extends MarketDataProvider, I extends Instrument> {
 
     /** Возвращает провайдера, к которому относится обработчик. */
     P getProvider();
@@ -19,11 +19,11 @@ public interface InstrumentHandler<P extends MarketDataProvider> {
     InstrumentType getSupportedInstrumentType();
 
     /** Возвращает набор поддерживаемых инструментов. */
-    Set<Instrument> getSupportedInstruments();
+    Set<I> getSupportedInstruments();
 
     /** Проверяет поддержку указанного инструмента. */
-    boolean supportsInstrument(Instrument instrument);
+    boolean supportsInstrument(I instrument);
 
     /** Возвращает котировку для заданного инструмента. */
-    Publisher<QuoteTick> getInstrumentQuote(Instrument instrument);
+    Publisher<QuoteTick> getInstrumentQuote(I instrument);
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -1,13 +1,13 @@
 package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.base.Instrument;
+import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.quote.QuoteTick;
-import com.alligator.market.domain.instrument.type.InstrumentType;
-import java.util.Map;
-
 import org.reactivestreams.Publisher;
+
+import java.util.Map;
 
 /**
  * Контракт провайдера рыночных данных.
@@ -18,7 +18,7 @@ public interface MarketDataProvider {
     Profile getProfile();
 
     /** Возвращает карту обработчиков {@link InstrumentHandler}. */
-    Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider>> getHandlers();
+    Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers();
 
     /**
      * Возвращает котировку.

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.reconciliation;
 
+import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.provider.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.profile.model.Profile;
@@ -15,5 +16,5 @@ public interface ProviderContextScanner {
     List<Profile> getProfiles();
 
     /** Вернуть список обработчиков финансовых инструментов из контекста. */
-    List<InstrumentHandler<? extends MarketDataProvider>> getHandlers();
+    List<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers();
 }


### PR DESCRIPTION
## Summary
- add instrument type parameter to InstrumentHandler and AbstractInstrumentHandler
- use concrete FxSpot type in TwelveFreeFxSpotHandler
- update provider contracts and adapters for new generic map

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a6a833c832d993f233f11e2f7b5