### PR TITLE
Add bulk operations for provider descriptors

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/DescriptorRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/adapter/DescriptorRepositoryAdapter.java
@@ -9,9 +9,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Адаптер, реализующий доменный порт {@link ProviderDescriptorRepository} через Spring Data JPA.
@@ -40,5 +42,27 @@ public class DescriptorRepositoryAdapter implements ProviderDescriptorRepository
     @Override
     public void deleteAll() {
         jpaRepository.deleteAllInBatch();
+    }
+
+    /** Удаляем дескрипторы по кодам провайдеров одним батчем. */
+    @Override
+    public void deleteAllByProviderCodes(Set<String> providerCodes) {
+        if (providerCodes.isEmpty()) {
+            return;
+        }
+        jpaRepository.deleteAllByProviderCodeIn(providerCodes);
+    }
+
+    /** Выполняем пакетную вставку дескрипторов. */
+    @Override
+    public void insertAll(Map<String, ProviderDescriptor> descriptors) {
+        if (descriptors.isEmpty()) {
+            return;
+        }
+        List<DescriptorEntity> entities = new ArrayList<>(descriptors.size());
+        for (Map.Entry<String, ProviderDescriptor> entry : descriptors.entrySet()) {
+            entities.add(mapper.toEntity(entry.getKey(), entry.getValue()));
+        }
+        jpaRepository.saveAllAndFlush(entities);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntityMapper.java
@@ -19,6 +19,14 @@ public class DescriptorEntityMapper {
         );
     }
 
+    /** Доменная модель ⇒ новая JPA-сущность. */
+    public DescriptorEntity toEntity(String providerCode, ProviderDescriptor descriptor) {
+        DescriptorEntity entity = new DescriptorEntity();
+        entity.setProviderCode(providerCode);
+        updateEntity(descriptor, entity);
+        return entity;
+    }
+
     /** Обновление JPA-сущности. */
     public void updateEntity(ProviderDescriptor descriptor, DescriptorEntity entity) {
         entity.setDisplayName(descriptor.displayName());

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorJpaRepository.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.catalog.descriptor.persistence.jpa
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -11,4 +12,7 @@ public interface DescriptorJpaRepository extends JpaRepository<DescriptorEntity,
 
     /** Найти сущность дескриптора по коду провайдера. */
     Optional<DescriptorEntity> findByProviderCode(String providerCode);
+
+    /** Удалить все сущности с кодами из коллекции. */
+    void deleteAllByProviderCodeIn(Collection<String> providerCodes);
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderDescriptorRepository.java
@@ -3,6 +3,7 @@ package com.alligator.market.domain.provider.repository;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Порт репозитория дескрипторов провайдеров.
@@ -14,4 +15,10 @@ public interface ProviderDescriptorRepository {
 
     /** Удалить все дескрипторы. */
     void deleteAll();
+
+    /** Удалить дескрипторы по переданным кодам провайдеров. */
+    void deleteAllByProviderCodes(Set<String> providerCodes);
+
+    /** Выполнить пакетную вставку дескрипторов. */
+    void insertAll(Map<String, ProviderDescriptor> descriptors);
 }


### PR DESCRIPTION
## Summary
- add bulk delete and insert operations to the provider descriptor repository port
- implement the new operations for the Spring Data adapter and mapper
- extend the JPA repository with a delete-by-codes helper

## Testing
- ./mvnw -pl backend test *(fails: wget unable to fetch Maven distribution in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dee3de06dc832da5c8edbbc87b4998