### PR TITLE
Refactor provider descriptor synchronization to use maps

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
@@ -65,7 +65,7 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
                 price,
                 price,
                 Instant.now(),
-                provider().descriptor().providerCode()
+                provider().providerCode()
         );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/ProviderDescriptorRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/ProviderDescriptorRepositoryAdapter.java
@@ -10,7 +10,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Адаптер, реализующий порт доменного репозитория для дескрипторов через Spring Data JPA.
@@ -23,10 +26,16 @@ public class ProviderDescriptorRepositoryAdapter implements ProviderDescriptorRe
     private final DescriptorEntityMapper mapper;
 
     @Override
-    public List<ProviderDescriptor> findAll() {
+    public Map<String, ProviderDescriptor> findAll() {
         return jpaRepository.findAll(Sort.by("providerCode")).stream()
-                .map(mapper::toDomain)
-                .toList();
+                .collect(Collectors.toMap(
+                        DescriptorEntity::getProviderCode,
+                        mapper::toDomain,
+                        (left, right) -> {
+                            throw new IllegalStateException("Duplicate provider code found in repository");
+                        },
+                        LinkedHashMap::new
+                ));
     }
 
     @Override
@@ -43,10 +52,10 @@ public class ProviderDescriptorRepositoryAdapter implements ProviderDescriptorRe
     }
 
     @Override
-    public void insertAll(List<ProviderDescriptor> descriptors) {
+    public void insertAll(Map<String, ProviderDescriptor> descriptors) {
         if (descriptors.isEmpty()) return; // Нечего вставлять
-        List<DescriptorEntity> entities = descriptors.stream()
-                .map(mapper::toEntity)
+        List<DescriptorEntity> entities = descriptors.entrySet().stream()
+                .map(e -> mapper.toEntity(e.getKey(), e.getValue()))
                 .toList();
         jpaRepository.saveAll(entities);
         jpaRepository.flush();

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
@@ -35,7 +35,7 @@ public class DescriptorEntity extends BaseEntity {
     @Column(name = "id")
     private Long id;
 
-    /** Технический код провайдера {@link ProviderDescriptor#providerCode()}. */
+    /** Технический код провайдера {@link com.alligator.market.domain.provider.contract.MarketDataProvider#providerCode()}. */
     @NotBlank
     @Size(max = 50)
     @Column(name = "provider_code", length = 50, nullable = false, updatable = false)

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
@@ -12,7 +12,6 @@ public class DescriptorEntityMapper {
     /** Сущность ⇒ доменная модель. */
     public ProviderDescriptor toDomain(DescriptorEntity entity) {
         return new ProviderDescriptor(
-                entity.getProviderCode(),
                 entity.getDisplayName(),
                 entity.getDeliveryMode(),
                 entity.getAccessMethod(),
@@ -21,9 +20,9 @@ public class DescriptorEntityMapper {
     }
 
     /** Доменная модель ⇒ сущность. */
-    public DescriptorEntity toEntity(ProviderDescriptor providerDescriptor) {
+    public DescriptorEntity toEntity(String providerCode, ProviderDescriptor providerDescriptor) {
         var entity = new DescriptorEntity();
-        entity.setProviderCode(providerDescriptor.providerCode());
+        entity.setProviderCode(providerCode);
         entity.setDisplayName(providerDescriptor.displayName());
         entity.setDeliveryMode(providerDescriptor.deliveryMode());
         entity.setAccessMethod(providerDescriptor.accessMethod());

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCase.java
@@ -2,13 +2,13 @@ package com.alligator.market.backend.provider.catalog.descriptor.service;
 
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Application-сервис (use case) для операций с дескрипторами.
  */
 public interface DescriptorUseCase {
 
-    /** Вернуть все дескрипторы. */
-    List<ProviderDescriptor> getAll();
+    /** Вернуть карту всех дескрипторов индексированную по коду провайдера. */
+    Map<String, ProviderDescriptor> getAll();
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCaseImpl.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Реализация сервиса {@link DescriptorUseCase}.
@@ -21,8 +21,8 @@ public class DescriptorUseCaseImpl implements DescriptorUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ProviderDescriptor> getAll() {
-        List<ProviderDescriptor> descriptors = repository.findAll();
+    public Map<String, ProviderDescriptor> getAll() {
+        Map<String, ProviderDescriptor> descriptors = repository.findAll();
         log.debug("Found {} provider descriptors", descriptors.size());
         return descriptors;
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorController.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.common.web.ResponseEntityFactory;
 import com.alligator.market.backend.provider.catalog.descriptor.web.dto.DescriptorDto;
 import com.alligator.market.backend.provider.catalog.descriptor.web.dto.DescriptorDtoMapper;
 import com.alligator.market.backend.provider.catalog.descriptor.service.DescriptorUseCase;
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * REST-контроллер дескрипторов.
@@ -27,9 +29,10 @@ public class DescriptorController {
     /** Вернуть все дескрипторы. */
     @GetMapping
     public ResponseEntity<ApiResponse<List<DescriptorDto>>> getAll() {
-        List<DescriptorDto> descriptors = service.getAll().stream()
-                .map(mapper::toDto)
+        Map<String, ProviderDescriptor> descriptors = service.getAll();
+        List<DescriptorDto> response = descriptors.entrySet().stream()
+                .map(e -> mapper.toDto(e.getKey(), e.getValue()))
                 .toList();
-        return ResponseEntityFactory.ok(descriptors);
+        return ResponseEntityFactory.ok(response);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/dto/DescriptorDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/dto/DescriptorDtoMapper.java
@@ -10,9 +10,9 @@ import org.springframework.stereotype.Component;
 public class DescriptorDtoMapper {
 
     /** Доменная модель ⇒ основной DTO. */
-    public DescriptorDto toDto(ProviderDescriptor providerDescriptor) {
+    public DescriptorDto toDto(String providerCode, ProviderDescriptor providerDescriptor) {
         return new DescriptorDto(
-                providerDescriptor.providerCode(),
+                providerCode,
                 providerDescriptor.displayName(),
                 providerDescriptor.deliveryMode(),
                 providerDescriptor.accessMethod(),
@@ -23,7 +23,6 @@ public class DescriptorDtoMapper {
     /** Основной DTO ⇒ доменная модель. */
     public ProviderDescriptor toDomain(DescriptorDto dto) {
         return new ProviderDescriptor(
-                dto.providerCode(),
                 dto.displayName(),
                 dto.deliveryMode(),
                 dto.accessMethod(),

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -2,12 +2,14 @@ package com.alligator.market.backend.provider.reconciliation.scanner;
 
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.exception.ProviderDescriptorDuplicateException;
 import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 /**
  * Адаптер доменного сканера контекста приложения для получения данных о провайдерах рыночных данных.
@@ -19,9 +21,16 @@ public class ProviderContextScannerAdapter implements ProviderContextScanner {
     private final List<MarketDataProvider> providers;
 
     @Override
-    public List<ProviderDescriptor> providerDescriptors() {
-        return providers.stream()
-                .map(MarketDataProvider::descriptor)
-                .collect(Collectors.toList());
+    public Map<String, ProviderDescriptor> providerDescriptors() {
+        Map<String, ProviderDescriptor> descriptors = new LinkedHashMap<>();
+        for (MarketDataProvider provider : providers) {
+            String providerCode = provider.providerCode();
+            ProviderDescriptor descriptor = provider.descriptor();
+            ProviderDescriptor previous = descriptors.put(providerCode, descriptor);
+            if (previous != null) {
+                throw new ProviderDescriptorDuplicateException(providerCode, descriptor.displayName());
+            }
+        }
+        return descriptors;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
@@ -2,13 +2,13 @@ package com.alligator.market.domain.provider.reconciliation;
 
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Сканер контекста приложения для получения данных о провайдерах рыночных данных.
  */
 public interface ProviderContextScanner {
 
-    /** Вернуть список дескрипторов провайдеров. */
-    List<ProviderDescriptor> providerDescriptors();
+    /** Вернуть карту дескрипторов провайдеров, индексированную по коду провайдера. */
+    Map<String, ProviderDescriptor> providerDescriptors();
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/descriptor/ProviderDescriptorSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/descriptor/ProviderDescriptorSynchronizer.java
@@ -30,8 +30,8 @@ public class ProviderDescriptorSynchronizer {
     /** Выполнить синхронизацию дескрипторов провайдеров. */
     public ProviderDescriptorSyncResult synchronize() {
         // 0) Считываем оба источника
-        List<ProviderDescriptor> contextDescriptors = contextScanner.providerDescriptors();
-        List<ProviderDescriptor> repositoryDescriptors = repository.findAll();
+        Map<String, ProviderDescriptor> contextDescriptors = contextScanner.providerDescriptors();
+        Map<String, ProviderDescriptor> repositoryDescriptors = repository.findAll();
 
         int inContext = contextDescriptors.size();
         int inRepoBefore = repositoryDescriptors.size();
@@ -64,12 +64,8 @@ public class ProviderDescriptorSynchronizer {
         assertUniqueByCodeAndName(contextDescriptors);
         assertUniqueByCodeAndName(repositoryDescriptors);
 
-        // 3) Строим карты по коду провайдера (далее для краткости "код провайдера" = "код")
-        Map<String, ProviderDescriptor> repoMap = toMapByCode(repositoryDescriptors);
-        Map<String, ProviderDescriptor> ctxMap  = toMapByCode(contextDescriptors);
-
         // Ранний выход: карты идентичны по ключам (кодам) и значениям (дескрипторам)
-        if (repoMap.equals(ctxMap)) {
+        if (repositoryDescriptors.equals(contextDescriptors)) {
             return new ProviderDescriptorSyncResult(
                     inContext,
                     inRepoBefore,
@@ -81,20 +77,20 @@ public class ProviderDescriptorSynchronizer {
         }
 
         // 4.1) К удалению: дескрипторы в репозитории с кодами, которых больше нет в контексте
-        Set<String> codesToDelete = new LinkedHashSet<>(repoMap.keySet()); // Берем множество кодов из repoMap
-        codesToDelete.removeAll(ctxMap.keySet()); // "Вычитаем" множество кодов из ctxMap
+        Set<String> codesToDelete = new LinkedHashSet<>(repositoryDescriptors.keySet()); // Берем множество кодов из репозитория
+        codesToDelete.removeAll(contextDescriptors.keySet()); // "Вычитаем" множество кодов из контекста
 
         // 4.2) К добавлению/обновлению: новые и изменившиеся дескрипторы
-        List<ProviderDescriptor> descriptorsToAdd = new ArrayList<>(); // список для новых дескрипторов
-        Set<String> codesToUpdate = new LinkedHashSet<>(); // набор для кодов изменившиеся дескрипторов
-        // ↓↓ Перебираем элементы карты ctxMap
-        for (Map.Entry<String, ProviderDescriptor> e : ctxMap.entrySet()) {
+        Map<String, ProviderDescriptor> descriptorsToAdd = new LinkedHashMap<>(); // карта для новых дескрипторов
+        Set<String> codesToUpdate = new LinkedHashSet<>(); // набор для кодов изменившихся дескрипторов
+        // ↓↓ Перебираем элементы карты контекста
+        for (Map.Entry<String, ProviderDescriptor> e : contextDescriptors.entrySet()) {
             String ctxProviderCode = e.getKey(); // Текущий индекс (он же код)
             ProviderDescriptor ctxDescriptor = e.getValue(); // Текущий элемент (он же дескриптор)
-            // В карте repoMap ищем дескриптор с таким же кодом
-            ProviderDescriptor maybeRepoDescriptor = repoMap.get(ctxProviderCode);
+            // В карте репозитория ищем дескриптор с таким же кодом
+            ProviderDescriptor maybeRepoDescriptor = repositoryDescriptors.get(ctxProviderCode);
             if (maybeRepoDescriptor == null) {
-                descriptorsToAdd.add(ctxDescriptor); // Значит ctxDescriptor — новый дескриптор
+                descriptorsToAdd.put(ctxProviderCode, ctxDescriptor); // Значит ctxDescriptor — новый дескриптор
             } else if (!Objects.equals(maybeRepoDescriptor, ctxDescriptor)) {
                 codesToUpdate.add(ctxProviderCode); // Значит ctxDescriptor изменился
             } // else — идентичен, ничего не делаем
@@ -114,9 +110,9 @@ public class ProviderDescriptorSynchronizer {
 
         // 5.2) Формируем единый список для INSERT: новые + изменившиеся
         if (!descriptorsToAdd.isEmpty() || !codesToUpdate.isEmpty()) {
-            List<ProviderDescriptor> toInsert = new ArrayList<>(descriptorsToAdd);
+            Map<String, ProviderDescriptor> toInsert = new LinkedHashMap<>(descriptorsToAdd);
             for (String code : codesToUpdate) {
-                toInsert.add(ctxMap.get(code));
+                toInsert.put(code, contextDescriptors.get(code));
             }
             // На крайний случай проверяем инварианты уникальности перед вставкой
             assertUniqueByCodeAndName(toInsert);
@@ -138,27 +134,19 @@ public class ProviderDescriptorSynchronizer {
     }
 
     /* Проверка уникальности кодов провайдеров и отображаемых имен. */
-    private static void assertUniqueByCodeAndName(List<ProviderDescriptor> descriptors) {
+    private static void assertUniqueByCodeAndName(Map<String, ProviderDescriptor> descriptors) {
         Set<String> seenProviderCodes = new HashSet<>();
         Set<String> seenDisplayNames = new HashSet<>();
-        for (ProviderDescriptor d : descriptors) {
-            String code = d.providerCode();
+        for (Map.Entry<String, ProviderDescriptor> entry : descriptors.entrySet()) {
+            String code = entry.getKey();
             if (!seenProviderCodes.add(code)) {
-                throw new ProviderDescriptorDuplicateException(d.providerCode(), d.displayName());
+                throw new ProviderDescriptorDuplicateException(code, entry.getValue().displayName());
             }
-            String displayName = d.displayName();
+            ProviderDescriptor descriptor = entry.getValue();
+            String displayName = descriptor.displayName();
             if (!seenDisplayNames.add(displayName)) {
-                throw new ProviderDescriptorDuplicateException(d.providerCode(), d.displayName());
+                throw new ProviderDescriptorDuplicateException(code, displayName);
             }
         }
-    }
-
-    /* Построить карту: providerCode ⇒ ProviderDescriptor. */
-    private static Map<String, ProviderDescriptor> toMapByCode(List<ProviderDescriptor> list) {
-        Map<String, ProviderDescriptor> map = new LinkedHashMap<>(); // сохраняем порядок для предсказуемых логов
-        for (ProviderDescriptor d : list) {
-            map.put(d.providerCode(), d);
-        }
-        return map;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
@@ -3,15 +3,15 @@ package com.alligator.market.domain.provider.repository;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Map;
 
 /**
  * Порт репозитория дескрипторов провайдеров.
  */
 public interface ProviderDescriptorRepository {
 
-    /** Получить все дескрипторы провайдеров. */
-    List<ProviderDescriptor> findAll();
+    /** Получить карту дескрипторов провайдеров, индексированную по коду провайдера. */
+    Map<String, ProviderDescriptor> findAll();
 
     /** Полностью очистить таблицу дескрипторов (админ/служебная операция). */
     void deleteAll();
@@ -20,5 +20,5 @@ public interface ProviderDescriptorRepository {
     void deleteAllByProviderCodes(Collection<String> providerCodes);
 
     /** INSERT после предварительного удаления; не upsert. Дубликаты providerCode → ошибка UNIQUE. */
-    void insertAll(List<ProviderDescriptor> descriptors);
+    void insertAll(Map<String, ProviderDescriptor> descriptors);
 }

--- a/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/QuoteTick.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.quote;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
-import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -10,7 +10,7 @@ import java.time.Instant;
  * Глобальная модель тика котировки для валютной пары.
  *
  * @param instrumentCode соответствует {@link Instrument#code()}
- * @param providerCode   соответствует {@link ProviderDescriptor#providerCode()}
+ * @param providerCode   соответствует {@link MarketDataProvider#providerCode()}
  */
 public record QuoteTick(
 


### PR DESCRIPTION
## Summary
- update provider context scanning and descriptor synchronization to work with provider descriptor maps keyed by code
- refactor the persistence adapter and repository contract to persist map entries instead of raw lists
- adapt backend services, controller DTO mapping, and quote metadata to continue exposing provider codes

## Testing
- mvn -pl backend -am test *(fails: cannot download org.springframework.boot:spring-boot-starter-parent:3.4.5, HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d988e55c10832dbdfb1b70ea048119