### PR TITLE
Добавить проверку уникальности displayName провайдеров

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDisplayNameDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDisplayNameDuplicateException.java
@@ -1,0 +1,11 @@
+package com.alligator.market.domain.provider.exception;
+
+/**
+ * Дублирование отображаемых имен провайдеров.
+ */
+public class ProviderDisplayNameDuplicateException extends RuntimeException {
+
+    public ProviderDisplayNameDuplicateException(String displayName) {
+        super("Duplicate provider display name detected: '%s'".formatted(displayName));
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/AbstractProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/AbstractProviderContextScanner.java
@@ -3,12 +3,15 @@ package com.alligator.market.domain.provider.reconciliation;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.exception.ProviderCodeDuplicateException;
+import com.alligator.market.domain.provider.exception.ProviderDisplayNameDuplicateException;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * Абстрактный сканер контекста приложения, содержащий доменную проверку на уникальность кода провайдера.
+ * Абстрактный сканер контекста приложения, содержащий доменную проверку на уникальность кода и отображаемого имени провайдера.
  */
 public abstract non-sealed class AbstractProviderContextScanner implements ProviderContextScanner {
 
@@ -18,12 +21,17 @@ public abstract non-sealed class AbstractProviderContextScanner implements Provi
     @Override
     public final Map<String, ProviderDescriptor> providerDescriptors() {
         Map<String, ProviderDescriptor> descriptors = new LinkedHashMap<>();
+        Set<String> displayNames = new HashSet<>();
         for (MarketDataProvider provider : providers()) {
             String providerCode = provider.providerCode();
             ProviderDescriptor descriptor = provider.descriptor();
             ProviderDescriptor previous = descriptors.put(providerCode, descriptor);
             if (previous != null) {
                 throw new ProviderCodeDuplicateException(providerCode);
+            }
+            String displayName = descriptor.displayName();
+            if (!displayNames.add(displayName)) {
+                throw new ProviderDisplayNameDuplicateException(displayName);
             }
         }
         return descriptors;


### PR DESCRIPTION
## Summary
- добавить доменную проверку уникальности отображаемых имен провайдеров в контекстном сканере
- ввести исключение ProviderDisplayNameDuplicateException для фиксации конфликтов

## Testing
- ./mvnw -pl domain test *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68dedc352348832db50275ddf05e5f17