### PR TITLE
Rename FxSpot quote decimal field to primitive fraction digits

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -16,7 +16,7 @@ public class FxSpot extends AbstractInstrument {
     private final Currency base;
     private final Currency quote;
     private final ValueDateCode valueDateCode;
-    private final Integer quoteDecimal;
+    private final int defaultQuoteFractionDigits;
 
     /**
      * Конструктор инструмента с проверками.
@@ -25,14 +25,14 @@ public class FxSpot extends AbstractInstrument {
      * @throws NullPointerException          если параметр не передан
      * @throws IllegalArgumentException      если код валюты пустой
      */
-    public FxSpot(Currency base, Currency quote, ValueDateCode valueDateCode, Integer quoteDecimal) {
+    public FxSpot(Currency base, Currency quote, ValueDateCode valueDateCode, int defaultQuoteFractionDigits) {
 
         // ↓↓ Базовые проверки аргументов
         this.base = Objects.requireNonNull(base, "Base currency must not be null");
         this.quote = Objects.requireNonNull(quote, "Quote currency must not be null");
         this.valueDateCode = Objects.requireNonNull(valueDateCode, "Value date code must not be null");
-        this.quoteDecimal = Objects.requireNonNull(quoteDecimal, "Quote decimal must not be null");
-        if (this.quoteDecimal < 0) {
+        this.defaultQuoteFractionDigits = defaultQuoteFractionDigits;
+        if (this.defaultQuoteFractionDigits < 0) {
             throw new IllegalArgumentException("Quote decimal must not be negative");
         }
         // Валюты должны отличиться
@@ -57,8 +57,8 @@ public class FxSpot extends AbstractInstrument {
     }
 
     /** Количество знаков после запятой в котировке (согласно рыночной практике). */
-    public Integer quoteDecimal() {
-        return quoteDecimal;
+    public int quoteDecimal() {
+        return defaultQuoteFractionDigits;
     }
 
     /** Внутренний код инструмента (уникален в контексте приложения). */


### PR DESCRIPTION
## Summary
- rename the FxSpot quote decimal attribute to defaultQuoteFractionDigits for clarity
- update the constructor and getter to use a primitive type since the value must always be present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8ed9873d4832d887c9c3954ac74fa