### PR TITLE
Запуск синхронизации дескрипторов провайдеров при старте

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/bootstrap/ProviderDescriptorBootstrap.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/bootstrap/ProviderDescriptorBootstrap.java
@@ -1,0 +1,35 @@
+package com.alligator.market.backend.provider.reconciliation.bootstrap;
+
+import com.alligator.market.domain.provider.reconciliation.ProviderDescriptorSynchronizer;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Bootstrap-компонент: выполняет синхронизацию дескрипторов провайдеров при старте приложения.
+ */
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ProviderDescriptorBootstrap implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(ProviderDescriptorBootstrap.class);
+
+    /* ↓↓ Доменный сервис синхронизации дескрипторов. */
+    private final ProviderDescriptorSynchronizer synchronizer;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            synchronizer.synchronize();
+            log.info("Provider descriptors synchronization completed");
+        } catch (RuntimeException ex) {
+            log.error("Provider descriptors synchronization failed", ex);
+            throw ex;
+        }
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
@@ -1,0 +1,56 @@
+package com.alligator.market.domain.provider.reconciliation;
+
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.reppository.ProviderDescriptorRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+/**
+ * Сервис синхронизации дескрипторов провайдеров рыночных данных.
+ */
+@Service
+public class ProviderDescriptorSynchronizer {
+
+    private static final Logger log = LoggerFactory.getLogger(ProviderDescriptorSynchronizer.class);
+
+    /* ↓↓ Сканер контекста приложения: предоставляет актуальные дескрипторы провайдеров. */
+    private final ProviderContextScanner contextScanner;
+
+    /* ↓↓ Репозиторий дескрипторов провайдеров. */
+    private final ProviderDescriptorRepository repository;
+
+    public ProviderDescriptorSynchronizer(
+            ProviderContextScanner contextScanner,
+            ProviderDescriptorRepository repository
+    ) {
+        this.contextScanner = contextScanner;
+        this.repository = repository;
+    }
+
+    /** Выполнить синхронизацию дескрипторов провайдеров. */
+    public void synchronize() {
+        var descriptors = contextScanner.providerDescriptors(); // Загружаем дескрипторы из контекста
+
+        // ↓↓ Устраняем дубликаты по providerCode, сохраняя порядок регистрации.
+        var deduplicated = new LinkedHashMap<String, ProviderDescriptor>();
+        var duplicates = 0;
+        for (var descriptor : descriptors) {
+            var previous = deduplicated.put(descriptor.providerCode(), descriptor);
+            if (previous != null) {
+                duplicates++;
+            }
+        }
+        if (duplicates > 0) {
+            log.warn("Duplicate provider descriptors detected: {} duplicates removed", duplicates);
+        }
+
+        var uniqueDescriptors = new ArrayList<>(deduplicated.values());
+
+        repository.deleteAll(); // Полностью очищаем репозиторий
+        repository.saveAll(uniqueDescriptors); // Сохраняем обновлённый набор дескрипторов
+    }
+}


### PR DESCRIPTION
## Summary
- добавлен доменный сервис синхронизации дескрипторов с устранением дублей и массовой перезаписью
- выполнен транзакционный bootstrap-компонент backend, запускающий синхронизацию при старте
- добавлено минимальное логирование результатов синхронизации и устранения дублей

## Testing
- ./mvnw -pl backend -am test *(failed: нет доступа к Maven Central в среде)*

------
https://chatgpt.com/codex/tasks/task_e_68d15e7d8fd4832da8dbc041f2d30fae