### PR TITLE
Реализовать удаление всех дескрипторов провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/DescriptorRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/DescriptorRepositoryAdapter.java
@@ -35,4 +35,10 @@ public class DescriptorRepositoryAdapter implements ProviderDescriptorRepository
         }
         return descriptors;
     }
+
+    /* Удаляем все дескрипторы одним батчем. */
+    @Override
+    public void deleteAll() {
+        jpaRepository.deleteAllInBatch();
+    }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
@@ -11,4 +11,7 @@ public interface ProviderDescriptorRepository {
 
     /** Вернуть все дескрипторы с индексацией по коду провайдера. */
     Map<String, ProviderDescriptor> findAll();
+
+    /** Удалить все дескрипторы. */
+    void deleteAll();
 }


### PR DESCRIPTION
## Summary
- добавить в доменный порт ProviderDescriptorRepository метод удаления всех дескрипторов
- реализовать удаление всех дескрипторов одним батчем в адаптере JPA

## Testing
- mvn -pl backend -DskipTests compile *(не удалось из-за 403 Forbidden при загрузке зависимостей)*

------
https://chatgpt.com/codex/tasks/task_e_68dedf551e9c832dbd80b41efd204fb5