### PR TITLE
Ensure provider descriptors unique by code and name

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDescriptorDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDescriptorDuplicateException.java
@@ -4,7 +4,10 @@ package com.alligator.market.domain.provider.exception;
  * Дублирующий дескриптор провайдера.
  */
 public class ProviderDescriptorDuplicateException extends RuntimeException {
-    public ProviderDescriptorDuplicateException(String providerCode) {
-        super("Duplicate provider descriptor detected for provider code: %s".formatted(providerCode));
+    public ProviderDescriptorDuplicateException(String providerCode, String displayName) {
+        super("Duplicate provider descriptor detected for provider code '%s' or display name '%s'".formatted(
+                providerCode,
+                displayName
+        ));
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
@@ -41,13 +41,13 @@ public class ProviderDescriptorSynchronizer {
             return;
         }
 
-        // Проверка уникальности дескрипторов из контекста по коду провайдера
-        assertUniqueByCode(contextDescriptors);
+        // Проверка уникальности дескрипторов из контекста по коду провайдера и отображаемому имени
+        assertUniqueByCodeAndName(contextDescriptors);
         // Строим карту
         Map<String, ProviderDescriptor> repoMap = toMapByCode(repositoryDescriptors);
 
-        // Проверка уникальности дескрипторов из репозитория по коду провайдера
-        assertUniqueByCode(repositoryDescriptors);
+        // Проверка уникальности дескрипторов из репозитория по коду провайдера и отображаемому имени
+        assertUniqueByCodeAndName(repositoryDescriptors);
         // Строим карту
         Map<String, ProviderDescriptor> ctxMap  = toMapByCode(contextDescriptors);
 
@@ -82,8 +82,8 @@ public class ProviderDescriptorSynchronizer {
             }
         }
 
-        // Для страховки проверим, что descriptorsToUpsert уникальны по коду провайдера
-        assertUniqueByCode(descriptorsToUpsert);
+        // Для страховки проверим, что descriptorsToUpsert уникальны по коду провайдера и отображаемому имени
+        assertUniqueByCodeAndName(descriptorsToUpsert);
 
         // Применяем изменения
         if (!codesToDelete.isEmpty()) repository.deleteAllByProviderCodes(codesToDelete);
@@ -95,15 +95,26 @@ public class ProviderDescriptorSynchronizer {
         return code == null ? null : code.trim().toUpperCase(Locale.ROOT);
     }
 
-    /* Проверка уникальности кодов провайдеров. */
-    private static void assertUniqueByCode(List<ProviderDescriptor> descriptors) {
-        Set<String> seen = new HashSet<>();
+    /* Проверка уникальности кодов провайдеров и отображаемых имен. */
+    private static void assertUniqueByCodeAndName(List<ProviderDescriptor> descriptors) {
+        Set<String> seenCodes = new HashSet<>();
+        Set<String> seenDisplayNames = new HashSet<>();
         for (ProviderDescriptor d : descriptors) {
             String code = norm(d.providerCode());
-            if (!seen.add(code)) {
-                throw new ProviderDescriptorDuplicateException(code);
+            if (!seenCodes.add(code)) {
+                throw new ProviderDescriptorDuplicateException(code, d.displayName());
+            }
+
+            String displayName = normDisplayName(d.displayName());
+            if (!seenDisplayNames.add(displayName)) {
+                throw new ProviderDescriptorDuplicateException(d.providerCode(), d.displayName());
             }
         }
+    }
+
+    /* Нормализуем отображаемое имя провайдера: убираем пробелы. */
+    private static String normDisplayName(String displayName) {
+        return displayName == null ? null : displayName.trim();
     }
 
     /* Построить карту: providerCode ⇒ descriptor. */


### PR DESCRIPTION
## Summary
- enforce uniqueness of provider descriptors by both provider code and display name during synchronization
- update the duplicate descriptor exception message to cover provider codes and display names

## Testing
- ./mvnw -pl domain test *(fails: wget unable to fetch Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a05b5d84832da4457e0f1fed58f7