### PR TITLE
feat: expand wrong class exception details

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
@@ -5,7 +5,13 @@ package com.alligator.market.domain.provider.exception;
  */
 public class InstrumentWrongClassException extends RuntimeException {
 
-    public InstrumentWrongClassException(Class<?> expected, Class<?> actual) {
-        super("Instrument of class %s is not supported. Expected %s".formatted(actual.getName(), expected.getName()));
+    public InstrumentWrongClassException(
+            String instrumentCode,
+            Class<?> instrumentClass,
+            String handlerCode,
+            Class<?> expectedClass
+    ) {
+        super("Instrument %s has class %s, but provider handler %s expects %s"
+                .formatted(instrumentCode, instrumentClass.getName(), handlerCode, expectedClass.getName()));
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/base/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/base/AbstractInstrumentHandler.java
@@ -71,8 +71,10 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
         Objects.requireNonNull(instrument, "instrument must not be null");
         if (!instrumentClass.isInstance(instrument)) {
             throw new InstrumentWrongClassException(
-                    instrumentClass,
-                    instrument.getClass()
+                    instrument.code(),
+                    instrument.getClass(),
+                    handlerCode,
+                    instrumentClass
             );
         }
         if (!supportedInstruments.contains(instrument)) {


### PR DESCRIPTION
## Summary
- provide detailed information when instrument class mismatches handler expectations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.alligator:market-parent:1.0-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bfa1cbb8832d8fbc548e3d9d8688