### PR TITLE
feat: expose fx spot list item data

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
@@ -7,6 +7,7 @@ import com.alligator.market.backend.instrument.type.forex.spot.catalog.service.F
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.FxSpotDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.FxSpotUpdateDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.FxSpotDtoMapper;
+import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.FxSpotListItemDto;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -63,9 +64,9 @@ public class FxSpotController {
 
     /** Вернуть все инструменты. */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<FxSpotDto>>> getAll() {
-        List<FxSpotDto> list = service.findAll().stream()
-                .map(mapper::toDto)
+    public ResponseEntity<ApiResponse<List<FxSpotListItemDto>>> getAll() {
+        List<FxSpotListItemDto> list = service.findAll().stream()
+                .map(mapper::toListItemDto)
                 .toList();
         return ResponseEntityFactory.ok(list);
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotDtoMapper.java
@@ -18,5 +18,17 @@ public class FxSpotDtoMapper {
                 model.valueDateCode()
         );
     }
+
+    /** Преобразует доменную модель в DTO элемента списка. */
+    public FxSpotListItemDto toListItemDto(FxSpot model) {
+        return new FxSpotListItemDto(
+                model.code(),
+                model.symbol(),
+                model.base().code(),
+                model.quote().code(),
+                model.quoteDecimal(),
+                model.valueDateCode()
+        );
+    }
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotListItemDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotListItemDto.java
@@ -1,0 +1,16 @@
+package com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto;
+
+import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+
+/**
+ * DTO элемента списка FX_SPOT с кодом и символом.
+ */
+public record FxSpotListItemDto(
+        String code,
+        String symbol,
+        String baseCurrency,
+        String quoteCurrency,
+        Integer quoteDecimal,
+        ValueDateCode valueDateCode
+) {
+}

--- a/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
@@ -12,8 +12,18 @@ export interface FxSpotDto {
   valueDateCode: ValueDateCode;
 }
 
-/** DTO для отображения инструмента с вычисленным кодом. */
-export interface FxSpotItemDto extends FxSpotDto {
-  /* Код инструмента (base + quote + '_' + valueDateCode) */
-  instrumentCode: string;
+/** DTO строки списка с фактическим кодом и символом. */
+export interface FxSpotListItemDto {
+  /* Код инструмента от backend */
+  code: string;
+  /* Символ инструмента (например, EUR/USD TOD) */
+  symbol: string;
+  /* Код базовой валюты */
+  baseCurrency: string;
+  /* Код котируемой валюты */
+  quoteCurrency: string;
+  /* Количество знаков после запятой */
+  quoteDecimal: number;
+  /* Код даты валютирования */
+  valueDateCode: ValueDateCode;
 }

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
@@ -87,9 +87,14 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="instrumentCode">
+        <ng-container matColumnDef="code">
           <th mat-header-cell *matHeaderCellDef> Instrument Code</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.instrumentCode }}</td>
+          <td mat-cell *matCellDef="let spot"> {{ spot.code }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="symbol">
+          <th mat-header-cell *matHeaderCellDef> Symbol</th>
+          <td mat-cell *matCellDef="let spot"> {{ spot.symbol }}</td>
         </ng-container>
 
         <ng-container matColumnDef="baseCurrency">
@@ -118,7 +123,7 @@
             <button mat-icon-button color="primary" (click)="onEdit(spot)">
               <mat-icon>edit</mat-icon>
             </button>
-            <button mat-icon-button color="warn" (click)="onDelete(spot.instrumentCode)">
+            <button mat-icon-button color="warn" (click)="onDelete(spot)">
               <mat-icon>delete</mat-icon>
             </button>
           </td>

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -9,7 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCardModule } from '@angular/material/card';
-import { FxSpotItemDto } from '../../models/fx-spot.model';
+import { FxSpotListItemDto } from '../../models/fx-spot.model';
 import { FxSpotCreateDto } from '../../models/fx-spot-create.model';
 import { FxSpotService } from '../../services/fx-spot.service';
 import { FxSpotUpdateDto } from '../../models/fx-spot-update.model';
@@ -42,8 +42,8 @@ export class FxSpotAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['instrumentCode', 'baseCurrency', 'quoteCurrency', 'valueDateCode', 'quoteDecimal', 'actions'];
-  dataSource  = new MatTableDataSource<FxSpotItemDto>([]);
+  displayed: string[] = ['code', 'symbol', 'baseCurrency', 'quoteCurrency', 'valueDateCode', 'quoteDecimal', 'actions'];
+  dataSource = new MatTableDataSource<FxSpotListItemDto>([]);
 
   //=========================================
   // Форма добавления инструмента FX_SPOT
@@ -52,7 +52,8 @@ export class FxSpotAdminComponent implements OnInit {
 
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
-  editInstrumentCode: string | null = null; // код инструмента для редактирования
+  editCode: string | null = null; // код инструмента для редактирования
+  editSymbol: string | null = null; // символ инструмента для уведомления
   currencies: CurrencyDto[] = [];
   valueDateCodes = Object.values(ValueDateCode);
 
@@ -111,10 +112,10 @@ export class FxSpotAdminComponent implements OnInit {
     const dto = this.form.getRawValue() as FxSpotCreateDto;
 
     this.service.add(dto).subscribe({
-      next: instrumentCode => {
+      next: code => {
         // Если все ОК
         this.snack.open(
-          `FX Spot '${instrumentCode}' added`, 'OK', { duration: 2500 }
+          `FX Spot '${code}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();
         this.form.reset({
@@ -135,9 +136,10 @@ export class FxSpotAdminComponent implements OnInit {
   }
 
   /* клик по иконке Edit */
-  onEdit(spot: FxSpotItemDto): void {
+  onEdit(spot: FxSpotListItemDto): void {
     this.editing = true;
-    this.editInstrumentCode = spot.instrumentCode;
+    this.editCode = spot.code;
+    this.editSymbol = spot.symbol;
     this.form.setValue({
       baseCurrency: spot.baseCurrency,
       quoteCurrency: spot.quoteCurrency,
@@ -151,7 +153,7 @@ export class FxSpotAdminComponent implements OnInit {
 
   /* нажата кнопка Save */
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editInstrumentCode) { return; }
+    if (this.form.invalid || this.locked || !this.editCode) { return; }
 
     this.locked = true;
 
@@ -159,9 +161,10 @@ export class FxSpotAdminComponent implements OnInit {
       quoteDecimal: this.form.controls['quoteDecimal'].value
     } as FxSpotUpdateDto;
 
-    this.service.update(this.editInstrumentCode, dto).subscribe({
+    this.service.update(this.editCode, dto).subscribe({
       next: () => {
-        this.snack.open(`FX Spot '${this.editInstrumentCode}' updated`, 'OK', { duration: 2500 });
+        const title = this.editSymbol ?? this.editCode;
+        this.snack.open(`FX Spot '${title}' updated`, 'OK', { duration: 2500 });
         this.refresh();
         this.cancelEdit();
         this.locked = false;
@@ -177,7 +180,8 @@ export class FxSpotAdminComponent implements OnInit {
   /* нажата кнопка Cancel */
   cancelEdit(): void {
     this.editing = false;
-    this.editInstrumentCode = null;
+    this.editCode = null;
+    this.editSymbol = null;
     this.form.reset({
       baseCurrency: '',
       quoteCurrency: '',
@@ -191,10 +195,11 @@ export class FxSpotAdminComponent implements OnInit {
   }
 
   /* клик по иконке Delete */
-  onDelete(instrumentCode: string): void {
-    this.service.delete(instrumentCode).subscribe({
+  onDelete(spot: FxSpotListItemDto): void {
+    this.service.delete(spot.code).subscribe({
       next: () => {
-        this.snack.open(`FX Spot '${instrumentCode}' deleted`, 'OK', { duration: 2500 });
+        const title = spot.symbol ?? spot.code;
+        this.snack.open(`FX Spot '${title}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
       error: err =>

--- a/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
+++ b/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiResponse } from '../../../shared/api-response.model';
 import { FxSpotCreateDto } from '../models/fx-spot-create.model';
-import { FxSpotDto, FxSpotItemDto } from '../models/fx-spot.model';
+import { FxSpotListItemDto } from '../models/fx-spot.model';
 import { FxSpotUpdateDto } from '../models/fx-spot-update.model';
 
 /* Сервис для взаимодействия с API по работе с инструментами FX_SPOT */
@@ -18,13 +18,10 @@ export class FxSpotService {
   private readonly baseUrl = '/api/v1/fx-spot';
 
   /* Получить список всех инструментов FX_SPOT */
-  list(): Observable<FxSpotItemDto[]> {
+  list(): Observable<FxSpotListItemDto[]> {
     return this.http
-      .get<ApiResponse<FxSpotDto[]>>(this.baseUrl)
-      .pipe(map(res => res.data.map(dto => ({
-        ...dto,
-        instrumentCode: this.buildCode(dto)
-      }))));
+      .get<ApiResponse<FxSpotListItemDto[]>>(this.baseUrl)
+      .pipe(map(res => res.data));
   }
 
   /* Добавить инструмент FX_SPOT, backend вернёт его код */
@@ -35,21 +32,16 @@ export class FxSpotService {
   }
 
   /* Удалить инструмент FX_SPOT по коду */
-  delete(instrumentCode: string): Observable<void> {
+  delete(code: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${instrumentCode}`)
+      .delete<ApiResponse<void>>(`${this.baseUrl}/${code}`)
       .pipe(map(res => res.data));
   }
 
   /* Обновить инструмент FX_SPOT по коду */
-  update(instrumentCode: string, dto: FxSpotUpdateDto): Observable<void> {
+  update(code: string, dto: FxSpotUpdateDto): Observable<void> {
     return this.http
-      .patch<ApiResponse<void>>(`${this.baseUrl}/${instrumentCode}`, dto)
+      .patch<ApiResponse<void>>(`${this.baseUrl}/${code}`, dto)
       .pipe(map(res => res.data));
-  }
-
-  /* Построить код инструмента из данных DTO */
-  private buildCode(dto: FxSpotDto): string {
-    return `${dto.baseCurrency}${dto.quoteCurrency}_${dto.valueDateCode}`;
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated list item DTO for FX Spot responses and map model code/symbol
- extend Angular models and services to use API provided code and symbol values
- show FX Spot symbol in the admin table and use real codes for actions/snackbars

## Testing
- npm run test --prefix frontend -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e73a541c832dbad680fba147ce91