### PR TITLE
Переименовать CurrencyUpdateDto в UpdateCurrencyDto

### DIFF
--- a/frontend/src/app/features/currency/models/currency-update.model.ts
+++ b/frontend/src/app/features/currency/models/currency-update.model.ts
@@ -1,5 +1,5 @@
 /** DTO для обновления валюты аналогичный backend. */
-export interface CurrencyUpdateDto {
+export interface UpdateCurrencyDto {
   name: string;
   country: string;
   decimal: number;

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
@@ -10,7 +10,7 @@ import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {CurrencyDto} from '../../models/currency.model';
 import {CurrencyService} from '../../services/currency.service';
 import {MatCardModule} from "@angular/material/card";
-import {CurrencyUpdateDto} from "../../models/currency-update.model";
+import {UpdateCurrencyDto} from "../../models/currency-update.model";
 import {RouterLink} from '@angular/router';
 
 @Component({
@@ -145,11 +145,11 @@ export class CurrencyAdminComponent implements OnInit {
 
     this.locked = true;
 
-    const dto: CurrencyUpdateDto = {
+    const dto: UpdateCurrencyDto = {
       name: this.form.controls['name'].value,
       country: this.form.controls['country'].value,
       decimal: this.form.controls['decimal'].value
-    } as CurrencyUpdateDto;
+    } as UpdateCurrencyDto;
 
     this.service.update(this.editCode, dto).subscribe({
       next: () => {

--- a/frontend/src/app/features/currency/services/currency.service.ts
+++ b/frontend/src/app/features/currency/services/currency.service.ts
@@ -3,7 +3,7 @@ import {CurrencyDto} from '../models/currency.model';
 import {map, Observable} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {ApiResponse} from '../../../shared/api-response.model';
-import {CurrencyUpdateDto} from "../models/currency-update.model";
+import {UpdateCurrencyDto} from "../models/currency-update.model";
 
 /* Сервис для взаимодействия с API по работе с валютами */
 @Injectable({
@@ -39,7 +39,7 @@ export class CurrencyService {
   }
 
   /* Обновить валюту по коду */
-  update(code: string, dto: CurrencyUpdateDto): Observable<void> {
+  update(code: string, dto: UpdateCurrencyDto): Observable<void> {
     return this.http
       .put<ApiResponse<void>>(`${this.baseUrl}/${code}`, dto)
       .pipe(map(res => res.data));


### PR DESCRIPTION
## Summary
- переименован интерфейс DTO для обновления валюты и приведено его имя к UpdateCurrencyDto
- обновлены импорты и типы в сервисе и компоненте администратора валют

## Testing
- npm run build -- --configuration development

------
https://chatgpt.com/codex/tasks/task_e_68d05b45a160832db83900d97d5b29a6