### PR TITLE
Перенос displayName из ProviderDescriptor в MarketDataProvider

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -20,6 +20,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
 
     /* ↓↓ Базовые атрибуты провайдера. */
     protected final String providerCode;
+    protected final String displayName;
     protected final ProviderDescriptor descriptor;
     protected final ProviderSettings settings;
 
@@ -43,12 +44,14 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      */
     protected AbstractMarketDataProvider(
             String providerCode,
+            String displayName,
             ProviderDescriptor descriptor,
             ProviderSettings settings,
             Set<? extends AbstractInstrumentHandler<P, ? extends Instrument>> handlers // Набор обработчиков
     ) {
         // ↓↓ Базовая валидация аргументов
         Objects.requireNonNull(providerCode, "providerCode must not be null");
+        Objects.requireNonNull(displayName, "displayName must not be null");
         Objects.requireNonNull(descriptor,   "descriptor must not be null");
         Objects.requireNonNull(settings,     "settings must not be null");
         Objects.requireNonNull(handlers,     "handlers must not be null");
@@ -61,12 +64,16 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         if (!providerCode.equals(providerCode.toUpperCase(Locale.ROOT))) {
             throw new IllegalArgumentException("providerCode must be upper case");
         }
+        if (displayName.isBlank()) {
+            throw new IllegalArgumentException("displayName must not be blank");
+        }
         if (handlers.isEmpty()) {
             throw new IllegalArgumentException("handlers must not be empty");
         }
 
         // ↓↓ Инициализация базовых атрибутов провайдера
         this.providerCode = providerCode.trim();
+        this.displayName  = displayName.trim();
         this.descriptor   = descriptor;
         this.settings     = settings;
 
@@ -134,6 +141,12 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     @Override
     public String providerCode() {
         return providerCode;
+    }
+
+    /** Отображаемое имя провайдера (user friendly). */
+    @Override
+    public String displayName() {
+        return displayName;
     }
 
     /** Дескриптор провайдера: иммутабельный набор статических атрибутов. */

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -17,6 +17,9 @@ public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
     /** Технический код провайдера. */
     String providerCode();
 
+    /** Отображаемое имя провайдера (user friendly). */
+    String displayName();
+
     /** Дескриптор провайдера: иммутабельный набор статических атрибутов. */
     ProviderDescriptor descriptor();
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/ProviderDescriptor.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/ProviderDescriptor.java
@@ -5,26 +5,18 @@ import java.util.Objects;
 /**
  * Дескриптор провайдера: иммутабельный набор статических атрибутов.
  *
- * @param displayName            Отображаемое имя провайдера (user friendly)
  * @param deliveryMode           Режим доставки рыночных данных: PULL или PUSH {@link AccessMethod}
  * @param accessMethod           Метод доступа к рыночным данным {@link AccessMethod}
  * @param bulkSubscription       Поддержка массовой подписки одним запросом
  */
 public record ProviderDescriptor(
-        String displayName,
         DeliveryMode deliveryMode,
         AccessMethod accessMethod,
         boolean bulkSubscription
 ) {
     public ProviderDescriptor {
         // ↓↓ Базовая валидация аргументов
-        Objects.requireNonNull(displayName, "displayName must not be null");
         Objects.requireNonNull(deliveryMode, "deliveryMode must not be null");
         Objects.requireNonNull(accessMethod, "accessMethod must not be null");
-        if (displayName.isBlank()) {
-            throw new IllegalArgumentException("displayName must not be blank");
-        }
-
-        displayName = displayName.trim(); // Убираем пробелы по краям
     }
 }


### PR DESCRIPTION
## Summary
- переместил поле displayName из ProviderDescriptor в MarketDataProvider
- расширил AbstractMarketDataProvider поддержкой нового атрибута провайдера

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae84c1990832daca012b60e7ebe40