### PR TITLE
Внедрить CurrencyCode в доменную модель валюты

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/adapter/CurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/adapter/CurrencyRepositoryAdapter.java
@@ -24,7 +24,7 @@ public class CurrencyRepositoryAdapter implements CurrencyRepository {
 
     @Override
     public String save(Currency currency) {
-        CurrencyEntity entity = jpaRepository.findByCode(currency.code())
+        CurrencyEntity entity = jpaRepository.findByCode(currency.code().value())
                 .orElseGet(CurrencyEntity::new);
         mapper.updateEntity(currency, entity);
         return jpaRepository.save(entity).getCode();

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa;
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import org.springframework.stereotype.Component;
 
 /**
@@ -13,7 +14,7 @@ public class CurrencyEntityMapper {
     public Currency toDomain(CurrencyEntity entity) {
         // Собираем доменную модель
         return new Currency(
-                entity.getCode(),
+                CurrencyCode.of(entity.getCode()),
                 entity.getName(),
                 entity.getCountry(),
                 entity.getDecimal()
@@ -23,7 +24,7 @@ public class CurrencyEntityMapper {
     /** Обновление JPA-сущности. */
     public void updateEntity(Currency currency, CurrencyEntity entity) {
         // Переносим значения в JPA-сущность
-        entity.setCode(currency.code());
+        entity.setCode(currency.code().value());
         entity.setName(currency.name());
         entity.setCountry(currency.country());
         entity.setDecimal(currency.decimal());

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
@@ -29,8 +29,8 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
     @Override
     public String createCurrency(Currency currency) {
         // Проверяем, что нет валюты с таким же кодом
-        currencyRepository.findByCode(currency.code()).ifPresent(c -> {
-            throw new CurrencyDuplicateException("code", currency.code());
+        currencyRepository.findByCode(currency.code().value()).ifPresent(c -> {
+            throw new CurrencyDuplicateException("code", currency.code().value());
         });
         // Проверяем, что нет валюты с таким же названием
         currencyRepository.findByName(currency.name()).ifPresent(c -> {
@@ -44,8 +44,8 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
     @Override
     public void updateCurrency(Currency currency) {
         // Проверяем, что валюта с таким кодом существует
-        currencyRepository.findByCode(currency.code())
-                .orElseThrow(() -> new NotFoundException("Currency '%s' not found".formatted(currency.code())));
+        currencyRepository.findByCode(currency.code().value())
+                .orElseThrow(() -> new NotFoundException("Currency '%s' not found".formatted(currency.code().value())));
         // Проверяем, что нет валюты с таким же названием
         currencyRepository.findByName(currency.name()).ifPresent(c -> {
             if (!c.code().equals(currency.code())) {
@@ -53,7 +53,7 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
             }
         });
         currencyRepository.save(currency);
-        log.info("Currency {} updated", currency.code());
+        log.info("Currency {} updated", currency.code().value());
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/CurrencyDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/CurrencyDtoMapper.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.web.dto;
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import org.springframework.stereotype.Component;
 
 /**
@@ -12,7 +13,7 @@ public class CurrencyDtoMapper {
     /** Преобразует основной DTO в доменную модель. */
     public Currency toDomain(CurrencyDto dto) {
         return new Currency(
-                dto.code(),
+                CurrencyCode.of(dto.code()),
                 dto.name(),
                 dto.country(),
                 dto.decimal()
@@ -22,7 +23,7 @@ public class CurrencyDtoMapper {
     /** Преобразует DTO обновления и код в доменную модель. */
     public Currency toDomain(String code, UpdateCurrencyDto dto) {
         return new Currency(
-                code,
+                CurrencyCode.of(code),
                 dto.name(),
                 dto.country(),
                 dto.decimal()
@@ -32,7 +33,7 @@ public class CurrencyDtoMapper {
     /** Преобразует доменную модель в основной DTO. */
     public CurrencyDto toDto(Currency currency) {
         return new CurrencyDto(
-                currency.code(),
+                currency.code().value(),
                 currency.name(),
                 currency.country(),
                 currency.decimal()

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -31,10 +31,10 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         FxSpotEntity entity = jpaRepository.findByCode(fxSpot.code())
                 .orElseGet(FxSpotEntity::new);
         // Получаем валюты (существование проверено в сервисе)
-        CurrencyEntity base = currencyRepository.findByCode(fxSpot.base().code())
-                .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.base().code())));
-        CurrencyEntity quote = currencyRepository.findByCode(fxSpot.quote().code())
-                .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.quote().code())));
+        CurrencyEntity base = currencyRepository.findByCode(fxSpot.base().code().value())
+                .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.base().code().value())));
+        CurrencyEntity quote = currencyRepository.findByCode(fxSpot.quote().code().value())
+                .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.quote().code().value())));
         mapper.updateEntity(fxSpot, base, quote, entity);
         jpaRepository.save(entity);
     }
@@ -60,7 +60,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     @Override
     public boolean existsByCurrency(Currency currency) {
-        String code = currency.code();
+        String code = currency.code().value();
         return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(code, code);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotCatalog.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotCatalog.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 
 import java.util.Set;
 
@@ -16,8 +17,8 @@ public final class TwelveFreeFxSpotCatalog {
     }
 
     /* ↓↓ Валюты. */
-    private static final Currency EUR = new Currency("EUR", "Euro", "European Union", 2);
-    private static final Currency USD = new Currency("USD", "United States Dollar", "United States", 2);
+    private static final Currency EUR = new Currency(CurrencyCode.of("EUR"), "Euro", "European Union", 2);
+    private static final Currency USD = new Currency(CurrencyCode.of("USD"), "United States Dollar", "United States", 2);
 
     /* ↓↓ Инструменты. */
     private static final FxSpot EUR_USD = new FxSpot(EUR, USD, ValueDateCode.TOM, 4);

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  */
 public record Currency(
         /* ↓↓ Базовые атрибуты валюты. */
-        String code,
+        CurrencyCode code,
         String name,
         String country,
         Integer decimal
@@ -21,12 +21,6 @@ public record Currency(
         Objects.requireNonNull(country, "country must not be null");
         Objects.requireNonNull(decimal, "decimal must not be null");
 
-        if (code.isBlank()) {
-            throw new IllegalArgumentException("code must not be blank");
-        }
-        if (!code.matches("^[A-Z]{3}$")) {
-            throw new IllegalArgumentException("code must match ^[A-Z]{3}$");
-        }
         if (name.isBlank()) {
             throw new IllegalArgumentException("name must not be blank");
         }


### PR DESCRIPTION
## Summary
- заменить строковый код валюты на value object CurrencyCode в доменной модели
- обновить JPA- и DTO-мапперы, а также адаптеры FX Spot под новый тип кода
- скорректировать сервис валют для использования строкового представления из CurrencyCode в проверках и логах

## Testing
- ./mvnw -pl backend -am test *(failed: нет доступа к Maven Central в окружении)*

------
https://chatgpt.com/codex/tasks/task_e_68e41ce681d4832d9d436c7ddf140bd7