### PR TITLE
Refactor FX spot code generation

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.persiste
 
 import com.alligator.market.backend.instrument.base.persistence.jpa.InstrumentBaseEntity;
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntity;
+import com.alligator.market.domain.instrument.InstrumentCodeFactory;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
@@ -57,7 +58,11 @@ public class FxSpotEntity extends InstrumentBaseEntity {
         // Устанавливаем тип инструмента
         setType(InstrumentType.FX_SPOT);
         // Генерируем и устанавливаем код инструмента
-        String instrumentCode = baseCurrency.getCode() + quoteCurrency.getCode() + "_" + valueDateCode.name();
+        String instrumentCode = InstrumentCodeFactory.fxSpotCode(
+                baseCurrency.getCode(),
+                quoteCurrency.getCode(),
+                valueDateCode
+        );
         setCode(instrumentCode);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/InstrumentCodeFactory.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/InstrumentCodeFactory.java
@@ -1,0 +1,23 @@
+package com.alligator.market.domain.instrument;
+
+import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+
+import java.util.Objects;
+
+/**
+ * Утилита для генерации кодов инструментов.
+ */
+public final class InstrumentCodeFactory {
+
+    private InstrumentCodeFactory() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /** Формирует код инструмента FX_SPOT. */
+    public static String fxSpotCode(String baseCurrencyCode, String quoteCurrencyCode, ValueDateCode valueDateCode) {
+        Objects.requireNonNull(baseCurrencyCode, "Base currency code must not be null");
+        Objects.requireNonNull(quoteCurrencyCode, "Quote currency code must not be null");
+        Objects.requireNonNull(valueDateCode, "Value date code must not be null");
+        return baseCurrencyCode + quoteCurrencyCode + "_" + valueDateCode.name();
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.instrument.type.forex.spot.model;
 
+import com.alligator.market.domain.instrument.InstrumentCodeFactory;
 import com.alligator.market.domain.instrument.contract.AbstractInstrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
@@ -65,7 +66,7 @@ public class FxSpot extends AbstractInstrument {
 
     @Override
     public String code() {
-        return base.code() + quote.code() + "_" + valueDateCode;
+        return InstrumentCodeFactory.fxSpotCode(base.code(), quote.code(), valueDateCode);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- introduce InstrumentCodeFactory to centralize FX spot code formatting
- update the domain model and JPA entity to reuse the shared generator

## Testing
- ./mvnw -pl domain -am test *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb4a87f9c832dbf09015b749d1950