### PR TITLE
Установить TOD значением Value Date по умолчанию в FX Spot Toolbar

### DIFF
--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -83,7 +83,7 @@ export class FxSpotAdminComponent implements OnInit {
       ],
 
       valueDateCode: [
-        ValueDateCode.SPOT,
+        ValueDateCode.TOD,
         [Validators.required]
       ]
     });
@@ -121,7 +121,7 @@ export class FxSpotAdminComponent implements OnInit {
           baseCurrency: '',
           quoteCurrency: '',
           quoteDecimal: 4,
-          valueDateCode: ValueDateCode.SPOT
+          valueDateCode: ValueDateCode.TOD
         });
         this.locked = false;
       },
@@ -182,7 +182,7 @@ export class FxSpotAdminComponent implements OnInit {
       baseCurrency: '',
       quoteCurrency: '',
       quoteDecimal: 4,
-      valueDateCode: ValueDateCode.SPOT
+      valueDateCode: ValueDateCode.TOD
     });
     this.form.controls['baseCurrency'].enable();
     this.form.controls['quoteCurrency'].enable();


### PR DESCRIPTION
## Summary
- установил TOD значением по умолчанию для поля Value Date в форме FX Spot Toolbar
- обновил сброс формы после добавления и отмены редактирования, чтобы сохранялось значение TOD

## Testing
- не запускались (не требовалось)

------
https://chatgpt.com/codex/tasks/task_e_68d064fcc928832d946c8635e47ae00f