### PR TITLE
Add policy JPA entity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/policy/persistence/jpa/PolicyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/policy/persistence/jpa/PolicyEntity.java
@@ -1,0 +1,30 @@
+package com.alligator.market.backend.provider.catalog.policy.persistence.jpa;
+
+import com.alligator.market.backend.provider.catalog.base.jpa.ProviderBaseEntity;
+import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * JPA-сущность политики провайдера.
+ * Набор полей аналогичен доменной модели {@link ProviderPolicy}.
+ */
+@Entity
+@Table(name = "provider_policy")
+@PrimaryKeyJoinColumn(name = "id")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PolicyEntity extends ProviderBaseEntity {
+
+    /** Минимальный интервал обновления котировок (в секундах) {@link ProviderPolicy#minUpdateInterval()}. */
+    @Positive
+    @Column(name = "min_update_interval_seconds", nullable = false)
+    private long minUpdateIntervalSeconds;
+}


### PR DESCRIPTION
## Summary
- add the PolicyEntity JPA model for provider policy persistence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4ec1ff7c832d9295c461de8f1bcb