### PR TITLE
Скрыть технический код провайдера в таблице дескрипторов

### DIFF
--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
@@ -7,13 +7,8 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="providerCode">
-          <th mat-header-cell *matHeaderCellDef>Provider Code</th>
-          <td mat-cell *matCellDef="let descriptor">{{ descriptor.providerCode }}</td>
-        </ng-container>
-
         <ng-container matColumnDef="displayName">
-          <th mat-header-cell *matHeaderCellDef>Display Name</th>
+          <th mat-header-cell *matHeaderCellDef>Provider</th>
           <td mat-cell *matCellDef="let descriptor">{{ descriptor.displayName }}</td>
         </ng-container>
 

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -16,7 +16,6 @@ export class DescriptorListComponent implements OnInit {
 
   /* Список колонок таблицы. */
   displayed: string[] = [
-    'providerCode',
     'displayName',
     'deliveryMode',
     'accessMethod',


### PR DESCRIPTION
## Summary
- убрать колонку с техническим кодом провайдера из таблицы дескрипторов
- переименовать заголовок отображаемой колонки на понятное имя провайдера

## Testing
- npm run lint *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68deeb78db54832da620f15202ae50ce