### PR TITLE
Добавить equals/hashCode для InstrumentBaseEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentBaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentBaseEntity.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.NaturalId;
 
+import java.util.Objects;
+
 /**
  * Абстрактная родительская JPA-сущность финансового инструмента.
  */
@@ -43,4 +45,21 @@ public abstract class InstrumentBaseEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "type", length = 32, nullable = false, updatable = false)
     private InstrumentType type;
+
+    /** Сравниваем сущности по коду и типу. */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof InstrumentBaseEntity that)) {
+            return false;
+        }
+        return Objects.equals(code, that.code) && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, type);
+    }
 }


### PR DESCRIPTION
## Summary
- добавил переопределения equals/hashCode в базовую JPA-сущность инструмента, чтобы сравнение велось по коду и типу

## Testing
- mvn -pl backend test *(fails: cannot download org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e044f37a60832d8eb841a68faa5472