### PR TITLE
Add Lombok equals/hashCode annotations to entities

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/jpa/InstrumentBaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/jpa/InstrumentBaseEntity.java
@@ -19,6 +19,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public abstract class InstrumentBaseEntity extends BaseEntity {
 
     /** Суррогатный PK. */

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -27,6 +27,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CurrencyEntity extends BaseEntity {
 
     /** Суррогатный PK. */

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
@@ -28,6 +28,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class DescriptorEntity extends BaseEntity {
 
     /** Суррогатный PK. */


### PR DESCRIPTION
## Summary
- add Lombok `@EqualsAndHashCode(onlyExplicitlyIncluded = true)` to instrument, descriptor, and currency entities so equality relies on explicitly marked fields

## Testing
- mvn -pl backend test *(fails: Maven cannot reach central repository in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfea9623d4832db548229f77d35aca