### PR TITLE
Учитываем тип инструмента в equals и hashCode

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/base/AbstractInstrument.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/base/AbstractInstrument.java
@@ -1,26 +1,28 @@
 package com.alligator.market.domain.instrument.base;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
+import java.util.Objects;
 
 /**
- * Базовая модель инструмента с equals/hashCode по внутреннему коду инструмента.
+ * Базовая модель инструмента с equals/hashCode по коду и типу инструмента.
  */
 public abstract class AbstractInstrument implements Instrument {
 
+    /** Сравниваем инструменты по коду и типу. */
     @Override
     public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false; // Разные типы
+        if (!(o instanceof Instrument that)) {
+            return false; // Не инструмент
         }
-        Instrument that = (Instrument) o;
-        return code().equals(that.code()); // Сравниваем коды
+        return code().equals(that.code()) && type() == that.type(); // Сравниваем код и тип
     }
 
+    /** Хэш по коду и типу. */
     @Override
     public final int hashCode() {
-        return code().hashCode();
+        return Objects.hash(code(), type());
     }
 }


### PR DESCRIPTION
## Summary
- расширена модель `AbstractInstrument`, теперь инструменты сравниваются по коду и типу
- скорректирован `hashCode` с учётом типа инструмента

## Testing
- `./mvnw -q -ntp test` *(ошибка: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68c70849c654832da0fcd404e08b3107