### PR TITLE
Implement provider descriptor retrieval use case

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCase.java
@@ -1,6 +1,14 @@
 package com.alligator.market.backend.provider.catalog.descriptor.service;
 
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+
+import java.util.Map;
+
 /**
  * Application-сервис (use case) для операций с дескрипторами.
  */
-public interface DescriptorUseCase {}
+public interface DescriptorUseCase {
+
+    /** Вернуть все дескрипторы с индексацией по коду провайдера. */
+    Map<String, ProviderDescriptor> getAll();
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/service/DescriptorUseCaseImpl.java
@@ -1,8 +1,13 @@
 package com.alligator.market.backend.provider.catalog.descriptor.service;
 
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.repository.ProviderDescriptorRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 /**
  * Реализация сервиса {@link DescriptorUseCase}.
@@ -10,5 +15,17 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class DescriptorUseCaseImpl implements DescriptorUseCase {}
+@Transactional(readOnly = true)
+public class DescriptorUseCaseImpl implements DescriptorUseCase {
+
+    /* Репозиторий дескрипторов провайдеров. */
+    private final ProviderDescriptorRepository repository;
+
+    @Override
+    public Map<String, ProviderDescriptor> getAll() {
+        Map<String, ProviderDescriptor> descriptors = repository.findAll();
+        log.debug("Found {} provider descriptors", descriptors.size());
+        return descriptors;
+    }
+}
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorController.java
@@ -31,8 +31,8 @@ public class DescriptorController {
     public ResponseEntity<ApiResponse<List<DescriptorDto>>> getAll() {
         // Сервис возвращает доменные дескрипторы, индексированные по коду провайдера
         Map<String, ProviderDescriptor> descriptors = service.getAll();
-        List<DescriptorDto> response = descriptors.entrySet().stream()
-                .map(e -> mapper.toDto(e.getKey(), e.getValue()))
+        List<DescriptorDto> response = descriptors.values().stream()
+                .map(mapper::toDto)
                 .toList();
         return ResponseEntityFactory.ok(response);
     }


### PR DESCRIPTION
## Summary
- declare the provider descriptor use case contract and implement read-only retrieval
- wire the implementation to the domain repository with logging
- adjust the controller mapping to use the mapper correctly

## Testing
- ./mvnw -pl backend -am test *(fails: unable to download Maven distribution in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dee9549b7c832d81b09c38446db515