### PR TITLE
Enforce exact instrument class matching in handlers

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
@@ -10,7 +10,7 @@ public class InstrumentWrongClassException extends RuntimeException {
             String handlerCode,
             Class<?> expectedClass
     ) {
-        super("Instrument %s has class %s, but provider handler %s expects %s"
+        super("Instrument %s has class %s, but provider handler %s expects exact class %s"
                 .formatted(instrumentCode, instrumentClass.getName(), handlerCode, expectedClass.getName()));
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/base/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/base/AbstractInstrumentHandler.java
@@ -82,7 +82,7 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
     @Override
     public final Publisher<QuoteTick> quote(I instrument) {
         Objects.requireNonNull(instrument, "instrument must not be null");
-        if (!instrumentClass.isInstance(instrument)) {
+        if (instrument.getClass() != instrumentClass) {
             throw new InstrumentWrongClassException(
                     instrument.code(),
                     instrument.getClass(),


### PR DESCRIPTION
## Summary
- switch instrument class validation in `AbstractInstrumentHandler` to strict equality
- clarify `InstrumentWrongClassException` message to mention the exact class expectation

## Testing
- ./mvnw -pl domain test *(fails: wget cannot download apache-maven-3.9.9-bin.zip in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97632f22c832d90d444b68292cfef