### PR TITLE
Refine FX spot currency existence check

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
@@ -81,7 +81,7 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
         }
 
         // Проверяем, что валюта не используется инструментами FX_SPOT
-        if (fxSpotRepository.existsByCurrency(currency)) {
+        if (fxSpotRepository.existsByCurrencyCode(code)) {
             throw new ResourceInUseException("Currency '%s'".formatted(code), "FX_SPOT instrument");
         }
         currencyRepository.deleteByCode(code);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -5,7 +5,6 @@ import com.alligator.market.backend.instrument.type.forex.spot.catalog.persisten
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyJpaRepository;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntityMapper;
-import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
@@ -60,8 +59,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
-    public boolean existsByCurrency(Currency currency) {
-        CurrencyCode code = currency.code();
-        return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(code, code);
+    public boolean existsByCurrencyCode(CurrencyCode currencyCode) {
+        return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(currencyCode, currencyCode);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
@@ -1,6 +1,6 @@
 package com.alligator.market.domain.instrument.type.forex.spot.repository;
 
-import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 
 import java.util.List;
@@ -23,6 +23,6 @@ public interface FxSpotRepository {
     /** Вернуть все инструменты. */
     List<FxSpot> findAll();
 
-    /** Проверить, используется ли заданная валюта хотя бы в одном инструменте FX_SPOT. */
-    boolean existsByCurrency(Currency currency);
+    /** Проверить, используется ли валюта с заданным кодом хотя бы в одном инструменте FX_SPOT. */
+    boolean existsByCurrencyCode(CurrencyCode currencyCode);
 }


### PR DESCRIPTION
## Summary
- update the FX spot repository port to expose currency usage checks by natural currency code
- align the Spring Data adapter and currency service with the new port contract

## Testing
- ./mvnw -pl backend -am test *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e8236e0a90832d97554ffa49ab9ab8