### PR TITLE
fix(provider): validate twelve free connection props

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/config/TwelveFreeConnectionProps.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/config/TwelveFreeConnectionProps.java
@@ -1,13 +1,16 @@
 package com.alligator.market.backend.provider.adapter.twelve.free.config;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Параметры подключения к провайдеру рыночных данных TwelveData (бесплатная подписка).
- * Автоматически считываются из настроек приложения.
+ * Автоматически считываются из настроек приложения и валидируются на обязательность.
  */
+@Validated
 @ConfigurationProperties("provider.connection-config.twelve-free")
 public record TwelveFreeConnectionProps(
-        String baseUrl,
-        String apiKey
+        @NotBlank String baseUrl,
+        @NotBlank String apiKey
 ) {}


### PR DESCRIPTION
## Summary
- enforce validation of TwelveData free connection properties by marking required fields as `@NotBlank`

## Testing
- `./mvnw -pl backend test` *(fails: Maven wrapper cannot download distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d495d004832d9c582ddae7c074ba