### PR TITLE
Add provider descriptor read endpoint

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/api/DescriptorController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/api/DescriptorController.java
@@ -1,10 +1,17 @@
 package com.alligator.market.backend.provider.catalog.descriptor.api;
 
-import com.alligator.market.backend.provider.catalog.descriptor.service.DescriptorUseCase;
+import com.alligator.market.backend.common.web.ApiResponse;
+import com.alligator.market.backend.common.web.ResponseEntityFactory;
+import com.alligator.market.backend.provider.catalog.descriptor.api.dto.DescriptorDto;
 import com.alligator.market.backend.provider.catalog.descriptor.api.dto.DescriptorDtoMapper;
+import com.alligator.market.backend.provider.catalog.descriptor.service.DescriptorUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * REST-контроллер дескрипторов.
@@ -18,5 +25,11 @@ public class DescriptorController {
     private final DescriptorDtoMapper mapper;
 
     /** Вернуть все дескрипторы. */
-
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<DescriptorDto>>> getAll() {
+        List<DescriptorDto> descriptors = service.getAll().stream()
+                .map(mapper::toDto)
+                .toList();
+        return ResponseEntityFactory.ok(descriptors);
+    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCase.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.catalog.descriptor.service;
 
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * Application-сервис (use case) для операций с дескрипторами.
@@ -10,6 +10,8 @@ import java.util.Map;
 public interface DescriptorUseCase {
 
     /** Вернуть все дескрипторы. */
+    List<ProviderDescriptor> getAll();
 
     /** Удалить все дескрипторы. */
+    void clear();
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCaseImpl.java
@@ -1,14 +1,37 @@
 package com.alligator.market.backend.provider.catalog.descriptor.service;
 
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.reppository.ProviderDescriptorRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * Реализация сервиса {@link DescriptorUseCase}.
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DescriptorUseCaseImpl implements DescriptorUseCase {
 
+    private final ProviderDescriptorRepository repository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProviderDescriptor> getAll() {
+        List<ProviderDescriptor> descriptors = repository.findAll();
+        log.debug("Found {} provider descriptors", descriptors.size());
+        return descriptors;
+    }
+
+    @Override
+    @Transactional
+    public void clear() {
+        repository.deleteAll();
+        log.info("Provider descriptors cleared");
+    }
 }
 


### PR DESCRIPTION
## Summary
- expose descriptor use case with methods to read and clear descriptors
- implement descriptor use case to fetch data from repository with logging
- add GET /api/v1/providers endpoint returning descriptors wrapped into ApiResponse

## Testing
- mvn -pl backend test *(fails: Network is unreachable while downloading Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d266088d40832db64cb9db9db23097