### PR TITLE
Add guard for minimal provider update interval

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/settings/ProviderSettings.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/settings/ProviderSettings.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.contract.settings;
 
+import java.time.Duration;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -11,12 +12,18 @@ import java.util.Objects;
  */
 public record ProviderSettings(
         String providerCode,
-        java.time.Duration minUpdateInterval
+        Duration minUpdateInterval
 ) {
+    /**
+     * Минимально допустимый интервал обновления котировки.
+     * 1 секунда защищает от ошибочного указания меньшей размерности и чрезмерной нагрузки.
+     */
+    private static final Duration MIN_ALLOWED_UPDATE_INTERVAL = Duration.ofSeconds(1);
+
     public ProviderSettings {
         // ↓↓ Базовые проверки аргументов
         Objects.requireNonNull(providerCode, "providerCode must not be null");
-        java.util.Objects.requireNonNull(minUpdateInterval, "minUpdateInterval must not be null");
+        Objects.requireNonNull(minUpdateInterval, "minUpdateInterval must not be null");
 
         providerCode = providerCode.trim();
 
@@ -31,6 +38,9 @@ public record ProviderSettings(
         }
         if (minUpdateInterval.isZero() || minUpdateInterval.isNegative()) {
             throw new IllegalArgumentException("minUpdateInterval must be positive");
+        }
+        if (minUpdateInterval.compareTo(MIN_ALLOWED_UPDATE_INTERVAL) < 0) {
+            throw new IllegalArgumentException("minUpdateInterval must be greater or equal to PT1S");
         }
     }
 }


### PR DESCRIPTION
## Summary
- enforce a minimum update interval of one second in `ProviderSettings`
- document the intent of the guard to prevent misconfigured high-frequency updates
- tidy the null-check usage now that `Duration` is imported

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95b6b8600832d80c8aa239fdaf06d