### PR TITLE
Rename currency decimal field to defaultFractionDigits

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -56,6 +56,6 @@ public class CurrencyEntity extends BaseEntity {
     @NotNull
     @Min(0)
     @Max(10)
-    @Column(name = "decimal_value", nullable = false)
-    private Integer decimal;
+    @Column(name = "default_fraction_digits", nullable = false)
+    private Integer defaultFractionDigits;
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
@@ -17,7 +17,7 @@ public class CurrencyEntityMapper {
                 CurrencyCode.of(entity.getCode()),
                 entity.getName(),
                 entity.getCountry(),
-                entity.getDecimal()
+                entity.getDefaultFractionDigits()
         );
     }
 
@@ -27,6 +27,6 @@ public class CurrencyEntityMapper {
         entity.setCode(currency.code().value());
         entity.setName(currency.name());
         entity.setCountry(currency.country());
-        entity.setDecimal(currency.decimal());
+        entity.setDefaultFractionDigits(currency.defaultFractionDigits());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/common/CurrencyDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/common/CurrencyDto.java
@@ -21,6 +21,6 @@ public record CurrencyDto(
 
         @NotNull
         @Min(0) @Max(10)
-        Integer decimal
+        Integer defaultFractionDigits
 ) {}
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/in/UpdateCurrencyDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/in/UpdateCurrencyDto.java
@@ -17,5 +17,5 @@ public record UpdateCurrencyDto(
 
         @NotNull
         @Min(0) @Max(10)
-        Integer decimal
+        Integer defaultFractionDigits
 ) {}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
@@ -18,7 +18,7 @@ public class CurrencyDtoMapper {
                 CurrencyCode.of(dto.code()),
                 dto.name(),
                 dto.country(),
-                dto.decimal()
+                dto.defaultFractionDigits()
         );
     }
 
@@ -28,7 +28,7 @@ public class CurrencyDtoMapper {
                 CurrencyCode.of(code),
                 dto.name(),
                 dto.country(),
-                dto.decimal()
+                dto.defaultFractionDigits()
         );
     }
 
@@ -38,7 +38,7 @@ public class CurrencyDtoMapper {
                 currency.code().value(),
                 currency.name(),
                 currency.country(),
-                currency.decimal()
+                currency.defaultFractionDigits()
         );
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
@@ -9,10 +9,10 @@ public record Currency(
         CurrencyCode code,
         String name,
         String country,
-        int decimal
+        int defaultFractionDigits
 ) {
     /** Конструктор с проверками. */
-    public Currency (CurrencyCode code, String name, String country, int decimal) {
+    public Currency (CurrencyCode code, String name, String country, int defaultFractionDigits) {
         // ↓↓ Базовые проверки аргументов
         Objects.requireNonNull(code, "code must not be null");
         Objects.requireNonNull(name, "name must not be null");
@@ -25,14 +25,14 @@ public record Currency(
         if (nCountry.isEmpty()) throw new IllegalArgumentException("country must not be blank");
 
         // Ограничение на количество знаков после запятой
-        if (decimal < 0 || decimal > 10) {
-            throw new IllegalArgumentException("decimal must be between 0 and 10");
+        if (defaultFractionDigits < 0 || defaultFractionDigits > 10) {
+            throw new IllegalArgumentException("defaultFractionDigits must be between 0 and 10");
         }
 
         this.code = code;
         this.name = nName;
         this.country = nCountry;
-        this.decimal = decimal;
+        this.defaultFractionDigits = defaultFractionDigits;
     }
 
     /** Сравниваем валюты по коду. */

--- a/frontend/src/app/features/currency/models/currency-update.model.ts
+++ b/frontend/src/app/features/currency/models/currency-update.model.ts
@@ -2,5 +2,5 @@
 export interface UpdateCurrencyDto {
   name: string;
   country: string;
-  decimal: number;
+  defaultFractionDigits: number;
 }

--- a/frontend/src/app/features/currency/models/currency.model.ts
+++ b/frontend/src/app/features/currency/models/currency.model.ts
@@ -3,5 +3,5 @@ export interface CurrencyDto {
   code: string;
   name: string;
   country: string;
-  decimal: number;
+  defaultFractionDigits: number;
 }

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.html
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.html
@@ -50,17 +50,17 @@
         </mat-form-field>
 
         <mat-form-field appearance="outline">
-          <mat-label>Decimal</mat-label>
+          <mat-label>Default fraction digits</mat-label>
           <input
             matInput
             type="number"
-            formControlName="decimal"
+            formControlName="defaultFractionDigits"
           />
-          <mat-error *ngIf="form.controls['decimal'].hasError('required')">
+          <mat-error *ngIf="form.controls['defaultFractionDigits'].hasError('required')">
             Is required
           </mat-error>
-          <mat-error *ngIf="form.controls['decimal'].hasError('min')
-               || form.controls['decimal'].hasError('max')">
+          <mat-error *ngIf="form.controls['defaultFractionDigits'].hasError('min')
+               || form.controls['defaultFractionDigits'].hasError('max')">
             0 – 10 allowed
           </mat-error>
         </mat-form-field>
@@ -105,9 +105,9 @@
           <td mat-cell *matCellDef="let c"> {{ c.country }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="decimal">
-          <th mat-header-cell *matHeaderCellDef> Decimal</th>
-          <td mat-cell *matCellDef="let c"> {{ c.decimal }}</td>
+        <ng-container matColumnDef="defaultFractionDigits">
+          <th mat-header-cell *matHeaderCellDef> Default fraction digits</th>
+          <td mat-cell *matCellDef="let c"> {{ c.defaultFractionDigits }}</td>
         </ng-container>
 
         <ng-container matColumnDef="actions">

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
@@ -36,7 +36,7 @@ export class CurrencyAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['code', 'name', 'country', 'decimal', 'actions'];
+  displayed: string[] = ['code', 'name', 'country', 'defaultFractionDigits', 'actions'];
   dataSource  = new MatTableDataSource<CurrencyDto>([]);
 
   //========================
@@ -78,7 +78,7 @@ export class CurrencyAdminComponent implements OnInit {
         ]
       ],
 
-      decimal: [
+      defaultFractionDigits: [
         2,
         [
           Validators.required,
@@ -113,7 +113,7 @@ export class CurrencyAdminComponent implements OnInit {
           `Currency '${code}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();                    // обновляем таблицу
-        this.form.reset({ decimal: 2 });   // оставляем decimal по-умолчанию
+        this.form.reset({ defaultFractionDigits: 2 });   // оставляем количество знаков по-умолчанию
         this.locked = false;               // разблокируем кнопку
       },
       error: err => {
@@ -134,7 +134,7 @@ export class CurrencyAdminComponent implements OnInit {
       code: c.code,
       name: c.name,
       country: c.country,
-      decimal: c.decimal
+      defaultFractionDigits: c.defaultFractionDigits
     });
     this.form.controls['code'].disable();
   }
@@ -148,7 +148,7 @@ export class CurrencyAdminComponent implements OnInit {
     const dto: UpdateCurrencyDto = {
       name: this.form.controls['name'].value,
       country: this.form.controls['country'].value,
-      decimal: this.form.controls['decimal'].value
+      defaultFractionDigits: this.form.controls['defaultFractionDigits'].value
     } as UpdateCurrencyDto;
 
     this.service.update(this.editCode, dto).subscribe({
@@ -170,7 +170,7 @@ export class CurrencyAdminComponent implements OnInit {
   cancelEdit(): void {
     this.editing = false;
     this.editCode = null;
-    this.form.reset({ code: '', name: '', country: '', decimal: 2 });
+    this.form.reset({ code: '', name: '', country: '', defaultFractionDigits: 2 });
     this.form.controls['code'].enable();
     this.locked = false;
   }


### PR DESCRIPTION
## Summary
- rename the Currency domain record field from decimal to defaultFractionDigits and adjust validation message
- propagate the new defaultFractionDigits name through JPA entities, mappers, DTOs, and the Angular admin UI
- update the persistence column to default_fraction_digits to match the renamed field

## Testing
- ./mvnw -pl domain,backend test *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f08e10d0832daf02a91d88de664a