### PR TITLE
Map provider policy duration with converter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/policy/DurationToSecondsConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/policy/DurationToSecondsConverter.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.provider.catalog.persistence.jpa.policy;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.Duration;
+
+/**
+ * Конвертер длительности в секунды и обратно для хранения в БД.
+ */
+@Converter(autoApply = false)
+public class DurationToSecondsConverter implements AttributeConverter<Duration, Long> {
+
+    @Override
+    public Long convertToDatabaseColumn(Duration attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getSeconds();
+    }
+
+    @Override
+    public Duration convertToEntityAttribute(Long dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return Duration.ofSeconds(dbData);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/policy/ProviderPolicyEmbeddable.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/policy/ProviderPolicyEmbeddable.java
@@ -3,8 +3,9 @@ package com.alligator.market.backend.provider.catalog.persistence.jpa.policy;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.reconciliation.ProviderSynchronizer;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
-import jakarta.validation.constraints.Positive;
+import org.hibernate.validator.constraints.time.DurationMin;
 import lombok.NoArgsConstructor;
 
 import java.time.Duration;
@@ -21,7 +22,8 @@ public class ProviderPolicyEmbeddable {
 
     /** Минимальный интервал обновления котировок (независимо от режима доставки)
      * {@link ProviderPolicy#minUpdateInterval()}. */
-    @Positive
+    @DurationMin(seconds = 1)
+    @Convert(converter = DurationToSecondsConverter.class)
     @Column(name = "min_update_interval", nullable = false, updatable = false)
     private Duration minUpdateInterval;
 }


### PR DESCRIPTION
## Summary
- add a JPA converter to persist provider policy durations as seconds
- use the converter and @DurationMin validation for the embedded provider policy field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0270a921c832d8b6e8a3dd390d2af