### PR TITLE
refactor: improve abstract provider

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -14,19 +14,38 @@ import java.util.Set;
  */
 public abstract class AbstractMarketDataProvider implements MarketDataProvider {
 
+    /** Профиль провайдера. */
     protected final Profile profile;
-    Set<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlers();
 
-    // Конструктор
+    /** Набор обработчиков. */
+    protected final Set<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlers;
+
+    /** Карта инструмент → обработчик. */
+    protected final Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> instrumentHandlerMap;
+
+    /**
+     * Конструктор.
+     *
+     * @param profile  профиль провайдера
+     * @param handlers набор обработчиков
+     */
     protected AbstractMarketDataProvider(
-            Profile profile;
-            Set<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlers();
+            Profile profile,
+            Set<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlers
     ) {
-        this.profile = profile;
-        // Создаем необходимую карту
-        Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> map = new HashMap<>();
-        // Заполняем карту
+        this.profile = Objects.requireNonNull(profile, "profile must not be null");
+        Objects.requireNonNull(handlers, "handlers must not be null");
 
+        // Делаем набор обработчиков неизменяемым
+        this.handlers = Set.copyOf(handlers);
+
+        // Собираем карту инструмент → обработчик
+        Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> map = new HashMap<>();
+        for (InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> handler : this.handlers) {
+            for (Instrument instrument : handler.supportedInstruments()) {
+                map.put(instrument, handler);
+            }
+        }
         this.instrumentHandlerMap = Map.copyOf(map);
     }
 
@@ -38,10 +57,13 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
 
     /** Набор обработчиков. */
     @Override
+    public Set<InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> handlers() {
+        return handlers;
+    }
 
     /** Карта инструмент → обработчик. */
     @Override
-    Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> instrumentHandlerMap() {
+    public Map<Instrument, InstrumentHandler<? extends MarketDataProvider, ? extends Instrument>> instrumentHandlerMap() {
         return instrumentHandlerMap;
     }
 
@@ -57,10 +79,11 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
         if (handler == null) {
             throw new InstrumentNotSupportedException(
                     instrument.code(),
-                    handler.code(),
+                    "unknown",
                     profile().providerCode()
             );
         }
         return handler;
     }
 }
+


### PR DESCRIPTION
### Summary
- реализован полноценный каркас `AbstractMarketDataProvider`
- конструктор формирует неизменяемые коллекции и карту инструментов
- добавлены реализации `profile()`, `handlers()`, `instrumentHandlerMap()` и `findHandler()`

### Testing
- `mvn -q test` *(не удалось разрешить зависимости: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3441dc040832d813fb91bd077dff3