### PR TITLE
Rename FX spot value date enum

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -5,7 +5,7 @@ import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.p
 import com.alligator.market.domain.instrument.type.forex.spot.codec.FxSpotCodec;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotValueDate;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -51,7 +51,7 @@ public class FxSpotEntity extends InstrumentBaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     @Column(name = "value_date_code", length = 4, updatable = false, nullable = false)
-    private ValueDateCode valueDateCode;
+    private FxSpotValueDate valueDateCode;
 
     /** Количество знаков после запятой для курса. */
     @NotNull

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/in/FxSpotDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/in/FxSpotDto.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.in;
 
-import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotValueDate;
 import jakarta.validation.constraints.*;
 
 /**
@@ -20,5 +20,5 @@ public record FxSpotDto(
         Integer quoteDecimal,
 
         @NotNull
-        ValueDateCode valueDateCode
+        FxSpotValueDate valueDateCode
 ) {}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/out/FxSpotListItemDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/out/FxSpotListItemDto.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.out;
 
-import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotValueDate;
 
 /**
  * DTO для передачи списка инструментов FX_SPOT.
@@ -10,5 +10,5 @@ public record FxSpotListItemDto(
         String baseCurrency,
         String quoteCurrency,
         Integer quoteDecimal,
-        ValueDateCode valueDateCode
+        FxSpotValueDate valueDateCode
 ) {}

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotCatalog.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotCatalog.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotValueDate;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
 
 import java.util.Set;
@@ -21,7 +21,7 @@ public final class TwelveFreeFxSpotCatalog {
     private static final Currency USD = new Currency(CurrencyCode.of("USD"), "United States Dollar", "United States", 2);
 
     /* ↓↓ Инструменты. */
-    private static final FxSpot EUR_USD = new FxSpot(EUR, USD, ValueDateCode.TOM, 4);
+    private static final FxSpot EUR_USD = new FxSpot(EUR, USD, FxSpotValueDate.TOM, 4);
 
     /** Набор поддерживаемых инструментов провайдера. */
     public static final Set<FxSpot> SUPPORTED = Set.of(EUR_USD);

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
@@ -3,7 +3,7 @@ package com.alligator.market.domain.instrument.type.forex.spot.codec;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
-import com.alligator.market.domain.instrument.type.forex.spot.model.ValueDateCode;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotValueDate;
 
 import java.util.Objects;
 
@@ -29,7 +29,7 @@ public final class FxSpotCodec {
     }
 
     /** Формирует символ инструмента из доменных моделей кодов валют и даты валютирования. */
-    public static String fxSpotSymbol(CurrencyCode baseCode, CurrencyCode quoteCode, ValueDateCode valueDate) {
+    public static String fxSpotSymbol(CurrencyCode baseCode, CurrencyCode quoteCode, FxSpotValueDate valueDate) {
         Objects.requireNonNull(baseCode, "Base currency code must not be null");
         Objects.requireNonNull(quoteCode, "Quote currency code must not be null");
         Objects.requireNonNull(valueDate, "Value date must not be null");
@@ -37,26 +37,26 @@ public final class FxSpotCodec {
     }
 
     /* ↪ Перегрузка для случая доменных моделей валют. */
-    public static String fxSpotSymbol(Currency base, Currency quote, ValueDateCode valueDate) {
+    public static String fxSpotSymbol(Currency base, Currency quote, FxSpotValueDate valueDate) {
         Objects.requireNonNull(base, "Base currency must not be null");
         Objects.requireNonNull(quote, "Quote currency must not be null");
         return fxSpotSymbol(base.code(), quote.code(), valueDate);
     }
 
     /** Формирует внутренний код инструмента из доменных моделей кодов валют и даты валютирования. */
-    public static String fxSpotCode(CurrencyCode baseCode, CurrencyCode quoteCode, ValueDateCode valueDate) {
+    public static String fxSpotCode(CurrencyCode baseCode, CurrencyCode quoteCode, FxSpotValueDate valueDate) {
         return TYPE_PREFIX + fxSpotSymbol(baseCode, quoteCode, valueDate);
     }
 
     /* ↪ Перегрузка для случая доменных моделей валют. */
-    public static String fxSpotCode(Currency base, Currency quote, ValueDateCode valueDate) {
+    public static String fxSpotCode(Currency base, Currency quote, FxSpotValueDate valueDate) {
         Objects.requireNonNull(base, "Base currency must not be null");
         Objects.requireNonNull(quote, "Quote currency must not be null");
         return fxSpotCode(base.code(), quote.code(), valueDate);
     }
 
     /**
-     * Разбирает строковый код инструмента формата {@code FX_SPOT_<AAA><BBB>_<ValueDateCode>} на составные компоненты.
+     * Разбирает строковый код инструмента формата {@code FX_SPOT_<AAA><BBB>_<FxSpotValueDate>} на составные компоненты.
      */
     public static FxSpotCodeParts parseFxSpotCode(String instrumentCode) {
         Objects.requireNonNull(instrumentCode, "Instrument code must not be null");
@@ -91,11 +91,11 @@ public final class FxSpotCodec {
         final CurrencyCode quoteCode = CurrencyCode.of(quoteRaw);
 
         // Валидация даты валютирования
-        final ValueDateCode valueDate = ValueDateCode.fromCode(valueDateRaw);
+        final FxSpotValueDate valueDate = FxSpotValueDate.fromCode(valueDateRaw);
 
         return new FxSpotCodeParts(baseCode, quoteCode, valueDate);
     }
 
     /** Модель разложения кода инструмента на валюты и дату валютирования. */
-    public record FxSpotCodeParts(CurrencyCode baseCode, CurrencyCode quoteCode, ValueDateCode valueDate) { }
+    public record FxSpotCodeParts(CurrencyCode baseCode, CurrencyCode quoteCode, FxSpotValueDate valueDate) { }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -1,10 +1,10 @@
 package com.alligator.market.domain.instrument.type.forex.spot.model;
 
-import com.alligator.market.domain.instrument.type.forex.spot.codec.FxSpotCodec;
 import com.alligator.market.domain.instrument.contract.AbstractInstrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotSameCurrenciesException;
+import com.alligator.market.domain.instrument.type.forex.spot.codec.FxSpotCodec;
 
 import java.util.Objects;
 
@@ -15,7 +15,7 @@ public class FxSpot extends AbstractInstrument {
     /* ↓↓ Базовые атрибуты инструмента. */
     private final Currency base;
     private final Currency quote;
-    private final ValueDateCode valueDateCode;
+    private final FxSpotValueDate valueDateCode;
     private final int defaultQuoteFractionDigits;
 
     /**
@@ -25,7 +25,7 @@ public class FxSpot extends AbstractInstrument {
      * @throws NullPointerException          если параметр не передан
      * @throws IllegalArgumentException      если код валюты пустой
      */
-    public FxSpot(Currency base, Currency quote, ValueDateCode valueDateCode, int defaultQuoteFractionDigits) {
+    public FxSpot(Currency base, Currency quote, FxSpotValueDate valueDateCode, int defaultQuoteFractionDigits) {
         // ↓↓ Базовые проверки аргументов
         Objects.requireNonNull(base, "base must not be null");
         Objects.requireNonNull(quote, "quote must not be null");
@@ -58,7 +58,7 @@ public class FxSpot extends AbstractInstrument {
     }
 
     /** Код даты валютирования. */
-    public ValueDateCode valueDateCode() {
+    public FxSpotValueDate valueDateCode() {
         return valueDateCode;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpotValueDate.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpotValueDate.java
@@ -3,7 +3,7 @@ package com.alligator.market.domain.instrument.type.forex.spot.model;
 /**
  * Коды дат валютирования инструмента FX_SPOT.
  */
-public enum ValueDateCode {
+public enum FxSpotValueDate {
     /* ↓↓ Константы. */
     TOD("TOD"),
     TOM("TOM"),
@@ -13,7 +13,7 @@ public enum ValueDateCode {
     private final String code; // Строковая переменная
 
     /** Конструктор enum (всегда неявно private). */
-    ValueDateCode(String code) {
+    FxSpotValueDate(String code) {
         this.code = code;
     }
 
@@ -23,12 +23,12 @@ public enum ValueDateCode {
     }
 
     /** Ищет значение enum по строковому коду. */
-    public static ValueDateCode fromCode(String code) {
-        for (ValueDateCode value : values()) {
+    public static FxSpotValueDate fromCode(String code) {
+        for (FxSpotValueDate value : values()) {
             if (value.code.equals(code)) {
                 return value;
             }
         }
-        throw new IllegalArgumentException("Unsupported value date code: " + code);
+        throw new IllegalArgumentException("Unsupported FX spot value date code: " + code);
     }
 }

--- a/frontend/src/app/features/fx_spot/models/fx-spot-create.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot-create.model.ts
@@ -1,4 +1,4 @@
-import { ValueDateCode } from './value-date-code.model';
+import { FxSpotValueDate } from './fx-spot-value-date.model';
 
 /** DTO для создания инструмента FX_SPOT аналогичный backend. */
 export interface FxSpotCreateDto {
@@ -9,5 +9,5 @@ export interface FxSpotCreateDto {
   /* Количество знаков после запятой */
   quoteDecimal: number;
   /* Код даты валютирования */
-  valueDateCode: ValueDateCode;
+  valueDateCode: FxSpotValueDate;
 }

--- a/frontend/src/app/features/fx_spot/models/fx-spot-value-date.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot-value-date.model.ts
@@ -1,0 +1,6 @@
+/** Перечень кодов дат валютирования как в backend FxSpotValueDate. */
+export enum FxSpotValueDate {
+  TOD = 'TOD',
+  TOM = 'TOM',
+  SPOT = 'SPOT'
+}

--- a/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
@@ -1,4 +1,4 @@
-import { ValueDateCode } from './value-date-code.model';
+import { FxSpotValueDate } from './fx-spot-value-date.model';
 
 /** Основной DTO инструмента FX_SPOT аналогичный backend. */
 export interface FxSpotDto {
@@ -9,7 +9,7 @@ export interface FxSpotDto {
   /* Количество знаков после запятой */
   quoteDecimal: number;
   /* Код даты валютирования */
-  valueDateCode: ValueDateCode;
+  valueDateCode: FxSpotValueDate;
 }
 
 /** DTO строки списка с символом инструмента. */
@@ -23,5 +23,5 @@ export interface FxSpotListItemDto {
   /* Количество знаков после запятой */
   quoteDecimal: number;
   /* Код даты валютирования */
-  valueDateCode: ValueDateCode;
+  valueDateCode: FxSpotValueDate;
 }

--- a/frontend/src/app/features/fx_spot/models/value-date-code.model.ts
+++ b/frontend/src/app/features/fx_spot/models/value-date-code.model.ts
@@ -1,6 +1,0 @@
-/** Перечень кодов дат валютирования как в backend ValueDateCode. */
-export enum ValueDateCode {
-  TOD = 'TOD',
-  TOM = 'TOM',
-  SPOT = 'SPOT'
-}

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -16,7 +16,7 @@ import { FxSpotUpdateDto } from '../../models/fx-spot-update.model';
 import { CurrencyService } from '../../../currency/services/currency.service';
 import { CurrencyDto } from '../../../currency/models/currency.model';
 import { RouterLink } from '@angular/router';
-import { ValueDateCode } from '../../models/value-date-code.model';
+import { FxSpotValueDate } from '../../models/fx-spot-value-date.model';
 
 @Component({
   selector: 'app-fx-spot-admin',
@@ -55,7 +55,7 @@ export class FxSpotAdminComponent implements OnInit {
   editCode: string | null = null; // внутренний код инструмента для редактирования (собирается на UI)
   editSymbol: string | null = null; // символ инструмента для уведомления
   currencies: CurrencyDto[] = [];
-  valueDateCodes = Object.values(ValueDateCode);
+  valueDateCodes = Object.values(FxSpotValueDate);
 
   constructor(
     private readonly service: FxSpotService,
@@ -84,7 +84,7 @@ export class FxSpotAdminComponent implements OnInit {
       ],
 
       valueDateCode: [
-        ValueDateCode.TOD,
+        FxSpotValueDate.TOD,
         [Validators.required]
       ]
     });
@@ -122,7 +122,7 @@ export class FxSpotAdminComponent implements OnInit {
           baseCurrency: '',
           quoteCurrency: '',
           quoteDecimal: 4,
-          valueDateCode: ValueDateCode.TOD
+          valueDateCode: FxSpotValueDate.TOD
         });
         this.locked = false;
       },
@@ -186,7 +186,7 @@ export class FxSpotAdminComponent implements OnInit {
       baseCurrency: '',
       quoteCurrency: '',
       quoteDecimal: 4,
-      valueDateCode: ValueDateCode.TOD
+      valueDateCode: FxSpotValueDate.TOD
     });
     this.form.controls['baseCurrency'].enable();
     this.form.controls['quoteCurrency'].enable();


### PR DESCRIPTION
## Summary
- rename the FX spot value date enum to `FxSpotValueDate` in the domain model and supporting codecs
- update backend DTOs, entity mapping, and provider catalog to use the new enum name
- align the Angular models and admin UI with the renamed enum and module paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e91619c160832d82a7a6587880e381