### PR TITLE
Ensure immutability of provider embeddables

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
@@ -8,9 +8,11 @@ import com.alligator.market.domain.provider.reconciliation.ProviderSynchronizer;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import java.util.Objects;
 
 /**
  * JPA-сущность провайдера рыночных данных.
@@ -25,8 +27,7 @@ import lombok.Setter;
         }
 )
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProviderEntity extends BaseEntity {
 
     /** Суррогатный PK. */
@@ -48,4 +49,23 @@ public class ProviderEntity extends BaseEntity {
     /** Иммутабельный набор параметров политики провайдера. */
     @Embedded
     private ProviderPolicyEmbeddable policy;
+
+    ProviderEntity(
+            String providerCode,
+            ProviderDescriptorEmbeddable descriptor,
+            ProviderPolicyEmbeddable policy
+    ) {
+        this.providerCode = Objects.requireNonNull(providerCode, "providerCode must not be null");
+        this.descriptor = Objects.requireNonNull(descriptor, "descriptor must not be null");
+        this.policy = Objects.requireNonNull(policy, "policy must not be null");
+    }
+
+    /** Фабрика для создания иммутабельной сущности провайдера. */
+    public static ProviderEntity of(
+            String providerCode,
+            ProviderDescriptorEmbeddable descriptor,
+            ProviderPolicyEmbeddable policy
+    ) {
+        return new ProviderEntity(providerCode, descriptor, policy);
+    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/descriptor/ProviderDescriptorEmbeddable.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/descriptor/ProviderDescriptorEmbeddable.java
@@ -11,7 +11,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 /**
  * Embeddable JPA-сущность дескриптора.
@@ -20,7 +24,8 @@ import lombok.NoArgsConstructor;
  * стратегию delete → insert {@link ProviderSynchronizer}.
  */
 @Embeddable
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProviderDescriptorEmbeddable {
 
     /** Отображаемое имя провайдера (user friendly) {@link ProviderDescriptor#displayName()}. */
@@ -44,4 +49,27 @@ public class ProviderDescriptorEmbeddable {
     /** Поддержка массовой подписки одним запросом {@link ProviderDescriptor#bulkSubscription()}. */
     @Column(name = "bulk_subscription", nullable = false, updatable = false)
     private boolean bulkSubscription;
+
+    ProviderDescriptorEmbeddable(
+            String displayName,
+            DeliveryMode deliveryMode,
+            AccessMethod accessMethod,
+            boolean bulkSubscription
+    ) {
+        this.displayName = Objects.requireNonNull(displayName, "displayName must not be null");
+        this.deliveryMode = Objects.requireNonNull(deliveryMode, "deliveryMode must not be null");
+        this.accessMethod = Objects.requireNonNull(accessMethod, "accessMethod must not be null");
+        this.bulkSubscription = bulkSubscription;
+    }
+
+    /** Фабрика создания иммутабельного embeddable из доменного дескриптора. */
+    public static ProviderDescriptorEmbeddable from(ProviderDescriptor descriptor) {
+        Objects.requireNonNull(descriptor, "descriptor must not be null");
+        return new ProviderDescriptorEmbeddable(
+                descriptor.displayName(),
+                descriptor.deliveryMode(),
+                descriptor.accessMethod(),
+                descriptor.bulkSubscription()
+        );
+    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/policy/ProviderPolicyEmbeddable.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/policy/ProviderPolicyEmbeddable.java
@@ -7,9 +7,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import org.hibernate.validator.constraints.time.DurationMin;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Duration;
+import java.util.Objects;
 
 /**
  * Embeddable JPA-сущность для параметров политики провайдера.
@@ -18,7 +21,8 @@ import java.time.Duration;
  * стратегию delete → insert {@link ProviderSynchronizer}.
  */
 @Embeddable
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProviderPolicyEmbeddable {
 
     /** Минимальный интервал обновления котировок (независимо от режима доставки)
@@ -27,4 +31,14 @@ public class ProviderPolicyEmbeddable {
     @Convert(converter = DurationToSecondsConverter.class)
     @Column(name = "min_update_interval", nullable = false, updatable = false)
     private Duration minUpdateInterval;
+
+    ProviderPolicyEmbeddable(Duration minUpdateInterval) {
+        this.minUpdateInterval = Objects.requireNonNull(minUpdateInterval, "minUpdateInterval must not be null");
+    }
+
+    /** Фабрика создания иммутабельного embeddable из доменной политики. */
+    public static ProviderPolicyEmbeddable from(ProviderPolicy policy) {
+        Objects.requireNonNull(policy, "policy must not be null");
+        return new ProviderPolicyEmbeddable(policy.minUpdateInterval());
+    }
 }


### PR DESCRIPTION
## Summary
- restrict JPA provider entity and embeddables to immutable construction patterns
- add factories for descriptor and policy embeddables to create instances without setters

## Testing
- ./mvnw -pl backend -am -DskipTests package *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68e028f93768832d9c399a574a3e3cb5