### PR TITLE
Return provider descriptor sync result and add logging

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/service/ProviderDescriptorSyncService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/service/ProviderDescriptorSyncService.java
@@ -1,13 +1,16 @@
 package com.alligator.market.backend.provider.reconciliation.service;
 
+import com.alligator.market.domain.provider.reconciliation.descriptor.ProviderDescriptorSyncResult;
 import com.alligator.market.domain.provider.reconciliation.descriptor.ProviderDescriptorSynchronizer;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Сервис запускает доменную логику реконсиляции дескрипторов провайдеров рыночных данных. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ProviderDescriptorSyncService {
 
     /* Доменный сервис синхронизации дескрипторов. */
@@ -15,6 +18,15 @@ public class ProviderDescriptorSyncService {
 
     @Transactional
     public void runSync() {
-        synchronizer.synchronize();
+        ProviderDescriptorSyncResult result = synchronizer.synchronize();
+        log.info(
+                "Provider descriptors sync: context={}, repoBefore={}, deleted={}, insertedNew={}, reinsertedUpdated={}, changed={}",
+                result.inContext(),
+                result.inRepoBefore(),
+                result.deleted(),
+                result.insertedNew(),
+                result.reinsertedUpdated(),
+                result.changed()
+        );
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/descriptor/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/descriptor/ProviderDescriptorSynchronizer.java
@@ -28,17 +28,29 @@ public class ProviderDescriptorSynchronizer {
     }
 
     /** Выполнить синхронизацию дескрипторов провайдеров. */
-    public void synchronize() {
+    public ProviderDescriptorSyncResult synchronize() {
         // 0) Считываем оба источника
         List<ProviderDescriptor> contextDescriptors = contextScanner.providerDescriptors();
         List<ProviderDescriptor> repositoryDescriptors = repository.findAll();
+
+        int inContext = contextDescriptors.size();
+        int inRepoBefore = repositoryDescriptors.size();
 
         // 1) Если в контексте пусто (нет дескрипторов) — очищаем репозиторий и выходим
         if (contextDescriptors.isEmpty()) {
             if (!repositoryDescriptors.isEmpty()) {
                 repository.deleteAll();
+                int deleted = repositoryDescriptors.size();
+                return new ProviderDescriptorSyncResult(
+                        inContext,
+                        inRepoBefore,
+                        deleted,
+                        0,
+                        0,
+                        deleted > 0
+                );
             }
-            return;
+            return new ProviderDescriptorSyncResult(inContext, inRepoBefore, 0, 0, 0, false);
         }
 
         // 2) Проверяем инварианты уникальности наборов (код провайдера и имя провайдера)
@@ -51,7 +63,7 @@ public class ProviderDescriptorSynchronizer {
 
         // Ранний выход: карты идентичны по ключам (кодам) и значениям (дескрипторам)
         if (repoMap.equals(ctxMap)) {
-            return;
+            return new ProviderDescriptorSyncResult(inContext, inRepoBefore, 0, 0, 0, false);
         }
 
         // 4.1) К удалению: дескрипторы в репозитории с кодами, которых больше нет в контексте
@@ -97,6 +109,18 @@ public class ProviderDescriptorSynchronizer {
             repository.insertAll(toInsert); // выполняется пакетный INSERT
         }
         // Готово
+        int deleted = codesToRemoveFirst.size();
+        int insertedNew = descriptorsToAdd.size();
+        int reinsertedUpdated = codesToUpdate.size();
+        boolean changed = deleted > 0 || insertedNew > 0 || reinsertedUpdated > 0;
+        return new ProviderDescriptorSyncResult(
+                inContext,
+                inRepoBefore,
+                deleted,
+                insertedNew,
+                reinsertedUpdated,
+                changed
+        );
     }
 
     /* Проверка уникальности кодов провайдеров и отображаемых имен. */


### PR DESCRIPTION
## Summary
- return a detailed ProviderDescriptorSyncResult from ProviderDescriptorSynchronizer and cover all early exit paths
- log synchronization statistics in ProviderDescriptorSyncService using the returned result

## Testing
- ./mvnw -pl domain test *(fails: unable to download Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fe953838832da33d8d264ec688f6