### PR TITLE
Запечатал MarketDataProvider и сделал базовый провайдер открытым для наследования

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/base/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/base/AbstractMarketDataProvider.java
@@ -15,7 +15,7 @@ import java.util.*;
 /**
  * Абстрактный каркас провайдера рыночных данных.
  */
-public abstract class AbstractMarketDataProvider<P extends MarketDataProvider> implements MarketDataProvider {
+public abstract non-sealed class AbstractMarketDataProvider<P extends MarketDataProvider> implements MarketDataProvider {
 
     /* ↓↓ Базовые атрибуты обработчика. */
     protected final ProviderDescriptor descriptor;

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.provider.base.AbstractMarketDataProvider;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import com.alligator.market.domain.quote.QuoteTick;
@@ -9,7 +10,7 @@ import org.reactivestreams.Publisher;
 /**
  * Контракт провайдера рыночных данных.
  */
-public interface MarketDataProvider {
+public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
 
     /** Дескриптор провайдера: иммутабельный набор статических атрибутов. */
     ProviderDescriptor descriptor();


### PR DESCRIPTION
## Summary
- запечатал интерфейс MarketDataProvider и разрешил реализацию только через AbstractMarketDataProvider
- отметил AbstractMarketDataProvider как non-sealed, чтобы специализированные провайдеры могли его наследовать

## Testing
- ./mvnw -pl domain test *(failed: недоступно скачивание Maven Wrapper в окружении)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bd6989c4832daf62f051db7e3c83