### PR TITLE
Адаптация TwelveFreeAdapterV2 к новому каркасу провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -3,61 +3,58 @@ package com.alligator.market.backend.provider.adapter.twelve.free;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeWebConfig;
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.spot.TwelveFreeFxSpotHandler;
-import com.alligator.market.domain.instrument.type.InstrumentType;
-import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
-import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
-import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
-import com.alligator.market.domain.provider.handler.contract.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.descriptor.AccessMethod;
 import com.alligator.market.domain.provider.contract.descriptor.DeliveryMode;
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.Map;
+import java.time.Duration;
 import java.util.Set;
-import java.util.HashMap;
 
 /**
  * Адаптер для провайдера рыночных данных TwelveData (free).
  */
 @Component
-public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider {
+public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider<TwelveFreeAdapterV2> {
 
     private static final String PROVIDER_CODE = "TWELVE_FREE";
+
+    /* Статический дескриптор провайдера. */
+    private static final ProviderDescriptor DESCRIPTOR = new ProviderDescriptor(
+            PROVIDER_CODE,
+            "TwelveData Free Plan",
+            DeliveryMode.PULL,
+            AccessMethod.API_POLL,
+            false
+    );
+
+    /* Иммутабельные настройки провайдера. */
+    private static final ProviderSettings SETTINGS = new ProviderSettings(Duration.ofSeconds(60));
 
     /**
      * Конструктор адаптера TwelveFreeAdapterV2.
      *
      * @param props     конфигурационные настройки подключения {@link TwelveFreeConnectionProps}
      * @param webClient конфигурационный класс веб-клиента {@link TwelveFreeWebConfig}
-     * @param fxSpotRepository репозиторий инструментов FX_SPOT
      */
     public TwelveFreeAdapterV2(
             TwelveFreeConnectionProps props,
-            @Qualifier("twelveFreeWebClient") WebClient webClient,
-            FxSpotRepository fxSpotRepository
+            @Qualifier("twelveFreeWebClient") WebClient webClient
     ) {
-        Set<FxSpot> instruments = Set.copyOf(fxSpotRepository.findAll());
-        TwelveFreeFxSpotHandler handler = new TwelveFreeFxSpotHandler(webClient, props, instruments);
-        // Собираем карту обработчиков
-        Map<Instrument, InstrumentHandler<TwelveFreeAdapterV2, ? extends Instrument>> handlers = new HashMap<>();
-        instruments.forEach(inst -> handlers.put(inst, handler));
         super(
-                handlers.values(),
-                new ProviderDescriptor(
-                        ProfileStatus.ACTIVE,
-                        PROVIDER_CODE,
-                        "TwelveData Free Plan",
-                        Set.of(InstrumentType.FX_SPOT),
-                        DeliveryMode.PULL,
-                        AccessMethod.API_POLL,
-                        false,
-                        60_000
-                )
+                DESCRIPTOR,
+                SETTINGS,
+                Set.of(new TwelveFreeFxSpotHandler(webClient, props))
         );
+    }
+
+    @Override
+    protected TwelveFreeAdapterV2 self() {
+        return this;
     }
 
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
@@ -2,7 +2,9 @@ package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.
 
 import com.alligator.market.backend.provider.adapter.twelve.free.TwelveFreeAdapterV2;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 import com.alligator.market.domain.provider.handler.contract.AbstractInstrumentHandler;
 import com.alligator.market.domain.quote.QuoteTick;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,19 +21,30 @@ import java.util.Set;
  */
 public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFreeAdapterV2, FxSpot> {
 
+    /* Уникальный код обработчика. */
     private static final String HANDLER_CODE = "TWELVE_FREE_FX_SPOT_HANDLER";
+
+    /* Базовая валюта пары. */
+    private static final Currency EUR = new Currency("EUR", "Euro", "European Union", 2);
+
+    /* Котируемая валюта пары. */
+    private static final Currency USD = new Currency("USD", "United States Dollar", "United States", 2);
+
+    /* Единственный поддерживаемый инструмент EUR/USD SPOT. */
+    private static final FxSpot EUR_USD = new FxSpot(EUR, USD, ValueDateCode.SPOT, 5);
+
+    /* Набор поддерживаемых инструментов. */
+    private static final Set<FxSpot> SUPPORTED_INSTRUMENTS = Set.of(EUR_USD);
 
     private final WebClient webClient;
     private final TwelveFreeConnectionProps props;
 
     // Конструктор
     public TwelveFreeFxSpotHandler(
-            TwelveFreeAdapterV2 provider,
-            Set<FxSpot> instruments,
             WebClient webClient,
             TwelveFreeConnectionProps props
     ) {
-        super(HANDLER_CODE, provider, FxSpot.class, instruments);
+        super(HANDLER_CODE, FxSpot.class, SUPPORTED_INSTRUMENTS);
         this.webClient = Objects.requireNonNull(webClient, "webClient must not be null");
         this.props = Objects.requireNonNull(props, "props must not be null");
     }


### PR DESCRIPTION
## Summary
- перевёл адаптер TwelveFreeAdapterV2 на новый AbstractMarketDataProvider с неизменяемым дескриптором и настройками
- упростил обработчик TwelveFreeFxSpotHandler до статического списка инструментов с единственным EUR/USD и текущим построением тиков

## Testing
- ./mvnw -pl backend test *(failed: не удалось скачать Maven Wrapper из-за ограничений среды)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ccdb7f3c832db6549109bf7b500b