### PR TITLE
Add status field to descriptor entity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
@@ -42,5 +42,10 @@ public class DescriptorEntity extends BaseEntity {
     /** Встраиваемый компонент со статическими атрибутами дескриптора. */
     @Embedded
     private DescriptorEmbedded descriptor;
+
+    /** Статус актуальности дескриптора. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private DescriptorStatus status = DescriptorStatus.ACTIVE;
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
@@ -33,6 +33,7 @@ public class DescriptorEntityMapper {
         descriptor.setBulkSubscription(providerDescriptor.bulkSubscription());
 
         entity.setDescriptor(descriptor);
+        entity.setStatus(DescriptorStatus.ACTIVE); // Сохраняем дескриптор как активный
         return entity;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorStatus.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorStatus.java
@@ -1,0 +1,16 @@
+package com.alligator.market.backend.provider.catalog.descriptor.persistence.jpa;
+
+/**
+ * Возможные статусы дескриптора провайдера.
+ */
+public enum DescriptorStatus {
+
+    /** Дескриптор актуален и используется. */
+    ACTIVE,
+
+    /** Дескриптор заменён новой версией. */
+    REPLACED,
+
+    /** Дескриптор отсутствует у провайдера. */
+    MISSED
+}


### PR DESCRIPTION
## Summary
- introduce the DescriptorStatus enum for provider descriptor entities
- persist the descriptor status on DescriptorEntity with ACTIVE default value
- ensure mapper assigns ACTIVE status to new entities

## Testing
- `./mvnw -pl backend test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68dad458ed68832da264286f8818012d