### PR TITLE
Handle FX_SPOT code prefix when assembling domain model

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.FxSpotDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.FxSpotUpdateDto;
+import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotCurrencyNotFoundException;
@@ -9,6 +10,8 @@ import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.Objects;
 
 /**
  * Сборщик модели FX_SPOT из DTO.
@@ -30,12 +33,32 @@ public class FxSpotAssembler {
 
     /** Код инструмента + DTO обновления ⇒ доменная модель. */
     public FxSpot toDomainByCode(String instrumentCode, FxSpotUpdateDto dto) {
-        // Разделяем код на валюты и дату валютирования
-        String[] parts = instrumentCode.split("_");
-        String pair = parts[0];
-        String baseCode = pair.substring(0, 3);
-        String quoteCode = pair.substring(3);
-        ValueDateCode valueDateCode = ValueDateCode.valueOf(parts[1]);
+        Objects.requireNonNull(instrumentCode, "Instrument code must not be null");
+
+        String prefix = InstrumentType.FX_SPOT + "_";
+        if (!instrumentCode.startsWith(prefix)) {
+            throw new IllegalArgumentException("Instrument code must start with " + prefix);
+        }
+
+        // Отбрасываем префикс типа инструмента и разделяем символ и дату валютирования
+        String[] parts = instrumentCode.substring(prefix.length()).split("_");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Instrument code must contain currency pair and value date");
+        }
+
+        String symbol = parts[0];
+        if (symbol.length() != 6) {
+            throw new IllegalArgumentException("Currency pair must contain 6 characters");
+        }
+        String baseCode = symbol.substring(0, 3);
+        String quoteCode = symbol.substring(3, 6);
+
+        ValueDateCode valueDateCode;
+        try {
+            valueDateCode = ValueDateCode.valueOf(parts[1]);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Unsupported value date code: " + parts[1], ex);
+        }
 
         Currency base = currencyRepository.findByCode(baseCode)
                 .orElseThrow(() -> new FxSpotCurrencyNotFoundException(baseCode));

--- a/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssemblerTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssemblerTest.java
@@ -1,0 +1,41 @@
+package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
+
+import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.FxSpotUpdateDto;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.spot.utility.FxSpotNaming;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Тесты сборщика FX_SPOT. */
+class FxSpotAssemblerTest {
+
+    @Test
+    void toDomainByCodeParsesCodeWithPrefix() {
+        // Готовим фикстуры и заглушки
+        CurrencyRepository currencyRepository = mock(CurrencyRepository.class);
+        FxSpotAssembler assembler = new FxSpotAssembler(currencyRepository);
+        String instrumentCode = FxSpotNaming.fxSpotCode("EUR", "USD", ValueDateCode.TOD);
+        FxSpotUpdateDto dto = new FxSpotUpdateDto(4);
+
+        Currency eur = new Currency("EUR", "Euro", "European Union", 2);
+        Currency usd = new Currency("USD", "US Dollar", "United States", 2);
+        when(currencyRepository.findByCode("EUR")).thenReturn(Optional.of(eur));
+        when(currencyRepository.findByCode("USD")).thenReturn(Optional.of(usd));
+
+        // Проверяем формирование доменной модели
+        FxSpot fxSpot = assembler.toDomainByCode(instrumentCode, dto);
+
+        assertThat(fxSpot.base()).isEqualTo(eur);
+        assertThat(fxSpot.quote()).isEqualTo(usd);
+        assertThat(fxSpot.valueDateCode()).isEqualTo(ValueDateCode.TOD);
+        assertThat(fxSpot.quoteDecimal()).isEqualTo(4);
+    }
+}


### PR DESCRIPTION
## Summary
- validate FX_SPOT instrument codes by stripping the prefix and checking the currency/value date parts
- guard against malformed codes and wrap value date parsing errors
- cover parsing of full FX_SPOT codes with a unit test

## Testing
- ./mvnw -pl backend test *(fails: unable to download Maven wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e73663e4832da43abacf326262d4