### PR TITLE
Add Spring adapter enforcing provider bean naming

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.provider.adapter.twelve.free;
 
+import com.alligator.market.backend.provider.contract.SpringMarketDataProvider;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.spot.TwelveFreeFxSpotHandler;
-import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
 import com.alligator.market.domain.provider.contract.descriptor.AccessMethod;
 import com.alligator.market.domain.provider.contract.descriptor.DeliveryMode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
@@ -17,8 +17,8 @@ import java.util.Set;
 /**
  * Адаптер для провайдера рыночных данных TwelveData (free).
  */
-@Component
-public class TwelveFreeAdapterV2 extends AbstractMarketDataProvider<TwelveFreeAdapterV2> {
+@Component("TWELVE_FREE")
+public class TwelveFreeAdapterV2 extends SpringMarketDataProvider<TwelveFreeAdapterV2> {
 
     /* Технический код провайдера. */
     private static final String PROVIDER_CODE = "TWELVE_FREE";

--- a/backend/src/main/java/com/alligator/market/backend/provider/contract/SpringMarketDataProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/contract/SpringMarketDataProvider.java
@@ -1,0 +1,56 @@
+package com.alligator.market.backend.provider.contract;
+
+import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
+import com.alligator.market.domain.provider.contract.MarketDataProvider;
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
+import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
+import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.beans.factory.InitializingBean;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Spring-адаптер каркаса провайдера с проверкой имени бина.
+ */
+public abstract class SpringMarketDataProvider<P extends MarketDataProvider>
+        extends AbstractMarketDataProvider<P>
+        implements BeanNameAware, InitializingBean {
+
+    /* Имя бина, которое назначил Spring. */
+    private String beanName;
+
+    /**
+     * Конструктор.
+     */
+    protected SpringMarketDataProvider(
+            String providerCode,
+            String displayName,
+            ProviderDescriptor descriptor,
+            ProviderPolicy policy,
+            ProviderSettings settings,
+            Set<? extends AbstractInstrumentHandler<P, ? extends Instrument>> handlers
+    ) {
+        super(providerCode, displayName, descriptor, policy, settings, handlers);
+    }
+
+    @Override
+    public void setBeanName(String name) {
+        // Сохраняем имя бина до хука afterPropertiesSet
+        this.beanName = Objects.requireNonNull(name, "beanName must not be null");
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        // Правило уникальности: имя бина должно совпадать с providerCode
+        if (!beanName.equals(providerCode())) {
+            throw new IllegalStateException(
+                    "Bean name must equal providerCode (name='" + beanName
+                            + "', providerCode='" + providerCode() + "')"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Spring-specific market data provider adapter that enforces bean name equality with provider code
- update the TwelveData free provider to extend the Spring adapter and declare the bean name explicitly

## Testing
- ./mvnw -pl backend test *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c081bd34832d90970d49af46f2d4