### PR TITLE
Avoid updating immutable currency code

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
@@ -27,7 +27,7 @@ public class CurrencyEntityMapper {
     public void updateEntity(Currency c, CurrencyEntity e) {
         Objects.requireNonNull(c, "model must not be null");
         Objects.requireNonNull(e, "entity must not be null");
-        e.setCode(c.code());
+        // Код валюты неизменяемый (см. updatable = false), поэтому пропускаем его.
         e.setName(c.name());
         e.setCountry(c.country());
         e.setDefaultFractionDigits(c.defaultFractionDigits());


### PR DESCRIPTION
## Summary
- skip updating the currency code during entity updates because the column is marked as immutable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e527002ce4832daff35c70ca13d4b8