### PR TITLE
feat: override equals/hashCode in ProviderEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
@@ -83,4 +83,22 @@ public class ProviderEntity extends BaseEntity {
     ) {
         return new ProviderEntity(providerCode, descriptor, policy);
     }
+
+    /** Сравниваем сущности по техническому коду провайдера. */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ProviderEntity that)) {
+            return false;
+        }
+        return Objects.equals(providerCode, that.providerCode);
+    }
+
+    /** Хеш-код зависит только от технического кода провайдера. */
+    @Override
+    public int hashCode() {
+        return Objects.hash(providerCode);
+    }
 }


### PR DESCRIPTION
## Summary
- переопределены equals и hashCode в ProviderEntity для сравнения сущностей по техническому коду провайдера

## Testing
- не запускались (не требовалось)


------
https://chatgpt.com/codex/tasks/task_e_68e0407fed70832da1a7586c69df4f50