### PR TITLE
Добавить стабильные коды для ValueDateCode

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
@@ -23,7 +23,7 @@ public final class FxSpotCodec {
         Objects.requireNonNull(base, "Base currency code must not be null");
         Objects.requireNonNull(quote, "Quote currency code must not be null");
         Objects.requireNonNull(valueDate, "Value date code must not be null");
-        return base.toUpperCase() + quote.toUpperCase() + "_" + valueDate.name();
+        return base.toUpperCase() + quote.toUpperCase() + "_" + valueDate.code();
     }
 
     /** Формирует код инструмента FX_SPOT из параметров доменной модели. */
@@ -67,7 +67,7 @@ public final class FxSpotCodec {
 
     private static ValueDateCode parseValueDate(String valueDate) {
         try {
-            return ValueDateCode.valueOf(valueDate);
+            return ValueDateCode.fromCode(valueDate);
         } catch (IllegalArgumentException ex) {
             throw new IllegalArgumentException("Unsupported value date code: " + valueDate, ex);
         }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/ValueDateCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/ValueDateCode.java
@@ -4,7 +4,28 @@ package com.alligator.market.domain.instrument.type.forex.spot.model;
  * Коды дат валютирования инструмента FX_SPOT.
  */
 public enum ValueDateCode {
-    TOD,
-    TOM,
-    SPOT
+    TOD("TOD"),
+    TOM("TOM"),
+    SPOT("SPOT");
+
+    private final String code;
+
+    ValueDateCode(String code) {
+        this.code = code;
+    }
+
+    /** Строковый код для форматирования и парсинга. */
+    public String code() {
+        return code;
+    }
+
+    /** Ищет значение enum по строковому коду. */
+    public static ValueDateCode fromCode(String code) {
+        for (ValueDateCode value : values()) {
+            if (value.code.equals(code)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported value date code: " + code);
+    }
 }


### PR DESCRIPTION
## Summary
- добавить в ValueDateCode стабильные строковые коды и метод обратного поиска
- использовать новые методы кодирования в FxSpotCodec вместо зависимостей от name()

## Testing
- mvn -pl domain test *(fails: доступ к Maven Central заблокирован 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cdd11550832d86716556a9a61884