### PR TITLE
Refactor handler mapping to instrument-level

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -19,6 +19,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.HashMap;
 
 /**
  * Адаптер для провайдера рыночных данных TwelveData (бесплатная подписка).
@@ -42,12 +43,12 @@ public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
             FxSpotRepository fxSpotRepository
     ) {
         Set<FxSpot> instruments = Set.copyOf(fxSpotRepository.findAll());
-        Map<InstrumentType, InstrumentHandler<TwelveFreeAdapterV2, ? extends Instrument>> handlers = Map.of(
-                InstrumentType.FX_SPOT,
-                new TwelveFreeFxSpotHandler(webClient, props, instruments)
-        );
+        TwelveFreeFxSpotHandler handler = new TwelveFreeFxSpotHandler(webClient, props, instruments);
+        // Собираем карту обработчиков
+        Map<Instrument, InstrumentHandler<TwelveFreeAdapterV2, ? extends Instrument>> handlers = new HashMap<>();
+        instruments.forEach(inst -> handlers.put(inst, handler));
         super(
-                handlers,
+                handlers.values(),
                 new Profile(
                         ProfileStatus.ACTIVE,
                         PROVIDER_CODE,

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -28,9 +28,10 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
     }
 
     @Override
+    /** Возвращает обработчики без повторов. */
     public List<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers() {
         return providers.stream()
-                .flatMap(p -> p.getHandlers().values().stream())
+                .flatMap(p -> p.getHandlers().values().stream().distinct())
                 .collect(Collectors.toList());
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -1,12 +1,13 @@
 package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.base.contract.Instrument;
-import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.quote.QuoteTick;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -17,22 +18,24 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     // Профиль провайдера
     protected final Profile profile;
 
-    // Карта обработчиков инструментов
-    protected final Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlersMap;
+    // Карта обработчиков по инструментам
+    protected final Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlersMap;
 
     // Конструктор
     protected AbstractMarketDataProvider(
-            Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlersMap,
+            Collection<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlers,
             Profile profile
     ) {
         this.profile = profile;
-        this.handlersMap = Map.copyOf(handlersMap);
-        this.handlersMap.values().forEach(h -> {
+        Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> map = new HashMap<>();
+        handlers.forEach(h -> {
             if (h instanceof AbstractInstrumentHandler<?, ?> handler) {
                 // Передаем ссылку на провайдера
                 ((AbstractInstrumentHandler) handler).setProvider(this);
             }
+            h.getSupportedInstruments().forEach(i -> map.put(i, h));
         });
+        this.handlersMap = Map.copyOf(map);
     }
 
     /** Возвращает профиль провайдера. */
@@ -43,7 +46,7 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
 
     /** Возвращает карту обработчиков. */
     @Override
-    public Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers() {
+    public Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers() {
         return handlersMap;
     }
 
@@ -54,10 +57,9 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
      */
     @Override
     public Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException {
-        InstrumentType type = instrument.getType();
-        InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> handler = handlersMap.get(type);
+        InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> handler = handlersMap.get(instrument);
         if (handler == null) {
-            return Flux.error(new InstrumentNotSupportedException(type, getProfile().providerCode()));
+            return Flux.error(new InstrumentNotSupportedException(instrument.getType(), getProfile().providerCode()));
         }
         @SuppressWarnings("unchecked")
         InstrumentHandler<? extends MarketDataProvider, Instrument> casted =

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -1,7 +1,6 @@
 package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.base.contract.Instrument;
-import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.quote.QuoteTick;
@@ -17,8 +16,8 @@ public interface MarketDataProvider {
     /** Возвращает профиль провайдера {@link Profile}. */
     Profile getProfile();
 
-    /** Возвращает карту обработчиков {@link InstrumentHandler}. */
-    Map<InstrumentType, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers();
+    /** Возвращает карту обработчиков по инструментам. */
+    Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers();
 
     /**
      * Возвращает котировку.


### PR DESCRIPTION
## Summary
- map handlers by instrument instead of type across provider APIs
- collect instrument handlers from collections and expose instrument-keyed map
- deduplicate provider handlers during context scanning

## Testing
- `mvn -q -pl domain,backend -am test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e4a31ec832da010b072c81a9ab7