### PR TITLE
Fix unique constraint column names for provider entities

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/base/persistence/jpa/ProviderBaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/base/persistence/jpa/ProviderBaseEntity.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 @Table(
         name = "market_data_provider",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_provider_code", columnNames = "providerCode")
+                @UniqueConstraint(name = "uq_provider_code", columnNames = "provider_code")
         }
 )
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/persistence/jpa/DescriptorEntity.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "provider_descriptor",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_display_name", columnNames = "displayName")
+                @UniqueConstraint(name = "uq_display_name", columnNames = "display_name")
         })
 @PrimaryKeyJoinColumn(name = "id")
 @Getter


### PR DESCRIPTION
## Summary
- align provider base entity unique constraint with the snake_case database column
- align descriptor entity unique constraint with the snake_case database column

## Testing
- mvn -pl backend -am test *(fails: Maven Central responded with 403 while downloading parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68def518bed8832da0043df2cf740b8f