### PR TITLE
Normalize provider descriptor inputs

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/ProviderDescriptor.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/ProviderDescriptor.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.contract.descriptor;
 
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -19,14 +20,23 @@ public record ProviderDescriptor(
         boolean bulkSubscription
 ) {
     public ProviderDescriptor {
-
         // ↓↓ Базовые проверки аргументов
         Objects.requireNonNull(deliveryMode, "deliveryMode must not be null");
         Objects.requireNonNull(accessMethod, "accessMethod must not be null");
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(displayName, "displayName must not be null");
+
+        providerCode = providerCode.trim();
+        displayName = displayName.trim();
+
         if (providerCode.isBlank()) {
             throw new IllegalArgumentException("providerCode must not be blank");
+        }
+        if (providerCode.chars().anyMatch(Character::isWhitespace)) {
+            throw new IllegalArgumentException("providerCode must not contain whitespaces");
+        }
+        if (!providerCode.equals(providerCode.toUpperCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("providerCode must be upper case");
         }
         if (displayName.isBlank()) {
             throw new IllegalArgumentException("displayName must not be blank");

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderDescriptorSynchronizer.java
@@ -85,11 +85,11 @@ public class ProviderDescriptorSynchronizer {
         Set<String> seenProviderCodes = new HashSet<>();
         Set<String> seenDisplayNames = new HashSet<>();
         for (ProviderDescriptor d : descriptors) {
-            String code = normProviderCode(d.providerCode());
+            String code = d.providerCode();
             if (!seenProviderCodes.add(code)) {
                 throw new ProviderDescriptorDuplicateException(d.providerCode(), d.displayName());
             }
-            String displayName = normDisplayName(d.displayName());
+            String displayName = d.displayName();
             if (!seenDisplayNames.add(displayName)) {
                 throw new ProviderDescriptorDuplicateException(d.providerCode(), d.displayName());
             }
@@ -100,18 +100,8 @@ public class ProviderDescriptorSynchronizer {
     private static Map<String, ProviderDescriptor> toMapByCode(List<ProviderDescriptor> list) {
         Map<String, ProviderDescriptor> map = new LinkedHashMap<>(); // сохраняем порядок для предсказуемых логов
         for (ProviderDescriptor d : list) {
-            map.put(normProviderCode(d.providerCode()), d);
+            map.put(d.providerCode(), d);
         }
         return map;
-    }
-
-    /* Нормализуем код провайдера: убираем пробелы и приводим к верхнему регистру. */
-    private static String normProviderCode(String code) {
-        return code == null ? null : code.trim().toUpperCase(Locale.ROOT);
-    }
-
-    /* Нормализуем отображаемое имя провайдера: убираем пробелы. */
-    private static String normDisplayName(String displayName) {
-        return displayName == null ? null : displayName.trim();
     }
 }


### PR DESCRIPTION
## Summary
- normalize provider descriptor constructor by trimming values, checking uppercase code without inner whitespace, and keeping normalized data
- simplify descriptor synchronizer to rely on normalized record values and drop legacy normalization helpers

## Testing
- `./mvnw -pl domain test` *(fails: wget could not fetch Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bb07cb98832d8f518a8b2d4854ad