### PR TITLE
Add domain exceptions for resource creation and update failures

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/common/exception/ResourceCreationException.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/ResourceCreationException.java
@@ -1,0 +1,32 @@
+package com.alligator.market.domain.common.exception;
+
+/**
+ * Базовое исключение для ошибок при создании ресурса.
+ */
+public class ResourceCreationException extends RuntimeException {
+
+    /* Имя ресурса (например, "Currency", "FxSpot"). */
+    private final String resource;
+
+    /* Причина, по которой не удалось создать ресурс. */
+    private final String reason;
+
+    /** Конструктор с деталями. */
+    public ResourceCreationException(String resource, String reason) {
+        super("Failed to create resource: " + resource +
+                (reason == null || reason.isBlank() ? "" : " [" + reason + "]"));
+        this.resource = resource;
+        this.reason = reason;
+    }
+
+    /** Конструктор с первопричиной (если нужно прокинуть cause). */
+    public ResourceCreationException(String resource, String reason, Throwable cause) {
+        super("Failed to create resource: " + resource +
+                (reason == null || reason.isBlank() ? "" : " [" + reason + "]"), cause);
+        this.resource = resource;
+        this.reason = reason;
+    }
+
+    public String getResource() { return resource; }
+    public String getReason() { return reason; }
+}

--- a/domain/src/main/java/com/alligator/market/domain/common/exception/ResourceUpdateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/ResourceUpdateException.java
@@ -1,0 +1,32 @@
+package com.alligator.market.domain.common.exception;
+
+/**
+ * Базовое исключение для ошибок при обновлении ресурса.
+ */
+public class ResourceUpdateException extends RuntimeException {
+
+    /* Имя ресурса (например, "Currency", "FxSpot"). */
+    private final String resource;
+
+    /* Причина, по которой не удалось обновить ресурс. */
+    private final String reason;
+
+    /** Конструктор с деталями. */
+    public ResourceUpdateException(String resource, String reason) {
+        super("Failed to update resource: " + resource +
+                (reason == null || reason.isBlank() ? "" : " [" + reason + "]"));
+        this.resource = resource;
+        this.reason = reason;
+    }
+
+    /** Конструктор с первопричиной (если нужно прокинуть cause). */
+    public ResourceUpdateException(String resource, String reason, Throwable cause) {
+        super("Failed to update resource: " + resource +
+                (reason == null || reason.isBlank() ? "" : " [" + reason + "]"), cause);
+        this.resource = resource;
+        this.reason = reason;
+    }
+
+    public String getResource() { return resource; }
+    public String getReason() { return reason; }
+}


### PR DESCRIPTION
## Summary
- add a base exception for resource creation failures that captures the resource and optional reason
- add a base exception for resource update failures following the same pattern

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67b799230832d813bd8561072a90d