### PR TITLE
Refactor currency mapper into static utility

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/adapter/CurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/adapter/CurrencyRepositoryAdapter.java
@@ -6,7 +6,6 @@ import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.p
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
@@ -17,17 +16,19 @@ import java.util.Optional;
  * Адаптер, реализующий доменный порт {@link CurrencyRepository} через Spring Data JPA.
  */
 @Repository
-@RequiredArgsConstructor
 public class CurrencyRepositoryAdapter implements CurrencyRepository {
 
     private final CurrencyJpaRepository jpaRepository;
-    private final CurrencyEntityMapper mapper;
+
+    public CurrencyRepositoryAdapter(CurrencyJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
 
     @Override
     public String save(Currency currency) {
         CurrencyEntity entity = jpaRepository.findByCode(currency.code())
                 .orElseGet(CurrencyEntity::new);
-        mapper.updateEntity(currency, entity);
+        CurrencyEntityMapper.updateEntity(currency, entity);
         return jpaRepository.save(entity).getCode().value();
     }
 
@@ -38,18 +39,18 @@ public class CurrencyRepositoryAdapter implements CurrencyRepository {
 
     @Override
     public Optional<Currency> findByCode(String code) {
-        return jpaRepository.findByCode(CurrencyCode.of(code)).map(mapper::toDomain);
+        return jpaRepository.findByCode(CurrencyCode.of(code)).map(CurrencyEntityMapper::toDomain);
     }
 
     @Override
     public Optional<Currency> findByName(String name) {
-        return jpaRepository.findByName(name).map(mapper::toDomain);
+        return jpaRepository.findByName(name).map(CurrencyEntityMapper::toDomain);
     }
 
     @Override
     public List<Currency> findAll() {
         return jpaRepository.findAll(Sort.by("code")).stream()
-                .map(mapper::toDomain)
+                .map(CurrencyEntityMapper::toDomain)
                 .toList();
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
@@ -1,18 +1,18 @@
 package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa;
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
-import org.springframework.stereotype.Component;
-
 import java.util.Objects;
 
 /**
  * Маппер: JPA-сущность ⇄ доменная модель.
  */
-@Component
-public class CurrencyEntityMapper {
+public final class CurrencyEntityMapper {
+
+    private CurrencyEntityMapper() {
+    }
 
     /** JPA-сущность ⇒ доменная модель. */
-    public Currency toDomain(CurrencyEntity e) {
+    public static Currency toDomain(CurrencyEntity e) {
         int digits = Objects.requireNonNull(e.getDefaultFractionDigits(),
                 "defaultFractionDigits must not be null");
         return new Currency(
@@ -24,7 +24,7 @@ public class CurrencyEntityMapper {
     }
 
     /** Обновление JPA-сущности. */
-    public void updateEntity(Currency c, CurrencyEntity e) {
+    public static void updateEntity(Currency c, CurrencyEntity e) {
         Objects.requireNonNull(c, "model must not be null");
         Objects.requireNonNull(e, "entity must not be null");
         // Код валюты неизменяемый (updatable = false)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -3,24 +3,20 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.persiste
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntityMapper;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
  * Маппер: JPA-сущность ⇄ доменная модель.
  */
 @Component
-@RequiredArgsConstructor
 public class FxSpotEntityMapper {
-
-    private final CurrencyEntityMapper currencyMapper;
 
     /** JPA-сущность ⇒ доменная модель. */
     public FxSpot toDomain(FxSpotEntity entity) {
         // Собираем доменную модель
         return new FxSpot(
-                currencyMapper.toDomain(entity.getBaseCurrency()),
-                currencyMapper.toDomain(entity.getQuoteCurrency()),
+                CurrencyEntityMapper.toDomain(entity.getBaseCurrency()),
+                CurrencyEntityMapper.toDomain(entity.getQuoteCurrency()),
                 entity.getValueDateCode(),
                 entity.getQuoteDecimal()
         );


### PR DESCRIPTION
## Summary
- convert CurrencyEntityMapper into a final utility with static mapping methods
- adjust adapters to call the static mapper directly instead of injecting it as a Spring bean

## Testing
- ./mvnw -pl backend test *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68e52e806cec832da3de8c0bb338016b