### PR TITLE
Expose provider code in descriptor responses

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorController.java
@@ -31,8 +31,8 @@ public class DescriptorController {
     public ResponseEntity<ApiResponse<List<DescriptorDto>>> getAll() {
         // Сервис возвращает доменные дескрипторы, индексированные по коду провайдера
         Map<String, ProviderDescriptor> descriptors = service.getAll();
-        List<DescriptorDto> response = descriptors.values().stream()
-                .map(mapper::toDto)
+        List<DescriptorDto> response = descriptors.entrySet().stream()
+                .map(entry -> mapper.toDto(entry.getKey(), entry.getValue()))
                 .toList();
         return ResponseEntityFactory.ok(response);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/dto/DescriptorDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/dto/DescriptorDto.java
@@ -8,8 +8,11 @@ import jakarta.validation.constraints.NotNull;
 
 /**
  * Основной DTO для дескриптора провайдера {@link ProviderDescriptor}.
+ *
+ * @param providerCode Технический код провайдера.
  */
 public record DescriptorDto(
+        @NotBlank String providerCode,
         @NotBlank String displayName,
         @NotNull DeliveryMode deliveryMode,
         @NotNull AccessMethod accessMethod,

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/dto/DescriptorDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/descriptor/web/dto/DescriptorDtoMapper.java
@@ -9,9 +9,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class DescriptorDtoMapper {
 
-    /** Доменная модель ⇒ основной DTO. */
-    public DescriptorDto toDto(ProviderDescriptor providerDescriptor) {
+    /**
+     * Доменная модель ⇒ основной DTO.
+     *
+     * @param providerCode Технический код провайдера.
+     */
+    public DescriptorDto toDto(String providerCode, ProviderDescriptor providerDescriptor) {
         return new DescriptorDto(
+                providerCode,
                 providerDescriptor.displayName(),
                 providerDescriptor.deliveryMode(),
                 providerDescriptor.accessMethod(),

--- a/backend/src/test/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorControllerTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/catalog/descriptor/web/DescriptorControllerTest.java
@@ -1,0 +1,53 @@
+package com.alligator.market.backend.provider.catalog.descriptor.web;
+
+import com.alligator.market.backend.provider.catalog.descriptor.service.DescriptorUseCase;
+import com.alligator.market.backend.provider.catalog.descriptor.web.dto.DescriptorDtoMapper;
+import com.alligator.market.domain.provider.contract.descriptor.AccessMethod;
+import com.alligator.market.domain.provider.contract.descriptor.DeliveryMode;
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Тест-кейс контроллера дескрипторов провайдеров.
+ */
+@WebMvcTest(DescriptorController.class)
+@Import(DescriptorDtoMapper.class)
+class DescriptorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DescriptorUseCase useCase;
+
+    /** Проверяем, что код провайдера присутствует в ответе. */
+    @Test
+    void getAll_ShouldExposeProviderCode() throws Exception {
+        // Подготавливаем карту дескрипторов с сохранением порядка
+        Map<String, ProviderDescriptor> descriptors = new LinkedHashMap<>();
+        descriptors.put("twelve-free", new ProviderDescriptor(
+                "Twelve Data",
+                DeliveryMode.PULL,
+                AccessMethod.API_POLL,
+                true
+        ));
+        given(useCase.getAll()).willReturn(descriptors);
+
+        mockMvc.perform(get("/api/v1/providers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].providerCode").value("twelve-free"));
+    }
+}

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
@@ -7,6 +7,11 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
+        <ng-container matColumnDef="providerCode">
+          <th mat-header-cell *matHeaderCellDef>Code</th>
+          <td mat-cell *matCellDef="let descriptor">{{ descriptor.providerCode }}</td>
+        </ng-container>
+
         <ng-container matColumnDef="displayName">
           <th mat-header-cell *matHeaderCellDef>Provider</th>
           <td mat-cell *matCellDef="let descriptor">{{ descriptor.displayName }}</td>

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -16,6 +16,7 @@ export class DescriptorListComponent implements OnInit {
 
   /* Список колонок таблицы. */
   displayed: string[] = [
+    'providerCode',
     'displayName',
     'deliveryMode',
     'accessMethod',


### PR DESCRIPTION
## Summary
- add providerCode to DescriptorDto and propagate it through the mapper and controller
- render the provider code alongside descriptor metadata in the frontend table
- cover the provider descriptors endpoint with a MockMvc test to ensure the provider code is exposed

## Testing
- mvn -pl backend test *(fails: cannot download parent POM from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68def5326018832d9709a102625265f6