### PR TITLE
Рефакторинг базовых настроек провайдера

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -12,6 +12,7 @@ import com.alligator.market.domain.quote.QuoteTick;
 import org.reactivestreams.Publisher;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Абстрактный каркас провайдера рыночных данных.
@@ -23,7 +24,8 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     protected final String providerCode;
     protected final ProviderDescriptor descriptor;
     protected final ProviderPolicy policy;
-    protected final ProviderSettings settings;
+    // Храним настройки в атомарной ссылке, чтобы позже можно было безопасно их обновлять из наследников.
+    private final AtomicReference<ProviderSettings> settingsRef;
 
     /* Карта "инструмент → обработчик". После инициализации становится неизменяемой. */
     private final Map<Instrument, InstrumentHandler<P, ? extends Instrument>> instrumentMap;
@@ -78,7 +80,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         this.providerCode = providerCode.trim();
         this.descriptor   = descriptor;
         this.policy       = policy;
-        this.settings     = settings;
+        this.settingsRef  = new AtomicReference<>(settings);
 
         // 1) Проверяем уникальность handlers по коду
         var handlerCodes = new java.util.HashSet<String>();
@@ -160,7 +162,15 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     /** Настройки провайдера: параметры, которые разрешено менять из frontend (read/write). */
     @Override
     public ProviderSettings settings() {
-        return settings;
+        return settingsRef.get();
+    }
+
+    /**
+     * Обновляет настройки провайдера. Метод защищённый, чтобы управлять жизненным циклом из наследника.
+     */
+    protected final void replaceSettings(ProviderSettings newSettings) {
+        Objects.requireNonNull(newSettings, "newSettings must not be null");
+        settingsRef.set(newSettings);
     }
 
     /** Иммутабельный набор кодов поддерживаемых провайдером инструментов. */

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/settings/ProviderSettings.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/settings/ProviderSettings.java
@@ -2,5 +2,25 @@ package com.alligator.market.domain.provider.contract.settings;
 
 /**
  * Настройки провайдера: параметры, которые разрешено менять из frontend (read/write).
+ * Пока что это заглушка: отдельные реализации появятся, когда будут реальными управляемыми параметрами.
  */
-public record ProviderSettings() {}
+public interface ProviderSettings {
+
+    /**
+     * Возвращает пустой набор настроек (заглушка по умолчанию).
+     */
+    static ProviderSettings empty() {
+        return EmptyProviderSettings.INSTANCE;
+    }
+
+    /**
+     * Заглушка без параметров.
+     */
+    final class EmptyProviderSettings implements ProviderSettings {
+
+        private static final EmptyProviderSettings INSTANCE = new EmptyProviderSettings();
+
+        private EmptyProviderSettings() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- перевёл ProviderSettings на интерфейс с пустой реализацией по умолчанию, чтобы позже добавлять реальные параметры
- обновил AbstractMarketDataProvider: храню настройки в AtomicReference и добавил защищённое обновление для будущих динамических изменений

## Testing
- `./mvnw -pl domain test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68dc43ed847c832d8d1071993d2a3885