### PR TITLE
Add equals and hashCode implementations for CurrencyEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.NaturalId;
 
+import java.util.Objects;
+
 /**
  * JPA-сущность валюты {@link Currency}.
  */
@@ -58,4 +60,22 @@ public class CurrencyEntity extends BaseEntity {
     @Max(10)
     @Column(name = "decimal_value", nullable = false)
     private Integer decimal;
+
+    /** Сравниваем сущности по ISO-4217 коду. */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CurrencyEntity that)) {
+            return false;
+        }
+        return Objects.equals(code, that.code);
+    }
+
+    /** Хеш-код зависит только от ISO-4217 кода. */
+    @Override
+    public int hashCode() {
+        return Objects.hash(code);
+    }
 }


### PR DESCRIPTION
## Summary
- add Objects-based equals and hashCode overrides to CurrencyEntity so instances compare by ISO-4217 code

## Testing
- mvn -pl backend test *(fails: Unable to download org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e044f21350832d8fba2e39b90d1c1b