### PR TITLE
Исправление модификатора AbstractInstrumentHandler

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/contract/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/contract/AbstractInstrumentHandler.java
@@ -13,7 +13,7 @@ import java.util.Set;
 /**
  * Абстрактный каркас обработчика инструмента.
  */
-public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
+public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
         implements InstrumentHandler<P, I> {
 
     /* ↓↓ Базовые атрибуты обработчика. */


### PR DESCRIPTION
## Summary
- пометил `AbstractInstrumentHandler` как `non-sealed`, чтобы реализация интерфейса `InstrumentHandler` соответствовала требованиям sealed-иерархии

## Testing
- ./mvnw -pl domain test *(падает: нет доступа к https://repo.maven.apache.org для загрузки Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bf6f714c832da42fcb0ea818edf2