### PR TITLE
Оптимизация синхронизации дескрипторов провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/ProviderDescriptorRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/ProviderDescriptorRepositoryAdapter.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -32,6 +33,14 @@ public class ProviderDescriptorRepositoryAdapter implements ProviderDescriptorRe
     public void deleteAll() {
         // Удаляем все записи таблицы без постраничного обхода
         jpaRepository.deleteAllInBatch();
+    }
+
+    @Override
+    public void deleteAllByProviderCodes(Collection<String> providerCodes) {
+        if (providerCodes.isEmpty()) {
+            return; // Нечего удалять
+        }
+        jpaRepository.deleteAllByProviderCodeIn(providerCodes);
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorJpaRepository.java
@@ -2,8 +2,14 @@ package com.alligator.market.backend.provider.catalog.descriptor.persistence.jpa
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+
 /**
  * Spring Data JPA-репозиторий дескрипторов.
  */
-public interface DescriptorJpaRepository extends JpaRepository<DescriptorEntity, Long> {}
+public interface DescriptorJpaRepository extends JpaRepository<DescriptorEntity, Long> {
+
+    /** Удалить дескрипторы по списку кодов провайдеров. */
+    void deleteAllByProviderCodeIn(Collection<String> providerCodes);
+}
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
@@ -5,7 +5,9 @@ import com.alligator.market.domain.provider.exception.ProviderDescriptorDuplicat
 import com.alligator.market.domain.provider.repository.ProviderDescriptorRepository;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Доменный сервис синхронизации дескрипторов провайдеров в контексте приложения и в репозитории.
@@ -30,18 +32,70 @@ public class ProviderDescriptorSynchronizer {
     /** Выполнить синхронизацию дескрипторов провайдеров. */
     public void synchronize() {
         // Загружаем дескрипторы из контекста
-        var descriptors = contextScanner.providerDescriptors();
+        var contextDescriptors = contextScanner.providerDescriptors();
 
         // Проверяем, что список дескрипторов не пуст
-        if (descriptors.isEmpty()) {
+        if (contextDescriptors.isEmpty()) {
             throw new IllegalStateException("No provider descriptors found");
         }
 
         // Проверяем отсутствие дубликатов по providerCode
-        var uniqueDescriptors = deduplicateDescriptors(descriptors);
+        var uniqueDescriptors = deduplicateDescriptors(contextDescriptors);
 
-        repository.deleteAll();                // Полностью очищаем репозиторий
-        repository.saveAll(uniqueDescriptors); // Сохраняем обновлённый набор дескрипторов
+        // Загружаем сохранённые ранее дескрипторы
+        var repositoryDescriptors = repository.findAll();
+
+        // Оптимизация: если наборы совпадают, то повторное сохранение не требуется
+        if (repositoryDescriptors.size() == uniqueDescriptors.size()
+                && repositoryDescriptors.containsAll(uniqueDescriptors)
+                && uniqueDescriptors.containsAll(repositoryDescriptors)) {
+            return;
+        }
+
+        // Собираем карту дескрипторов из репозитория по коду провайдера для быстрых проверок
+        var repositoryMap = new LinkedHashMap<String, ProviderDescriptor>();
+        for (var descriptor : repositoryDescriptors) {
+            repositoryMap.put(descriptor.providerCode(), descriptor);
+        }
+
+        // Формируем списки на удаление и добавление
+        var descriptorsToSave = new ArrayList<ProviderDescriptor>();
+        Set<String> codesToDelete = new LinkedHashSet<>();
+
+        for (var descriptor : uniqueDescriptors) {
+            var providerCode = descriptor.providerCode();
+            var existing = repositoryMap.get(providerCode);
+
+            if (existing == null) { // Новый код
+                descriptorsToSave.add(descriptor);
+                continue;
+            }
+
+            if (!existing.equals(descriptor)) { // Код есть, но данные изменились
+                descriptorsToSave.add(descriptor);
+                codesToDelete.add(providerCode);
+            }
+        }
+
+        // Вычисляем коды, которые присутствуют в репозитории, но отсутствуют в контексте
+        var contextCodes = new LinkedHashSet<String>();
+        for (var descriptor : uniqueDescriptors) {
+            contextCodes.add(descriptor.providerCode());
+        }
+        for (var descriptor : repositoryDescriptors) {
+            var providerCode = descriptor.providerCode();
+            if (!contextCodes.contains(providerCode)) {
+                codesToDelete.add(providerCode);
+            }
+        }
+
+        if (!codesToDelete.isEmpty()) {
+            repository.deleteAllByProviderCodes(codesToDelete); // Удаляем изменившиеся и устаревшие дескрипторы
+        }
+
+        if (!descriptorsToSave.isEmpty()) {
+            repository.saveAll(descriptorsToSave); // Добавляем новые или обновлённые дескрипторы
+        }
     }
 
     /** Статический метод проверки дескрипторов на дублирование по кодам провайдеров. */

--- a/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
@@ -2,6 +2,7 @@ package com.alligator.market.domain.provider.repository;
 
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -14,6 +15,9 @@ public interface ProviderDescriptorRepository {
 
     /** Полностью очистить таблицу дескрипторов. */
     void deleteAll();
+
+    /** Удалить дескрипторы по списку кодов провайдеров. */
+    void deleteAllByProviderCodes(Collection<String> providerCodes);
 
     /** Пакетно сохранить список дескрипторов. */
     void saveAll(List<ProviderDescriptor> descriptors);


### PR DESCRIPTION
## Summary
- оптимизирован доменный сервис синхронизации: теперь сравниваются дескрипторы из контекста и репозитория, удаляются устаревшие записи и добавляются только новые либо изменившиеся
- расширен порт репозитория и адаптер для удаления дескрипторов по списку кодов провайдеров

## Testing
- ./mvnw -pl backend test *(не удалось загрузить Maven Wrapper из интернета в окружении CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d29a81b384832dadecfb6c89327c7c