### PR TITLE
Замена InstrumentNotSupportedException на HandlerNotFoundException в AbstractMarketDataProvider

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
@@ -8,6 +8,7 @@ import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotSa
 import com.alligator.market.domain.common.exception.NotFoundException;
 import com.alligator.market.domain.common.exception.ResourceInUseException;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.exception.CurrencyDuplicateException;
+import com.alligator.market.domain.provider.exception.HandlerNotFoundException;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.profile.exeption.ContextProfileDuplicateException;
 import lombok.extern.slf4j.Slf4j;
@@ -85,8 +86,16 @@ public class ApplicationExceptionHandler {
     /** Тип инструмента не поддерживается провайдером. */
     @ExceptionHandler(InstrumentNotSupportedException.class)
     public ResponseEntity<ApiResponse<Void>> handleInstrumentNotSupported(InstrumentNotSupportedException ex) {
-        // 400, неподдерживаемый тип инструмента
+        // 400, неподдерживаемый инструмент
         log.warn("InstrumentNotSupportedException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    /** Обработчик для инструмента не найден. */
+    @ExceptionHandler(HandlerNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHandlerNotFound(HandlerNotFoundException ex) {
+        // 400, неподдерживаемый инструмент
+        log.warn("HandlerNotFoundException: {}", ex.getMessage());
         return ResponseEntityFactory.error(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.base.contract.Instrument;
-import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
+import com.alligator.market.domain.provider.exception.HandlerNotFoundException;
 import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.profile.model.Profile;
 import java.util.HashMap;
@@ -56,16 +56,15 @@ public abstract class AbstractMarketDataProvider implements MarketDataProvider {
     /**
      * Возвращает обработчик для указанного инструмента.
      *
-     * @throws InstrumentNotSupportedException если обработчик не найден
+     * @throws HandlerNotFoundException если обработчик не найден
      */
     @Override
     public InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> findHandler(Instrument instrument) {
         Objects.requireNonNull(instrument, "instrument must not be null");
         InstrumentHandler<? extends MarketDataProvider, ? extends Instrument> handler = instrumentHandlerMap.get(instrument);
         if (handler == null) {
-            throw new InstrumentNotSupportedException(
+            throw new HandlerNotFoundException(
                     instrument.code(),
-                    "unknown",
                     profile.providerCode()
             );
         }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.domain.provider.exception;
+
+/**
+ * Обработчик для инструмента не найден.
+ */
+public class HandlerNotFoundException extends RuntimeException {
+    public HandlerNotFoundException(String instrumentCode, String providerCode) {
+        super("Handler for instrument %s not found in provider %s".formatted(instrumentCode, providerCode));
+    }
+}


### PR DESCRIPTION
## Summary
- добавлен класс `HandlerNotFoundException`
- `AbstractMarketDataProvider.findHandler` теперь выбрасывает `HandlerNotFoundException`
- `ApplicationExceptionHandler` обрабатывает `HandlerNotFoundException`

## Testing
- `./mvnw -q -e -ntp test` *(ошибка: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68c3481cd444832d91f8dcc57d0cbd01