### PR TITLE
Добавлен конструктор для Currency с проверками

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
@@ -1,12 +1,42 @@
 package com.alligator.market.domain.instrument.type.forex.ref.currency.model;
 
+import java.util.Objects;
+
 /**
- * Модель валюты.
+ * Базовая модель валюты на рынке Forex.
  */
 public record Currency(
-
         String code,
         String name,
         String country,
         Integer decimal
-) {}
+) {
+
+    /**
+     * Канонический конструктор выполняет проверки:
+     * <ul>
+     *     <li>обязательность полей;</li>
+     *     <li>отсутствие пустых строк;</li>
+     *     <li>формат кода валюты.</li>
+     * </ul>
+     */
+    public Currency {
+        Objects.requireNonNull(code, "code must not be null");
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(country, "country must not be null");
+        Objects.requireNonNull(decimal, "decimal must not be null");
+
+        if (code.isBlank()) {
+            throw new IllegalArgumentException("code must not be blank");
+        }
+        if (!code.matches("^[A-Z]{3}$")) {
+            throw new IllegalArgumentException("code must match ^[A-Z]{3}$");
+        }
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        if (country.isBlank()) {
+            throw new IllegalArgumentException("country must not be blank");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- добавить канонический конструктор для `Currency` с проверками на `null`, пустые строки и формат кода

## Testing
- `mvn -q -pl domain -am test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e88f0504832da659911cecdcd165