### PR TITLE
Заменить строковый код валюты на CurrencyCode в JPA-слое

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/adapter/CurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/adapter/CurrencyRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.p
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntityMapper;
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyJpaRepository;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -24,20 +25,20 @@ public class CurrencyRepositoryAdapter implements CurrencyRepository {
 
     @Override
     public String save(Currency currency) {
-        CurrencyEntity entity = jpaRepository.findByCode(currency.code().value())
+        CurrencyEntity entity = jpaRepository.findByCode(currency.code())
                 .orElseGet(CurrencyEntity::new);
         mapper.updateEntity(currency, entity);
-        return jpaRepository.save(entity).getCode();
+        return jpaRepository.save(entity).getCode().value();
     }
 
     @Override
     public void deleteByCode(String code) {
-        jpaRepository.deleteByCode(code);
+        jpaRepository.deleteByCode(CurrencyCode.of(code));
     }
 
     @Override
     public Optional<Currency> findByCode(String code) {
-        return jpaRepository.findByCode(code).map(mapper::toDomain);
+        return jpaRepository.findByCode(CurrencyCode.of(code)).map(mapper::toDomain);
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyCodeConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyCodeConverter.java
@@ -1,0 +1,24 @@
+package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa;
+
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Конвертер для хранения {@link CurrencyCode} в виде строкового значения в БД.
+ */
+@Converter(autoApply = true)
+public class CurrencyCodeConverter implements AttributeConverter<CurrencyCode, String> {
+
+    /** Преобразует доменную модель в значение для БД. */
+    @Override
+    public String convertToDatabaseColumn(CurrencyCode attribute) {
+        return attribute != null ? attribute.value() : null;
+    }
+
+    /** Преобразует значение из БД в доменную модель. */
+    @Override
+    public CurrencyCode convertToEntityAttribute(String dbData) {
+        return dbData != null ? CurrencyCode.of(dbData) : null;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -2,12 +2,12 @@ package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.
 
 import com.alligator.market.backend.common.jpa.BaseEntity;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -36,11 +36,11 @@ public class CurrencyEntity extends BaseEntity {
     private Long id;
 
     /** ISO-4217 код валюты. */
-    @NotBlank
-    @Pattern(regexp = "^[A-Z]{3}$")
+    @NotNull
+    @Convert(converter = CurrencyCodeConverter.class)
     @NaturalId() // Полезно, так как по сути данное поле это «естественный» неизменяемый ключ
     @Column(name = "code", length = 3, nullable = false, updatable = false)
-    private String code;
+    private CurrencyCode code;
 
     /** Наименование валюты. */
     @NotBlank

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
@@ -1,7 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa;
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
-import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,7 +13,7 @@ public class CurrencyEntityMapper {
     public Currency toDomain(CurrencyEntity entity) {
         // Собираем доменную модель
         return new Currency(
-                CurrencyCode.of(entity.getCode()),
+                entity.getCode(),
                 entity.getName(),
                 entity.getCountry(),
                 entity.getDefaultFractionDigits()
@@ -24,7 +23,7 @@ public class CurrencyEntityMapper {
     /** Обновление JPA-сущности. */
     public void updateEntity(Currency currency, CurrencyEntity entity) {
         // Переносим значения в JPA-сущность
-        entity.setCode(currency.code().value());
+        entity.setCode(currency.code());
         entity.setName(currency.name());
         entity.setCountry(currency.country());
         entity.setDefaultFractionDigits(currency.defaultFractionDigits());

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyJpaRepository.java
@@ -2,6 +2,8 @@ package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
+
 import java.util.Optional;
 
 /**
@@ -10,11 +12,11 @@ import java.util.Optional;
 public interface CurrencyJpaRepository extends JpaRepository<CurrencyEntity, Long> {
 
     /** Найти JPA-сущность валюты по ISO-коду. */
-    Optional<CurrencyEntity> findByCode(String code);
+    Optional<CurrencyEntity> findByCode(CurrencyCode code);
 
     /** Найти JPA-сущность валюты по имени. */
     Optional<CurrencyEntity> findByName(String name);
 
     /** Удалить запись валюты по ISO-коду. */
-    void deleteByCode(String code);
+    void deleteByCode(CurrencyCode code);
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -6,6 +6,7 @@ import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.p
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyJpaRepository;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntityMapper;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import lombok.RequiredArgsConstructor;
@@ -31,9 +32,9 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         FxSpotEntity entity = jpaRepository.findByCode(fxSpot.code())
                 .orElseGet(FxSpotEntity::new);
         // Получаем валюты (существование проверено в сервисе)
-        CurrencyEntity base = currencyRepository.findByCode(fxSpot.base().code().value())
+        CurrencyEntity base = currencyRepository.findByCode(fxSpot.base().code())
                 .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.base().code().value())));
-        CurrencyEntity quote = currencyRepository.findByCode(fxSpot.quote().code().value())
+        CurrencyEntity quote = currencyRepository.findByCode(fxSpot.quote().code())
                 .orElseThrow(() -> new IllegalStateException("Currency '%s' not found".formatted(fxSpot.quote().code().value())));
         mapper.updateEntity(fxSpot, base, quote, entity);
         jpaRepository.save(entity);
@@ -60,7 +61,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     @Override
     public boolean existsByCurrency(Currency currency) {
-        String code = currency.code().value();
+        CurrencyCode code = currency.code();
         return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(code, code);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
@@ -1,6 +1,8 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa;
 
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 
 /**
@@ -15,5 +17,5 @@ public interface FxSpotJpaRepository extends JpaRepository<FxSpotEntity, Long> {
     void deleteByCode(String code);
 
     /** Проверить, используется ли заданная валюта хотя бы в одном инструменте. */
-    boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(String baseCurrency, String quoteCurrency);
+    boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(CurrencyCode baseCurrency, CurrencyCode quoteCurrency);
 }


### PR DESCRIPTION
## Summary
- заменить строковое поле кода в CurrencyEntity на CurrencyCode и добавить JPA-конвертер
- обновить мапперы и адаптеры валют и FX Spot для работы с типизированным кодом

## Testing
- ./mvnw -pl backend test *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68e51a690b14832dbe769e106a2f0505