### PR TITLE
Rename currency fraction digits field

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -63,7 +63,7 @@ public class CurrencyEntity extends BaseEntity {
     @Min(0)
     @Max(10)
     @Column(name = "default_fraction_digits", nullable = false)
-    private Integer defaultFractionDigits;
+    private Integer fractionDigits;
 
     /**
      * Специальный конструктор для создания JPA-сущности с заданным натуральным ключом (кодом валюты).

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
@@ -26,9 +26,9 @@ public final class CurrencyEntityMapper {
     public static Currency toDomain(CurrencyEntity e) {
         Objects.requireNonNull(e, "entity must not be null");
 
-        // defaultFractionDigits задана как Integer в JPA-сущности и как int в Currency ⇒ нужна проверка
-        int digits = Objects.requireNonNull(e.getDefaultFractionDigits(),
-                "defaultFractionDigits must not be null");
+        // fractionDigits задана как Integer в JPA-сущности и как int в Currency ⇒ нужна проверка
+        int digits = Objects.requireNonNull(e.getFractionDigits(),
+                "fractionDigits must not be null");
 
         return new Currency(e.getCode(), e.getName(), e.getCountry(), digits);
     }
@@ -46,6 +46,6 @@ public final class CurrencyEntityMapper {
         // Код валюты неизменяемый (updatable = false)
         e.setName(c.name());
         e.setCountry(c.country());
-        e.setDefaultFractionDigits(c.defaultFractionDigits());
+        e.setFractionDigits(c.fractionDigits());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/common/CurrencyDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/common/CurrencyDto.java
@@ -21,6 +21,6 @@ public record CurrencyDto(
 
         @NotNull
         @Min(0) @Max(10)
-        Integer defaultFractionDigits
+        Integer fractionDigits
 ) {}
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/in/UpdateCurrencyDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/in/UpdateCurrencyDto.java
@@ -17,5 +17,5 @@ public record UpdateCurrencyDto(
 
         @NotNull
         @Min(0) @Max(10)
-        Integer defaultFractionDigits
+        Integer fractionDigits
 ) {}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
@@ -18,7 +18,7 @@ public class CurrencyDtoMapper {
                 CurrencyCode.of(dto.code()),
                 dto.name(),
                 dto.country(),
-                dto.defaultFractionDigits()
+                dto.fractionDigits()
         );
     }
 
@@ -28,7 +28,7 @@ public class CurrencyDtoMapper {
                 CurrencyCode.of(code),
                 dto.name(),
                 dto.country(),
-                dto.defaultFractionDigits()
+                dto.fractionDigits()
         );
     }
 
@@ -38,7 +38,7 @@ public class CurrencyDtoMapper {
                 currency.code().value(),
                 currency.name(),
                 currency.country(),
-                currency.defaultFractionDigits()
+                currency.fractionDigits()
         );
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/ref/currency/model/Currency.java
@@ -9,16 +9,16 @@ import java.util.Objects;
  * @param code                    ISO-4217 код валюты
  * @param name                    Наименование валюты
  * @param country                 Страна или регион обращения
- * @param defaultFractionDigits   Количество знаков после запятой для денежных сумм
+ * @param fractionDigits          Количество знаков после запятой для денежных сумм
  */
 public record Currency(
         CurrencyCode code,
         String name,
         String country,
-        int defaultFractionDigits
+        int fractionDigits
 ) {
     /** Конструктор с проверками. */
-    public Currency (CurrencyCode code, String name, String country, int defaultFractionDigits) {
+    public Currency (CurrencyCode code, String name, String country, int fractionDigits) {
         // ↓↓ Базовые проверки аргументов
         Objects.requireNonNull(code, "code must not be null");
         Objects.requireNonNull(name, "name must not be null");
@@ -31,13 +31,13 @@ public record Currency(
         if (nCountry.isEmpty()) throw new IllegalArgumentException("country must not be blank");
 
         // Ограничение на стандартное количество знаков после запятой в суммах в данной валюте
-        if (defaultFractionDigits < 0 || defaultFractionDigits > 10) {
-            throw new IllegalArgumentException("defaultFractionDigits must be between 0 and 10");
+        if (fractionDigits < 0 || fractionDigits > 10) {
+            throw new IllegalArgumentException("fractionDigits must be between 0 and 10");
         }
 
         this.code = code;
         this.name = nName;
         this.country = nCountry;
-        this.defaultFractionDigits = defaultFractionDigits;
+        this.fractionDigits = fractionDigits;
     }
 }

--- a/frontend/src/app/features/currency/models/currency-update.model.ts
+++ b/frontend/src/app/features/currency/models/currency-update.model.ts
@@ -2,5 +2,5 @@
 export interface UpdateCurrencyDto {
   name: string;
   country: string;
-  defaultFractionDigits: number;
+  fractionDigits: number;
 }

--- a/frontend/src/app/features/currency/models/currency.model.ts
+++ b/frontend/src/app/features/currency/models/currency.model.ts
@@ -3,5 +3,5 @@ export interface CurrencyDto {
   code: string;
   name: string;
   country: string;
-  defaultFractionDigits: number;
+  fractionDigits: number;
 }

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.html
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.html
@@ -50,17 +50,17 @@
         </mat-form-field>
 
         <mat-form-field appearance="outline">
-          <mat-label>Default fraction digits</mat-label>
+          <mat-label>Fraction digits</mat-label>
           <input
             matInput
             type="number"
-            formControlName="defaultFractionDigits"
+            formControlName="fractionDigits"
           />
-          <mat-error *ngIf="form.controls['defaultFractionDigits'].hasError('required')">
+          <mat-error *ngIf="form.controls['fractionDigits'].hasError('required')">
             Is required
           </mat-error>
-          <mat-error *ngIf="form.controls['defaultFractionDigits'].hasError('min')
-               || form.controls['defaultFractionDigits'].hasError('max')">
+          <mat-error *ngIf="form.controls['fractionDigits'].hasError('min')
+               || form.controls['fractionDigits'].hasError('max')">
             0 – 10 allowed
           </mat-error>
         </mat-form-field>
@@ -105,9 +105,9 @@
           <td mat-cell *matCellDef="let c"> {{ c.country }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="defaultFractionDigits">
-          <th mat-header-cell *matHeaderCellDef> Default fraction digits</th>
-          <td mat-cell *matCellDef="let c"> {{ c.defaultFractionDigits }}</td>
+        <ng-container matColumnDef="fractionDigits">
+          <th mat-header-cell *matHeaderCellDef> Fraction digits</th>
+          <td mat-cell *matCellDef="let c"> {{ c.fractionDigits }}</td>
         </ng-container>
 
         <ng-container matColumnDef="actions">

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
@@ -36,7 +36,7 @@ export class CurrencyAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['code', 'name', 'country', 'defaultFractionDigits', 'actions'];
+  displayed: string[] = ['code', 'name', 'country', 'fractionDigits', 'actions'];
   dataSource  = new MatTableDataSource<CurrencyDto>([]);
 
   //========================
@@ -78,7 +78,7 @@ export class CurrencyAdminComponent implements OnInit {
         ]
       ],
 
-      defaultFractionDigits: [
+      fractionDigits: [
         2,
         [
           Validators.required,
@@ -113,7 +113,7 @@ export class CurrencyAdminComponent implements OnInit {
           `Currency '${code}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();                    // обновляем таблицу
-        this.form.reset({ defaultFractionDigits: 2 });   // оставляем количество знаков по-умолчанию
+        this.form.reset({ fractionDigits: 2 });   // оставляем количество знаков по-умолчанию
         this.locked = false;               // разблокируем кнопку
       },
       error: err => {
@@ -134,7 +134,7 @@ export class CurrencyAdminComponent implements OnInit {
       code: c.code,
       name: c.name,
       country: c.country,
-      defaultFractionDigits: c.defaultFractionDigits
+      fractionDigits: c.fractionDigits
     });
     this.form.controls['code'].disable();
   }
@@ -148,7 +148,7 @@ export class CurrencyAdminComponent implements OnInit {
     const dto: UpdateCurrencyDto = {
       name: this.form.controls['name'].value,
       country: this.form.controls['country'].value,
-      defaultFractionDigits: this.form.controls['defaultFractionDigits'].value
+      fractionDigits: this.form.controls['fractionDigits'].value
     } as UpdateCurrencyDto;
 
     this.service.update(this.editCode, dto).subscribe({
@@ -170,7 +170,7 @@ export class CurrencyAdminComponent implements OnInit {
   cancelEdit(): void {
     this.editing = false;
     this.editCode = null;
-    this.form.reset({ code: '', name: '', country: '', defaultFractionDigits: 2 });
+    this.form.reset({ code: '', name: '', country: '', fractionDigits: 2 });
     this.form.controls['code'].enable();
     this.locked = false;
   }


### PR DESCRIPTION
## Summary
- rename the currency domain and persistence models to use the fractionDigits property
- update DTO mappers and Angular models/components to consume the new fractionDigits field consistently

## Testing
- ./mvnw -pl backend test *(fails: Maven wrapper cannot download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8f4bbb114832d8c3d9e512f981279