### PR TITLE
Обеспечить регистронезависимую проверку имён провайдеров

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/AbstractProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/AbstractProviderContextScanner.java
@@ -7,6 +7,7 @@ import com.alligator.market.domain.provider.exception.ProviderDisplayNameDuplica
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,7 +26,7 @@ public abstract non-sealed class AbstractProviderContextScanner implements Provi
     @Override
     public final Map<String, ProviderDescriptor> providerDescriptors() {
         Map<String, ProviderDescriptor> descriptors = new LinkedHashMap<>();
-        Set<String> displayNames = new HashSet<>();
+        Set<String> displayNamesLowerCase = new HashSet<>();
         for (MarketDataProvider provider : providers()) {
             String providerCode = provider.providerCode();
             ProviderDescriptor descriptor = provider.descriptor();
@@ -34,7 +35,9 @@ public abstract non-sealed class AbstractProviderContextScanner implements Provi
                 throw new ProviderCodeDuplicateException(providerCode);
             }
             String displayName = descriptor.displayName();
-            if (!displayNames.add(displayName)) {
+            // Сравниваем имена провайдеров в нижнем регистре, чтобы обеспечить регистронезависимую уникальность.
+            String displayNameLowerCase = displayName.toLowerCase(Locale.ROOT);
+            if (!displayNamesLowerCase.add(displayNameLowerCase)) {
                 throw new ProviderDisplayNameDuplicateException(displayName);
             }
         }


### PR DESCRIPTION
## Summary
- привести хранение имён провайдеров в сканере к нижнему регистру
- использовать Locale.ROOT при нормализации для детерминированного поведения
- обновить комментарий о логике проверки дубликатов

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02dcb9fa4832d9985a197af3642b8