### PR TITLE
Сравнение валют только по коду

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
@@ -34,4 +34,22 @@ public record Currency(
             throw new IllegalArgumentException("country must not be blank");
         }
     }
+
+    /** Сравниваем валюты по коду. */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Currency that)) {
+            return false;
+        }
+        return code().equals(that.code());
+    }
+
+    /** Хэш по коду. */
+    @Override
+    public int hashCode() {
+        return Objects.hash(code());
+    }
 }


### PR DESCRIPTION
## Summary
- переопределил equals и hashCode в Currency для сравнения валют по коду

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e09801887c832daa0ba9dfe7332cb2