### PR TITLE
Fix provider descriptor list component style reference

### DIFF
--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -10,7 +10,7 @@ import { DescriptorDto } from '../../models/descriptor-dto.model';
   standalone: true,
   imports: [CommonModule, MatTableModule, MatCardModule],
   templateUrl: './descriptor-list.component.html',
-  styleUrl: './descriptor-list.component.scss'
+  styleUrls: ['./descriptor-list.component.scss']
 })
 export class DescriptorListComponent implements OnInit {
 


### PR DESCRIPTION
## Summary
- replace the obsolete `styleUrl` option with the Angular `styleUrls` array in the provider descriptor list component

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68defd850fd4832d9f60474d760da6f6