### PR TITLE
Перенос проверки дублей провайдеров в доменный каркас

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/scanner/ProviderContextScannerAdapter.java
@@ -1,36 +1,23 @@
 package com.alligator.market.backend.provider.reconciliation.scanner;
 
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
-import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
-import com.alligator.market.domain.provider.exception.ProviderCodeDuplicateException;
-import com.alligator.market.domain.provider.reconciliation.ProviderContextScanner;
+import com.alligator.market.domain.provider.reconciliation.AbstractProviderContextScanner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Адаптер доменного сканера контекста приложения для получения данных о провайдерах рыночных данных.
  */
 @Component
 @RequiredArgsConstructor
-public class ProviderContextScannerAdapter implements ProviderContextScanner {
+public class ProviderContextScannerAdapter extends AbstractProviderContextScanner {
 
     private final List<MarketDataProvider> providers;
 
     @Override
-    public Map<String, ProviderDescriptor> providerDescriptors() {
-        Map<String, ProviderDescriptor> descriptors = new LinkedHashMap<>();
-        for (MarketDataProvider p : providers) {
-            String providerCode = p.providerCode();
-            ProviderDescriptor descriptor = p.descriptor();
-            ProviderDescriptor previous = descriptors.put(providerCode, descriptor);
-            if (previous != null) {
-                throw new ProviderCodeDuplicateException(providerCode);
-            }
-        }
-        return descriptors;
+    protected Iterable<MarketDataProvider> providers() {
+        return providers;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/AbstractProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/AbstractProviderContextScanner.java
@@ -1,0 +1,34 @@
+package com.alligator.market.domain.provider.reconciliation;
+
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.exception.ProviderCodeDuplicateException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Базовая (non-sealed) реализация доменного сканера контекста.
+ * <p>
+ * Инкапсулирует проверку уникальности кода провайдера, чтобы правило домена
+ * выполнялось в одном месте независимо от конкретной инфраструктурной реализации.
+ */
+public abstract non-sealed class AbstractProviderContextScanner implements ProviderContextScanner {
+
+    /** Вернуть последовательность провайдеров для построения карты дескрипторов. */
+    protected abstract Iterable<MarketDataProvider> providers();
+
+    @Override
+    public final Map<String, ProviderDescriptor> providerDescriptors() {
+        Map<String, ProviderDescriptor> descriptors = new LinkedHashMap<>();
+        for (MarketDataProvider provider : providers()) {
+            String providerCode = provider.providerCode();
+            ProviderDescriptor descriptor = provider.descriptor();
+            ProviderDescriptor previous = descriptors.put(providerCode, descriptor);
+            if (previous != null) {
+                throw new ProviderCodeDuplicateException(providerCode);
+            }
+        }
+        return descriptors;
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderContextScanner.java
@@ -7,7 +7,7 @@ import java.util.Map;
 /**
  * Сканер контекста приложения для получения данных о провайдерах рыночных данных.
  */
-public interface ProviderContextScanner {
+public sealed interface ProviderContextScanner permits AbstractProviderContextScanner {
 
     /** Вернуть карту дескрипторов провайдеров, индексированную по коду провайдера. */
     Map<String, ProviderDescriptor> providerDescriptors();


### PR DESCRIPTION
## Summary
- добавить в домен абстрактный non-sealed каркас сканера, проверяющий уникальность кодов провайдеров
- обновить backend-адаптер до наследования от нового каркаса и делегировать ему список провайдеров

## Testing
- ./mvnw -pl backend -am test *(падает: Maven Wrapper не смог скачать Maven из-за сетевых ограничений)*

------
https://chatgpt.com/codex/tasks/task_e_68ded2f06990832da1e02fef863288e5