### PR TITLE
feat: add handler retrieval

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -5,7 +5,6 @@ import com.alligator.market.domain.provider.exception.InstrumentNotSupportedExce
 import com.alligator.market.domain.provider.profile.model.Profile;
 import com.alligator.market.domain.quote.QuoteTick;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,19 +50,30 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     }
 
     /**
+     * Извлекает обработчик для указанного инструмента.
+     *
+     * @throws InstrumentNotSupportedException если обработчик не найден
+     */
+    @Override
+    public InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> getHandler(Instrument instrument)
+            throws InstrumentNotSupportedException {
+        InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> handler = handlersMap.get(instrument);
+        if (handler == null) {
+            throw new InstrumentNotSupportedException(instrument.getType(), getProfile().providerCode());
+        }
+        return handler;
+    }
+
+    /**
      * Возвращает котировку.
      *
      * @throws InstrumentNotSupportedException если подходящий обработчик инструмента не найден
      */
     @Override
     public Publisher<QuoteTick> getQuote(Instrument instrument) throws InstrumentNotSupportedException {
-        InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> handler = handlersMap.get(instrument);
-        if (handler == null) {
-            return Flux.error(new InstrumentNotSupportedException(instrument.getType(), getProfile().providerCode()));
-        }
         @SuppressWarnings("unchecked")
-        InstrumentHandler<? extends MarketDataProvider, Instrument> casted =
-                (InstrumentHandler<? extends MarketDataProvider, Instrument>) handler;
-        return casted.getInstrumentQuote(instrument);
+        InstrumentHandler<? extends MarketDataProvider, Instrument> handler =
+                (InstrumentHandler<? extends MarketDataProvider, Instrument>) getHandler(instrument);
+        return handler.getInstrumentQuote(instrument);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -20,6 +20,14 @@ public interface MarketDataProvider {
     Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> getHandlers();
 
     /**
+     * Возвращает обработчик для указанного инструмента.
+     *
+     * @throws InstrumentNotSupportedException если обработчик для инструмента не найден
+     */
+    InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> getHandler(Instrument instrument)
+            throws InstrumentNotSupportedException;
+
+    /**
      * Возвращает котировку.
      *
      * @throws InstrumentNotSupportedException если подходящий обработчик инструмента не найден


### PR DESCRIPTION
## Summary
- expose handler lookup for instruments in `MarketDataProvider`
- implement handler retrieval with `InstrumentNotSupportedException`
- refactor `getQuote` to reuse handler lookup

## Testing
- `mvn -q -pl domain test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf33d88208832dbbba0f0baeab4c34