### PR TITLE
Добавить набор инструментов провайдера

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -110,6 +110,12 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         return settings;
     }
 
+    /** Иммутабельный набор поддерживаемых провайдером инструментов. */
+    @Override
+    public Set<Instrument> instruments() {
+        return instrumentMap.keySet();
+    }
+
     /**
      * Унифицированная операция получения котировок для любого поддерживаемого инструмента.
      *

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -6,6 +6,8 @@ import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import com.alligator.market.domain.quote.QuoteTick;
 import org.reactivestreams.Publisher;
 
+import java.util.Set;
+
 /**
  * Контракт провайдера рыночных данных.
  */
@@ -16,6 +18,9 @@ public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
 
     /** Иммутабельные настройки провайдера. */
     ProviderSettings settings();
+
+    /** Иммутабельный набор поддерживаемых провайдером инструментов. */
+    Set<Instrument> instruments();
 
     /** Унифицированная операция получения котировок для любого поддерживаемого инструмента. */
     <I extends Instrument> Publisher<QuoteTick> quote(I instrument);


### PR DESCRIPTION
## Summary
- расширил контракт MarketDataProvider методом instruments
- реализовал возврат неизменяемого набора инструментов в AbstractMarketDataProvider на основе реестра обработчиков

## Testing
- mvn -pl domain test *(ошибка из-за недоступного Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cc725419a4832dbb792072a23ef654