### PR TITLE
Normalize FX spot assembler currency lookups

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
@@ -32,10 +32,13 @@ public class FxSpotAssembler {
     public FxSpot toDomainByCode(String instrumentCode, FxSpotUpdateDto dto) {
         FxSpotCodec.FxSpotCodeParts parts = FxSpotCodec.parseFxSpotCode(instrumentCode);
 
-        Currency base = currencyRepository.findByCode(parts.baseCode().toString())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(parts.baseCode().toString()));
-        Currency quote = currencyRepository.findByCode(parts.quoteCode().toString())
-                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(parts.quoteCode().value()));
+        String baseCode = parts.baseCode().value();
+        String quoteCode = parts.quoteCode().value();
+
+        Currency base = currencyRepository.findByCode(baseCode)
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(baseCode));
+        Currency quote = currencyRepository.findByCode(quoteCode)
+                .orElseThrow(() -> new FxSpotCurrencyNotFoundException(quoteCode));
         return new FxSpot(base, quote, parts.valueDate(), dto.quoteDecimal());
     }
 }


### PR DESCRIPTION
## Summary
- reuse parsed FX spot currency codes when loading entities from the repository
- raise consistent not-found errors using the same normalized codes

## Testing
- mvn -pl backend -am -DskipTests compile *(fails: blocked from downloading parent pom from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e4341b0e9c832dab34136efca6a244