### PR TITLE
Перенос создания ProviderDescriptorSynchronizer в конфигурацию backend

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/ProviderReconciliationConfiguration.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/ProviderReconciliationConfiguration.java
@@ -1,0 +1,23 @@
+package com.alligator.market.backend.provider.reconciliation;
+
+import com.alligator.market.domain.provider.reppository.ProviderDescriptorRepository;
+import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
+import com.alligator.market.domain.provider.reconciliation.ProviderDescriptorSynchronizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация бинов доменного уровня для синхронизации дескрипторов провайдеров.
+ */
+@Configuration
+public class ProviderReconciliationConfiguration {
+
+    /** Бин доменного сервиса синхронизации дескрипторов провайдеров. */
+    @Bean
+    public ProviderDescriptorSynchronizer providerDescriptorSynchronizer(
+            ProviderContextScanner scanner,
+            ProviderDescriptorRepository repository
+    ) {
+        return new ProviderDescriptorSynchronizer(scanner, repository);
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
@@ -2,8 +2,6 @@ package com.alligator.market.domain.provider.reconciliation;
 
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.reppository.ProviderDescriptorRepository;
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -11,7 +9,6 @@ import java.util.List;
 /**
  * Доменный сервис синхронизации дескрипторов провайдеров рыночных данных.
  */
-@Service
 public class ProviderDescriptorSynchronizer {
 
     /* Сканер контекста приложения: предоставляет актуальные дескрипторы провайдеров. */


### PR DESCRIPTION
## Summary
- убрал аннотацию @Service из доменного синхронизатора и оставил его чистым компонентом доменного слоя
- добавил backend-конфигурацию ProviderReconciliationConfiguration, создающую бин ProviderDescriptorSynchronizer

## Testing
- ./mvnw -pl backend test *(failed: нет доступа к https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d27447ef40832d94214abdd4433879