### PR TITLE
Add descriptor entity update mapping

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
@@ -19,4 +19,10 @@ public class DescriptorEntityMapper {
     }
 
     /** Обновление JPA-сущности. */
+    public void updateEntity(ProviderDescriptor descriptor, DescriptorEntity entity) {
+        // Переносим значения доменной модели в JPA-сущность
+        entity.setDeliveryMode(descriptor.deliveryMode());
+        entity.setAccessMethod(descriptor.accessMethod());
+        entity.setBulkSubscription(descriptor.bulkSubscription());
+    }
 }


### PR DESCRIPTION
## Summary
- add a mapper helper to copy domain descriptor fields into JPA entity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf5008330832dac20c40640069b80