### PR TITLE
feat: initialize provider descriptors on startup

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/ProviderDescriptorInitializer.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/ProviderDescriptorInitializer.java
@@ -1,0 +1,38 @@
+package com.alligator.market.backend.provider.catalog.descriptor.service;
+
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
+import com.alligator.market.domain.provider.reppository.ProviderDescriptorRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Компонент, обновляющий каталог дескрипторов провайдеров при старте приложения.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProviderDescriptorInitializer implements ApplicationRunner {
+
+    private final ProviderContextScanner scanner;
+    private final ProviderDescriptorRepository repository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        // Получаем актуальный список дескрипторов провайдеров из контекста
+        List<ProviderDescriptor> descriptors = scanner.providerDescriptors();
+
+        // Очищаем таблицу и пересохраняем найденные дескрипторы
+        repository.deleteAll();
+        repository.saveAll(descriptors);
+
+        log.info("Provider descriptors refreshed: {} item(s)", descriptors.size());
+    }
+}


### PR DESCRIPTION
## Summary
- add startup initializer that refreshes provider descriptors from the application context on startup

## Testing
- ./mvnw -pl backend test *(fails: cannot download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d15e75acd4832d953f8cf2490f2f7e