### PR TITLE
Add duplicate provider descriptor domain exception

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.provider.reconciliation;
 
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.reconciliation.exception.ProviderDescriptorDuplicateException;
 import com.alligator.market.domain.provider.repository.ProviderDescriptorRepository;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -49,8 +50,7 @@ public class ProviderDescriptorSynchronizer {
         for (var descriptor : descriptors) {
             var providerCode = descriptor.providerCode();
             if (deduplicated.containsKey(providerCode)) {
-                var message = "Duplicate provider descriptor detected for provider code: " + providerCode;
-                throw new IllegalStateException(message);
+                throw new ProviderDescriptorDuplicateException(providerCode);
             }
             deduplicated.put(providerCode, descriptor);
         }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/exception/ProviderDescriptorDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/exception/ProviderDescriptorDuplicateException.java
@@ -1,0 +1,10 @@
+package com.alligator.market.domain.provider.reconciliation.exception;
+
+/**
+ * Дублирующий дескриптор провайдера.
+ */
+public class ProviderDescriptorDuplicateException extends RuntimeException {
+    public ProviderDescriptorDuplicateException(String providerCode) {
+        super("Duplicate provider descriptor detected for provider code: %s".formatted(providerCode));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated domain exception for duplicate provider descriptors
- replace the generic IllegalStateException in ProviderDescriptorSynchronizer with the new exception

## Testing
- ./mvnw -pl domain test *(fails: unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2877a7290832dbee95c63c4ee24be