### PR TITLE
Add DB constraints for FX spot currency pairs

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -13,12 +13,20 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Check;
 
 /**
- * JPA-сущность финансового инструмента FX_SPOT {@link FxSpot}.
+ * JPA-сущность финансового инструмента FX_SPOT {@link FxSpot} с проверками целостности данных валютной пары.
  */
 @Entity
-@Table(name = "fx_spot")
+@Table(name = "fx_spot", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_fx_spot_pair_value_date", columnNames = {
+                "base_currency",
+                "quote_currency",
+                "value_date_code"
+        })
+})
+@Check(constraints = "base_currency <> quote_currency")
 @PrimaryKeyJoinColumn(name = "id")
 @Getter
 @Setter

--- a/backend/src/main/resources/db/migration/V7__add_fx_spot_constraints.sql
+++ b/backend/src/main/resources/db/migration/V7__add_fx_spot_constraints.sql
@@ -1,0 +1,6 @@
+-- Обновляем ограничения таблицы валютных пар.
+ALTER TABLE fx_spot
+    ADD CONSTRAINT ck_fx_spot_currency_difference CHECK (base_currency <> quote_currency);
+
+ALTER TABLE fx_spot
+    ADD CONSTRAINT uq_fx_spot_pair_value_date UNIQUE (base_currency, quote_currency, value_date_code);


### PR DESCRIPTION
## Summary
- add a Hibernate-level check constraint to prevent identical FX spot currencies and declare a natural unique key
- introduce a database migration that adds the corresponding CHECK and UNIQUE constraints to the fx_spot table

## Testing
- ./mvnw -pl backend test *(fails: unable to download apache-maven due to network error)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc23737c4832d94083fd5e1650213