### PR TITLE
Add code-based lookup helpers to domain enums

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/InstrumentType.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/InstrumentType.java
@@ -4,6 +4,30 @@ package com.alligator.market.domain.instrument.type;
  * Типы финансовых инструментов.
  */
 public enum InstrumentType {
-    FX_SPOT,
-    FX_SWAP
+    /* ↓↓ Константы. */
+    FX_SPOT("FX_SPOT"),
+    FX_SWAP("FX_SWAP");
+
+    /* Поле enum. */
+    private final String code; // Строковое представление значения
+
+    /* ↓↓ Конструктор enum (всегда неявно private). */
+    InstrumentType(String code) {
+        this.code = code;
+    }
+
+    /** Возвращает строковый код. */
+    public String code() {
+        return code;
+    }
+
+    /** Ищет значение enum по строковому коду. */
+    public static InstrumentType fromCode(String code) {
+        for (InstrumentType value : values()) {
+            if (value.code.equals(code)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported instrument type: " + code);
+    }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/AccessMethod.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/AccessMethod.java
@@ -4,7 +4,31 @@ package com.alligator.market.domain.provider.contract.descriptor;
  * Список методов доступа к рыночным данным.
  */
 public enum AccessMethod {
-    API_POLL,    // Метод периодического опроса API провайдера для получения рыночных данных
-    WEBSOCKET,   // Метод получения данных через WebSocket соединение в режиме реального времени
-    FIX_PROTOCOL // Метод доступа через FIX протокол для высокочастотной торговли
+    /* ↓↓ Константы. */
+    API_POLL("API_POLL"),    // Метод периодического опроса API провайдера для получения рыночных данных
+    WEBSOCKET("WEBSOCKET"),  // Метод получения данных через WebSocket соединение в режиме реального времени
+    FIX_PROTOCOL("FIX_PROTOCOL"); // Метод доступа через FIX протокол для высокочастотной торговли
+
+    /* Поле enum. */
+    private final String code; // Строковое представление значения
+
+    /* ↓↓ Конструктор enum (всегда неявно private). */
+    AccessMethod(String code) {
+        this.code = code;
+    }
+
+    /** Возвращает строковый код. */
+    public String code() {
+        return code;
+    }
+
+    /** Ищет значение enum по строковому коду. */
+    public static AccessMethod fromCode(String code) {
+        for (AccessMethod value : values()) {
+            if (value.code.equals(code)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported access method: " + code);
+    }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/DeliveryMode.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/DeliveryMode.java
@@ -4,6 +4,30 @@ package com.alligator.market.domain.provider.contract.descriptor;
  * Список возможных режимов доставки данных провайдерами рыночных данных.
  */
 public enum DeliveryMode {
-    PUSH, // Провайдер активно отправляет данные при их появлении
-    PULL  // Клиент периодически запрашивает актуальные данные
+    /* ↓↓ Константы. */
+    PUSH("PUSH"), // Провайдер активно отправляет данные при их появлении
+    PULL("PULL"); // Клиент периодически запрашивает актуальные данные
+
+    /* Поле enum. */
+    private final String code; // Строковое представление значения
+
+    /* ↓↓ Конструктор enum (всегда неявно private). */
+    DeliveryMode(String code) {
+        this.code = code;
+    }
+
+    /** Возвращает строковый код. */
+    public String code() {
+        return code;
+    }
+
+    /** Ищет значение enum по строковому коду. */
+    public static DeliveryMode fromCode(String code) {
+        for (DeliveryMode value : values()) {
+            if (value.code.equals(code)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported delivery mode: " + code);
+    }
 }


### PR DESCRIPTION
## Summary
- add string code fields, accessors, and lookup helpers to InstrumentType, DeliveryMode, and AccessMethod enums for parity with ValueDateCode

## Testing
- ./mvnw -pl domain test *(fails: unable to download Maven distribution in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d36260dc832d8cae1afb70276570