### PR TITLE
Add provider settings storage infrastructure

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/adapter/ProviderSettingsRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/adapter/ProviderSettingsRepositoryAdapter.java
@@ -1,0 +1,53 @@
+package com.alligator.market.backend.provider.catalog.settings.persistence.adapter;
+
+import com.alligator.market.backend.provider.catalog.settings.persistence.jpa.ProviderSettingsEntity;
+import com.alligator.market.backend.provider.catalog.settings.persistence.jpa.ProviderSettingsEntityMapper;
+import com.alligator.market.backend.provider.catalog.settings.persistence.jpa.ProviderSettingsJpaRepository;
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+import com.alligator.market.domain.provider.repository.ProviderSettingsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Адаптер, реализующий порт доменного репозитория для настроек через Spring Data JPA.
+ */
+@Repository
+@RequiredArgsConstructor
+public class ProviderSettingsRepositoryAdapter implements ProviderSettingsRepository {
+
+    private final ProviderSettingsJpaRepository jpaRepository;
+    private final ProviderSettingsEntityMapper mapper;
+
+    @Override
+    public List<ProviderSettings> findAll() {
+        return jpaRepository.findAll(Sort.by("providerCode")).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void deleteAll() {
+        jpaRepository.deleteAllInBatch();
+    }
+
+    @Override
+    public void deleteAllByProviderCodes(Collection<String> providerCodes) {
+        if (providerCodes.isEmpty()) return; // Нечего удалять
+        jpaRepository.deleteAllByProviderCodeIn(providerCodes);
+        jpaRepository.flush(); // важно для порядка операций
+    }
+
+    @Override
+    public void insertAll(List<ProviderSettings> settings) {
+        if (settings.isEmpty()) return; // Нечего вставлять
+        List<ProviderSettingsEntity> entities = settings.stream()
+                .map(mapper::toEntity)
+                .toList();
+        jpaRepository.saveAll(entities);
+        jpaRepository.flush();
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/jpa/ProviderSettingsEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/jpa/ProviderSettingsEntity.java
@@ -1,0 +1,47 @@
+package com.alligator.market.backend.provider.catalog.settings.persistence.jpa;
+
+import com.alligator.market.backend.common.jpa.BaseEntity;
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * JPA-сущность настроек провайдера.
+ * Набор полей аналогичен доменной модели {@link ProviderSettings}.
+ */
+@Entity
+@Table(
+        name = "provider_settings",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_provider_settings_provider_code", columnNames = "provider_code")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProviderSettingsEntity extends BaseEntity {
+
+    /** Суррогатный PK. */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    /** Технический код провайдера {@link ProviderSettings#providerCode()}. */
+    @NotBlank
+    @Size(max = 50)
+    @Column(name = "provider_code", length = 50, nullable = false, updatable = false)
+    private String providerCode;
+
+    /** Минимальный интервал обновления котировки в секундах {@link ProviderSettings#minUpdateInterval()}. */
+    @NotNull
+    @Min(1)
+    @Column(name = "min_update_interval_seconds", nullable = false, updatable = false)
+    private Long minUpdateIntervalSeconds;
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/jpa/ProviderSettingsEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/jpa/ProviderSettingsEntityMapper.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.provider.catalog.settings.persistence.jpa;
+
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Маппер: сущность ⇄ доменная модель.
+ */
+@Component
+public class ProviderSettingsEntityMapper {
+
+    /** Сущность ⇒ доменная модель. */
+    public ProviderSettings toDomain(ProviderSettingsEntity entity) {
+        return new ProviderSettings(
+                entity.getProviderCode(),
+                Duration.ofSeconds(entity.getMinUpdateIntervalSeconds())
+        );
+    }
+
+    /** Доменная модель ⇒ сущность. */
+    public ProviderSettingsEntity toEntity(ProviderSettings settings) {
+        var entity = new ProviderSettingsEntity();
+        entity.setProviderCode(settings.providerCode());
+        entity.setMinUpdateIntervalSeconds(settings.minUpdateInterval().getSeconds());
+        return entity;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/jpa/ProviderSettingsJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/persistence/jpa/ProviderSettingsJpaRepository.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.provider.catalog.settings.persistence.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+
+/**
+ * Spring Data JPA-репозиторий настроек провайдеров.
+ */
+public interface ProviderSettingsJpaRepository extends JpaRepository<ProviderSettingsEntity, Long> {
+
+    /** Удалить настройки по списку кодов провайдеров. */
+    void deleteAllByProviderCodeIn(Collection<String> providerCodes);
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/service/ProviderSettingsUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/service/ProviderSettingsUseCase.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.provider.catalog.settings.service;
+
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+
+import java.util.List;
+
+/**
+ * Application-сервис (use case) для операций с настройками провайдеров.
+ */
+public interface ProviderSettingsUseCase {
+
+    /** Вернуть все настройки. */
+    List<ProviderSettings> getAll();
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/service/ProviderSettingsUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/service/ProviderSettingsUseCaseImpl.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.provider.catalog.settings.service;
+
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+import com.alligator.market.domain.provider.repository.ProviderSettingsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Реализация сервиса {@link ProviderSettingsUseCase}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProviderSettingsUseCaseImpl implements ProviderSettingsUseCase {
+
+    private final ProviderSettingsRepository repository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProviderSettings> getAll() {
+        List<ProviderSettings> settings = repository.findAll();
+        log.debug("Found {} provider settings", settings.size());
+        return settings;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/web/ProviderSettingsController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/web/ProviderSettingsController.java
@@ -1,0 +1,35 @@
+package com.alligator.market.backend.provider.catalog.settings.web;
+
+import com.alligator.market.backend.common.web.ApiResponse;
+import com.alligator.market.backend.common.web.ResponseEntityFactory;
+import com.alligator.market.backend.provider.catalog.settings.service.ProviderSettingsUseCase;
+import com.alligator.market.backend.provider.catalog.settings.web.dto.ProviderSettingsDto;
+import com.alligator.market.backend.provider.catalog.settings.web.dto.ProviderSettingsDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST-контроллер настроек провайдеров.
+ */
+@RestController
+@RequestMapping("/api/v1/provider-settings")
+@RequiredArgsConstructor
+public class ProviderSettingsController {
+
+    private final ProviderSettingsUseCase service;
+    private final ProviderSettingsDtoMapper mapper;
+
+    /** Вернуть все настройки. */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ProviderSettingsDto>>> getAll() {
+        List<ProviderSettingsDto> settings = service.getAll().stream()
+                .map(mapper::toDto)
+                .toList();
+        return ResponseEntityFactory.ok(settings);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/web/dto/ProviderSettingsDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/web/dto/ProviderSettingsDto.java
@@ -1,0 +1,13 @@
+package com.alligator.market.backend.provider.catalog.settings.web.dto;
+
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Основной DTO для настроек провайдера {@link ProviderSettings}.
+ */
+public record ProviderSettingsDto(
+        @NotBlank String providerCode,
+        @Min(1) long minUpdateIntervalSeconds
+) {}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/web/dto/ProviderSettingsDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/settings/web/dto/ProviderSettingsDtoMapper.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.provider.catalog.settings.web.dto;
+
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Маппер: DTO ⇄ доменная модель.
+ */
+@Component
+public class ProviderSettingsDtoMapper {
+
+    /** Доменная модель ⇒ основной DTO. */
+    public ProviderSettingsDto toDto(ProviderSettings settings) {
+        return new ProviderSettingsDto(
+                settings.providerCode(),
+                settings.minUpdateInterval().getSeconds()
+        );
+    }
+
+    /** Основной DTO ⇒ доменная модель. */
+    public ProviderSettings toDomain(ProviderSettingsDto dto) {
+        return new ProviderSettings(
+                dto.providerCode(),
+                Duration.ofSeconds(dto.minUpdateIntervalSeconds())
+        );
+    }
+}

--- a/backend/src/main/resources/db/migration/V2__create_provider_settings_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_provider_settings_table.sql
@@ -1,0 +1,15 @@
+-- Миграция Flyway: создание таблицы настроек провайдеров
+
+CREATE TABLE provider_settings (
+    id                          BIGSERIAL PRIMARY KEY,
+    version                     BIGINT                  NOT NULL,
+    created_timestamp           TIMESTAMPTZ             NOT NULL,
+    created_by                  VARCHAR(255)            NOT NULL,
+    created_via                 VARCHAR(255)            NOT NULL,
+    updated_timestamp           TIMESTAMPTZ             NOT NULL,
+    updated_by                  VARCHAR(255)            NOT NULL,
+    updated_via                 VARCHAR(255)            NOT NULL,
+    provider_code               VARCHAR(50)             NOT NULL,
+    min_update_interval_seconds BIGINT                  NOT NULL,
+    CONSTRAINT uq_provider_settings_provider_code UNIQUE (provider_code)
+);

--- a/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderSettingsRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderSettingsRepository.java
@@ -1,0 +1,24 @@
+package com.alligator.market.domain.provider.repository;
+
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Порт репозитория настроек провайдеров.
+ */
+public interface ProviderSettingsRepository {
+
+    /** Получить все настройки провайдеров. */
+    List<ProviderSettings> findAll();
+
+    /** Полностью очистить таблицу настроек (админ/служебная операция). */
+    void deleteAll();
+
+    /** Удалить настройки по списку кодов провайдеров. */
+    void deleteAllByProviderCodes(Collection<String> providerCodes);
+
+    /** INSERT после предварительного удаления; не upsert. Дубликаты providerCode → ошибка UNIQUE. */
+    void insertAll(List<ProviderSettings> settings);
+}


### PR DESCRIPTION
## Summary
- add a domain repository port dedicated to provider settings
- implement Spring Data JPA adapters, service layer, and REST controller for provider settings management
- create a Flyway migration for the provider_settings table with a provider code uniqueness constraint

## Testing
- ./mvnw -pl backend test *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d95e6cd44c832d913e349b7547dc83