### PR TITLE
Add validation constraints to FX spot list DTO

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotListItemDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotListItemDto.java
@@ -1,16 +1,37 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto;
 
 import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * DTO элемента списка FX_SPOT с кодом и символом.
  */
 public record FxSpotListItemDto(
+        @NotBlank
+        @Pattern(regexp = "^FX_SPOT_[A-Z]{3}[A-Z]{3}_(TOD|TOM|SPOT)$")
         String code,
+
+        @NotBlank
+        @Pattern(regexp = "^[A-Z]{3}[A-Z]{3}_(TOD|TOM|SPOT)$")
         String symbol,
+
+        @NotBlank
+        @Pattern(regexp = "^[A-Z]{3}$")
         String baseCurrency,
+
+        @NotBlank
+        @Pattern(regexp = "^[A-Z]{3}$")
         String quoteCurrency,
+
+        @NotNull
+        @Min(0) @Max(10)
         Integer quoteDecimal,
+
+        @NotNull
         ValueDateCode valueDateCode
 ) {
 }


### PR DESCRIPTION
## Summary
- add bean validation annotations to FxSpotListItemDto so list responses follow same rules as other DTOs

## Testing
- ./mvnw -pl backend test

------
https://chatgpt.com/codex/tasks/task_e_68e437bcb688832da9b5717dca39efa8