### PR TITLE
Align FX spot same currencies exception style

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotSameCurrenciesException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotSameCurrenciesException.java
@@ -1,11 +1,69 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
+
+import java.util.Objects;
+
 /**
- * Базовая и котируемая валюты не должны совпадать.
+ * Ошибка: базовая и котируемая валюты совпадают.
  */
-public class FxSpotSameCurrenciesException extends RuntimeException {
-    public FxSpotSameCurrenciesException() {
-        super("Base and quote currencies must be different");
+public final class FxSpotSameCurrenciesException extends RuntimeException {
+
+    private final CurrencyCode base;
+    private final CurrencyCode quote;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param base  код базовой валюты
+     * @param quote код котируемой валюты
+     * @return текст сообщения
+     */
+    private static String msg(CurrencyCode base, CurrencyCode quote) {
+        CurrencyCode b = Objects.requireNonNull(base, "base must not be null");
+        CurrencyCode q = Objects.requireNonNull(quote, "quote must not be null");
+        return "Base and quote currencies must be different (base=" + b.value() + ", quote=" + q.value() + ")";
     }
+
+    /**
+     * Создает исключение.
+     *
+     * @param base  код базовой валюты
+     * @param quote код котируемой валюты
+     */
+    @SuppressWarnings("unused")
+    public FxSpotSameCurrenciesException(CurrencyCode base, CurrencyCode quote) {
+        super(msg(base, quote));
+        this.base = base;
+        this.quote = quote;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param base  код базовой валюты
+     * @param quote код котируемой валюты
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public FxSpotSameCurrenciesException(CurrencyCode base, CurrencyCode quote, Throwable cause) {
+        super(msg(base, quote), cause);
+        this.base = base;
+        this.quote = quote;
+    }
+
+    /**
+     * Возвращает код базовой валюты.
+     *
+     * @return код базовой валюты
+     */
+    public CurrencyCode getBase() { return base; }
+
+    /**
+     * Возвращает код котируемой валюты.
+     *
+     * @return код котируемой валюты
+     */
+    public CurrencyCode getQuote() { return quote; }
 }
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -38,7 +38,7 @@ public class FxSpot extends AbstractInstrument {
 
         // Валюты не должны совпадать
         if (base.code().equals(quote.code())) {
-            throw new FxSpotSameCurrenciesException();
+            throw new FxSpotSameCurrenciesException(base.code(), quote.code());
         }
 
         this.base = base;


### PR DESCRIPTION
## Summary
- rewrite `FxSpotSameCurrenciesException` to follow the structured pattern used by currency reference exceptions
- include stored base and quote currency codes with contextualized error messaging
- update `FxSpot` model to supply the currency codes when raising the exception

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8fa3332c0832d93f982f6afdff130