### PR TITLE
Stop exposing FX spot instrument code to the frontend

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
@@ -37,11 +37,12 @@ public class FxSpotController {
         FxSpot fxSpot = assembler.toDomain(dto);
         // Передаем модель сервису
         String code = service.create(fxSpot);
+        String symbol = fxSpot.symbol();
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{code}")
                 .buildAndExpand(code)
                 .toUri();
-        return ResponseEntityFactory.created(location, code);
+        return ResponseEntityFactory.created(location, symbol);
     }
 
     /** Обновить инструмент. */

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotDtoMapper.java
@@ -12,7 +12,6 @@ public class FxSpotDtoMapper {
     /** Преобразует доменную модель в DTO элемента списка. */
     public FxSpotListItemDto toListItemDto(FxSpot model) {
         return new FxSpotListItemDto(
-                model.code(),
                 model.symbol(),
                 model.base().code().value(),
                 model.quote().code().value(),

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotListItemDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/FxSpotListItemDto.java
@@ -3,11 +3,10 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto;
 import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
 
 /**
- * DTO для передачи списка инструментов FX_SPOT с кодом и символом.
+ * DTO для передачи списка инструментов FX_SPOT.
  */
 public record FxSpotListItemDto(
         // Применяется только для получения данных из доменной модели и передачи во frontend => проверки не обязательны
-        String code,
         String symbol,
         String baseCurrency,
         String quoteCurrency,

--- a/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
@@ -12,11 +12,9 @@ export interface FxSpotDto {
   valueDateCode: ValueDateCode;
 }
 
-/** DTO строки списка с фактическим кодом и символом. */
+/** DTO строки списка с символом инструмента. */
 export interface FxSpotListItemDto {
-  /* Код инструмента от backend */
-  code: string;
-  /* Символ инструмента (например, EUR/USD TOD) */
+  /* Символ инструмента (например, EURUSD_TOD) */
   symbol: string;
   /* Код базовой валюты */
   baseCurrency: string;

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
@@ -87,11 +87,6 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="code">
-          <th mat-header-cell *matHeaderCellDef> Instrument Code</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.code }}</td>
-        </ng-container>
-
         <ng-container matColumnDef="symbol">
           <th mat-header-cell *matHeaderCellDef> Symbol</th>
           <td mat-cell *matCellDef="let spot"> {{ spot.symbol }}</td>

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -42,7 +42,7 @@ export class FxSpotAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['code', 'symbol', 'baseCurrency', 'quoteCurrency', 'valueDateCode', 'quoteDecimal', 'actions'];
+  displayed: string[] = ['symbol', 'baseCurrency', 'quoteCurrency', 'valueDateCode', 'quoteDecimal', 'actions'];
   dataSource = new MatTableDataSource<FxSpotListItemDto>([]);
 
   //=========================================
@@ -52,7 +52,7 @@ export class FxSpotAdminComponent implements OnInit {
 
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
-  editCode: string | null = null; // код инструмента для редактирования
+  editCode: string | null = null; // внутренний код инструмента для редактирования (собирается на UI)
   editSymbol: string | null = null; // символ инструмента для уведомления
   currencies: CurrencyDto[] = [];
   valueDateCodes = Object.values(ValueDateCode);
@@ -112,10 +112,10 @@ export class FxSpotAdminComponent implements OnInit {
     const dto = this.form.getRawValue() as FxSpotCreateDto;
 
     this.service.add(dto).subscribe({
-      next: code => {
+      next: symbol => {
         // Если все ОК
         this.snack.open(
-          `FX Spot '${code}' added`, 'OK', { duration: 2500 }
+          `FX Spot '${symbol}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();
         this.form.reset({
@@ -138,7 +138,7 @@ export class FxSpotAdminComponent implements OnInit {
   /* клик по иконке Edit */
   onEdit(spot: FxSpotListItemDto): void {
     this.editing = true;
-    this.editCode = spot.code;
+    this.editCode = this.composeCode(spot);
     this.editSymbol = spot.symbol;
     this.form.setValue({
       baseCurrency: spot.baseCurrency,
@@ -196,10 +196,10 @@ export class FxSpotAdminComponent implements OnInit {
 
   /* клик по иконке Delete */
   onDelete(spot: FxSpotListItemDto): void {
-    this.service.delete(spot.code).subscribe({
+    const code = this.composeCode(spot);
+    this.service.delete(code).subscribe({
       next: () => {
-        const title = spot.symbol ?? spot.code;
-        this.snack.open(`FX Spot '${title}' deleted`, 'OK', { duration: 2500 });
+        this.snack.open(`FX Spot '${spot.symbol}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
       error: err =>
@@ -216,6 +216,11 @@ export class FxSpotAdminComponent implements OnInit {
       next: list => this.dataSource.data = list,
       error: err => this.snack.open(err.message ?? 'Load failed', 'Close')
     });
+  }
+
+  /** Собираем внутренний код инструмента для запросов к backend. */
+  private composeCode(spot: Pick<FxSpotListItemDto, 'baseCurrency' | 'quoteCurrency' | 'valueDateCode'>): string {
+    return `FX_SPOT_${spot.baseCurrency}${spot.quoteCurrency}_${spot.valueDateCode}`;
   }
 
 }


### PR DESCRIPTION
## Summary
- return FX spot symbols from the controller and remove the internal code from list DTOs
- adjust the backend mapper to build list responses without the internal code
- update the FX Spot admin UI to consume the new payload and build internal codes locally when needed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e43ecc3838832dab94e5f0740c0ffa