### PR TITLE
Fail on duplicate provider descriptors

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
@@ -37,17 +37,16 @@ public class ProviderDescriptorSynchronizer {
         // Загружаем дескрипторы из контекста
         var descriptors = contextScanner.providerDescriptors();
 
-        // ↓↓ Устраняем дубликаты по providerCode, сохраняя порядок регистрации.
+        // ↓↓ Проверяем отсутствие дубликатов по providerCode, сохраняя порядок регистрации.
         var deduplicated = new LinkedHashMap<String, ProviderDescriptor>();
-        var duplicates = 0;
         for (var descriptor : descriptors) {
-            var previous = deduplicated.put(descriptor.providerCode(), descriptor);
-            if (previous != null) {
-                duplicates++;
+            var providerCode = descriptor.providerCode();
+            if (deduplicated.containsKey(providerCode)) {
+                var message = "Duplicate provider descriptor detected for provider code: " + providerCode;
+                log.error(message);
+                throw new IllegalStateException(message);
             }
-        }
-        if (duplicates > 0) {
-            log.warn("Duplicate provider descriptors detected: {} duplicates removed", duplicates);
+            deduplicated.put(providerCode, descriptor);
         }
 
         var uniqueDescriptors = new ArrayList<>(deduplicated.values());


### PR DESCRIPTION
## Summary
- stop synchronization when duplicate provider descriptors are discovered
- log an error and raise an IllegalStateException instead of silently deduplicating

## Testing
- ./mvnw test *(fails: unable to download Maven distribution in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1654262f8832d81d32f1940eed1c2