### PR TITLE
Add provider JPA repository

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderJpaRepository.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.provider.catalog.persistence.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Spring Data JPA-репозиторий для управления провайдерами рыночных данных.
+ */
+public interface ProviderJpaRepository extends JpaRepository<ProviderEntity, Long> {
+
+    /** Найти JPA-сущность провайдера по техническому коду. */
+    Optional<ProviderEntity> findByProviderCode(String providerCode);
+}


### PR DESCRIPTION
## Summary
- add Spring Data JPA repository for provider entities with lookup by provider code

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03bfa16bc832da93bc377c7939215