### PR TITLE
Рефакторинг обработчика TwelveData FX Spot

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
@@ -2,17 +2,12 @@ package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.
 
 import com.alligator.market.backend.provider.adapter.twelve.free.TwelveFreeAdapterV2;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
-import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
-import com.alligator.market.domain.provider.exception.InstrumentWrongClassException;
 import com.alligator.market.domain.provider.handler.contract.AbstractInstrumentHandler;
 import com.alligator.market.domain.quote.QuoteTick;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.reactivestreams.Publisher;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Flux;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -23,72 +18,28 @@ import java.util.Set;
  * Обработчик (handler) инструмента FX_SPOT для TwelveData (free).
  * Тип инструмента задаётся в родительском классе.
  */
-public class TwelveFreeFxSpotHandler implements AbstractInstrumentHandler<TwelveFreeAdapterV2, FxSpot> {
+public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFreeAdapterV2, FxSpot> {
 
     private static final String HANDLER_CODE = "TWELVE_FREE_FX_SPOT_HANDLER";
-    private TwelveFreeAdapterV2 provider;
-    private final Set<FxSpot> instruments;
-    private static final Class<FxSpot> INSTRUMENT_CLASS = FxSpot.class;
 
     private final WebClient webClient;
     private final TwelveFreeConnectionProps props;
 
     // Конструктор
     public TwelveFreeFxSpotHandler(
+            TwelveFreeAdapterV2 provider,
             Set<FxSpot> instruments,
             WebClient webClient,
             TwelveFreeConnectionProps props
     ) {
-        this.instruments = Set.copyOf(Objects.requireNonNull(instruments, "instruments must not be null"));
+        super(HANDLER_CODE, provider, FxSpot.class, instruments);
         this.webClient = Objects.requireNonNull(webClient, "webClient must not be null");
         this.props = Objects.requireNonNull(props, "props must not be null");
     }
 
-    // Устанавливает провайдера для обработчика
-    public void setProvider(TwelveFreeAdapterV2 provider) {
-        this.provider = Objects.requireNonNull(provider, "provider must not be null");
-    }
-
-    /** Код обработчика. */
+    /** Реализация получения котировки. */
     @Override
-    public String code() {
-        return HANDLER_CODE;
-    }
-
-    /** Провайдер, к которому относится обработчик. */
-    @Override
-    public TwelveFreeAdapterV2 provider() {
-        return provider;
-    }
-
-    /** Класс поддерживаемых инструментов. */
-    @Override
-    public Class<FxSpot> instrumentClass() {
-        return INSTRUMENT_CLASS;
-    }
-
-    /** Набор поддерживаемых инструментов. */
-    @Override
-    public Set<FxSpot> supportedInstruments() {
-        return instruments;
-    }
-
-    /**
-     * Котировка заданного инструмента.
-     */
-    @Override
-    public Publisher<QuoteTick> quote(FxSpot instrument) {
-        Objects.requireNonNull(instrument, "instrument must not be null");
-        if (!INSTRUMENT_CLASS.isInstance(instrument)) {
-            throw new InstrumentWrongClassException(INSTRUMENT_CLASS, instrument.getClass());
-        }
-        if (!instruments.contains(instrument)) {
-            throw new InstrumentNotSupportedException(
-                    instrument.code(),
-                    HANDLER_CODE,
-                    provider.profile().providerCode()
-            );
-        }
+    protected Publisher<QuoteTick> doQuote(FxSpot instrument) {
         // Провайдер ожидает формат символа инструмента: BASE/QUOTE
         String symbol = instrument.base().code() + "/" + instrument.quote().code();
         return webClient.get()
@@ -117,7 +68,7 @@ public class TwelveFreeFxSpotHandler implements AbstractInstrumentHandler<Twelve
                 price,
                 price,
                 Instant.now(),
-                provider.profile().providerCode()
+                provider().profile().providerCode()
         );
     }
 }


### PR DESCRIPTION
## Summary
- simplify TwelveFreeFxSpotHandler by extending AbstractInstrumentHandler
- move provider setup to superclass and rework quote logic as doQuote

## Testing
- `mvn -q -pl backend -am test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c41e59c4d0832d9d1921f569eb260e