### PR TITLE
Fix descriptor mapper to use embedded fields

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
@@ -11,11 +11,13 @@ public class DescriptorEntityMapper {
 
     /** Сущность ⇒ доменная модель. */
     public ProviderDescriptor toDomain(DescriptorEntity entity) {
+        DescriptorEmbedded descriptor = entity.getDescriptor();
+
         return new ProviderDescriptor(
-                entity.getDisplayName(),
-                entity.getDeliveryMode(),
-                entity.getAccessMethod(),
-                entity.isBulkSubscription()
+                descriptor.getDisplayName(),
+                descriptor.getDeliveryMode(),
+                descriptor.getAccessMethod(),
+                descriptor.isBulkSubscription()
         );
     }
 
@@ -23,10 +25,14 @@ public class DescriptorEntityMapper {
     public DescriptorEntity toEntity(String providerCode, ProviderDescriptor providerDescriptor) {
         DescriptorEntity entity = new DescriptorEntity();
         entity.setProviderCode(providerCode);
-        entity.setDisplayName(providerDescriptor.displayName());
-        entity.setDeliveryMode(providerDescriptor.deliveryMode());
-        entity.setAccessMethod(providerDescriptor.accessMethod());
-        entity.setBulkSubscription(providerDescriptor.bulkSubscription());
+
+        DescriptorEmbedded descriptor = new DescriptorEmbedded();
+        descriptor.setDisplayName(providerDescriptor.displayName());
+        descriptor.setDeliveryMode(providerDescriptor.deliveryMode());
+        descriptor.setAccessMethod(providerDescriptor.accessMethod());
+        descriptor.setBulkSubscription(providerDescriptor.bulkSubscription());
+
+        entity.setDescriptor(descriptor);
         return entity;
     }
 }


### PR DESCRIPTION
## Summary
- map ProviderDescriptor to DescriptorEntity through the embedded component instead of non-existent direct fields
- ensure domain conversion reads fields from DescriptorEmbedded so the entity matches the provider descriptor contract

## Testing
- `./mvnw -pl backend -am test` *(fails: wget could not download Maven distribution in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da996bbe44832d974472616bcc2cb8