### PR TITLE
Rename provider descriptor DTO

### DIFF
--- a/frontend/src/app/features/provider_descriptor/models/descriptor-dto.model.ts
+++ b/frontend/src/app/features/provider_descriptor/models/descriptor-dto.model.ts
@@ -1,0 +1,8 @@
+/** DTO дескриптора провайдера, соответствующее backend-контракту DescriptorDto. */
+export interface DescriptorDto {
+  providerCode: string;
+  displayName: string;
+  deliveryMode: string;
+  accessMethod: string;
+  bulkSubscription: boolean;
+}

--- a/frontend/src/app/features/provider_descriptor/models/descriptor-entity.model.ts
+++ b/frontend/src/app/features/provider_descriptor/models/descriptor-entity.model.ts
@@ -1,8 +1,0 @@
-/** DTO дескриптора провайдера, повторяющий поля DescriptorEntity. */
-export interface DescriptorEntityDto {
-  providerCode: string;
-  displayName: string;
-  deliveryMode: string;
-  accessMethod: string;
-  bulkSubscription: boolean;
-}

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
 import { ProviderDescriptorService } from '../../services/provider-descriptor.service';
-import { DescriptorEntityDto } from '../../models/descriptor-entity.model';
+import { DescriptorDto } from '../../models/descriptor-dto.model';
 
 @Component({
   selector: 'app-provider-descriptor-list',
@@ -23,7 +23,7 @@ export class DescriptorListComponent implements OnInit {
     'bulkSubscription'
   ];
   /* Источник данных для таблицы. */
-  dataSource = new MatTableDataSource<DescriptorEntityDto>([]);
+  dataSource = new MatTableDataSource<DescriptorDto>([]);
 
   constructor(private readonly service: ProviderDescriptorService) {}
 

--- a/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
+++ b/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiResponse } from '../../../shared/api-response.model';
-import { DescriptorEntityDto } from '../models/descriptor-entity.model';
+import { DescriptorDto } from '../models/descriptor-dto.model';
 
 /* Сервис для чтения дескрипторов провайдеров. */
 @Injectable({
@@ -16,9 +16,9 @@ export class ProviderDescriptorService {
   private readonly baseUrl = '/api/v1/providers';
 
   /* Получить все дескрипторы провайдеров. */
-  list(): Observable<DescriptorEntityDto[]> {
+  list(): Observable<DescriptorDto[]> {
     return this.http
-      .get<ApiResponse<DescriptorEntityDto[]>>(this.baseUrl)
+      .get<ApiResponse<DescriptorDto[]>>(this.baseUrl)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- rename the provider descriptor model to `DescriptorDto` and align the comment with the backend contract
- update the provider descriptor service and list component to import and use the new DTO name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d05d5e6844832dbd3364598cb76c93