### PR TITLE
Rename instrument accessors

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -28,7 +28,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     @Override
     public void save(FxSpot fxSpot) {
-        FxSpotEntity entity = jpaRepository.findByCode(fxSpot.code())
+        FxSpotEntity entity = jpaRepository.findByCode(fxSpot.instrumentCode())
                 .orElseGet(FxSpotEntity::new);
         // Получаем валюты (существование проверено в сервисе)
         CurrencyEntity base = currencyRepository.findByCode(fxSpot.base().code())

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -32,8 +32,8 @@ public class FxSpotEntityMapper {
         entity.setQuoteCurrency(quote);
         entity.setDefaultQuoteFractionDigits(model.defaultQuoteFractionDigits());
         entity.setValueDate(model.valueDate());
-        entity.setCode(model.code());
-        entity.setType(model.type());
+        entity.setCode(model.instrumentCode());
+        entity.setType(model.instrumentType());
     }
 }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -26,22 +26,22 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
     @Override
     public String create(FxSpot fxSpot) {
         // Проверяем, что инструмента с таким кодом нет, иначе выбрасываем доменное исключение
-        fxSpotRepository.find(fxSpot.code()).ifPresent(i -> {
-            throw new FxSpotDuplicateException(fxSpot.code());
+        fxSpotRepository.find(fxSpot.instrumentCode()).ifPresent(i -> {
+            throw new FxSpotDuplicateException(fxSpot.instrumentCode());
         });
         // Сохраняем инструмент
         fxSpotRepository.save(fxSpot);
-        log.info("FxSpot {} created", fxSpot.code());
-        return fxSpot.code();
+        log.info("FxSpot {} created", fxSpot.instrumentCode());
+        return fxSpot.instrumentCode();
     }
 
     @Override
     public void update(FxSpot fxSpot) {
         // Из модели извлекаем код
-        String code = fxSpot.code();
+        String instrumentCode = fxSpot.instrumentCode();
         // Ищем текущий инструмент
-        FxSpot current = fxSpotRepository.find(code)
-                .orElseThrow(() -> new FxSpotNotFoundException(code));
+        FxSpot current = fxSpotRepository.find(instrumentCode)
+                .orElseThrow(() -> new FxSpotNotFoundException(instrumentCode));
         // Обновляем текущий инструмент
         FxSpot updated = new FxSpot(
                 current.base(),
@@ -51,7 +51,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
         );
         // Сохраняем обновленный инструмент
         fxSpotRepository.save(updated);
-        log.info("FxSpot {} updated", code);
+        log.info("FxSpot {} updated", instrumentCode);
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
@@ -37,12 +37,12 @@ public class FxSpotController {
         FxSpot fxSpot = assembler.toDomain(dto);
         // Передаем модель сервису
         String code = service.create(fxSpot);
-        String symbol = fxSpot.symbol();
+        String instrumentSymbol = fxSpot.instrumentSymbol();
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{code}")
                 .buildAndExpand(code)
                 .toUri();
-        return ResponseEntityFactory.created(location, symbol);
+        return ResponseEntityFactory.created(location, instrumentSymbol);
     }
 
     /** Обновить инструмент. */

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
@@ -13,7 +13,7 @@ public class FxSpotDtoMapper {
     /** Преобразует доменную модель в DTO элемента списка. */
     public FxSpotListItemDto toListItemDto(FxSpot model) {
         return new FxSpotListItemDto(
-                model.symbol(),
+                model.instrumentSymbol(),
                 model.base().code().value(),
                 model.quote().code().value(),
                 model.defaultQuoteFractionDigits(),

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
@@ -40,16 +40,16 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
     @Override
     protected Publisher<QuoteTick> doQuote(FxSpot instrument) {
         // Провайдер ожидает формат символа инструмента: BASE/QUOTE
-        String symbol = instrument.base().code() + "/" + instrument.quote().code();
+        String instrumentSymbol = instrument.base().code() + "/" + instrument.quote().code();
         return webClient.get()
                 .uri(b -> b
                         .path("/price")
-                        .queryParam("symbol", symbol)
+                        .queryParam("symbol", instrumentSymbol)
                         .queryParam("apikey", props.apiKey())
                         .build())
                 .retrieve()
                 .bodyToMono(JsonNode.class)
-                .map(json -> responseJsonToQuoteTick(json, instrument.code()))
+                .map(json -> responseJsonToQuoteTick(json, instrument.instrumentCode()))
                 .flux();
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/contract/Instrument.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/contract/Instrument.java
@@ -8,11 +8,11 @@ import com.alligator.market.domain.instrument.type.InstrumentType;
 public interface Instrument {
 
     /** Внутренний код инструмента (уникален в контексте приложения). */
-    String code();
+    String instrumentCode();
 
     /** Символ инструмента для отображения в UI. */
-    String symbol();
+    String instrumentSymbol();
 
     /** Тип инструмента. */
-    InstrumentType type();
+    InstrumentType instrumentType();
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -47,19 +47,19 @@ public record FxSpot(
 
     /** Внутренний код инструмента (уникален в контексте приложения). */
     @Override
-    public String code() {
+    public String instrumentCode() {
         return FxSpotCodec.fxSpotCode(base, quote, valueDate);
     }
 
     /** Символ инструмента для отображения в UI. */
     @Override
-    public String symbol() {
+    public String instrumentSymbol() {
         return FxSpotCodec.fxSpotSymbol(base, quote, valueDate);
     }
 
     /** Тип инструмента. */
     @Override
-    public InstrumentType type() {
+    public InstrumentType instrumentType() {
         return InstrumentType.FX_SPOT;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -102,7 +102,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
                 // ↓↓ Дополнительно проверяем, что каждый инструмент соответствует декларируемому в обработчике классу
                 if (!h.instrumentClass().isInstance(ins)) {
                     throw new IllegalStateException(
-                            "Instrument '" + ins.code() +
+                            "Instrument '" + ins.instrumentCode() +
                                     "' must match '" + h.instrumentClass().getSimpleName()
                                     + "' for handler '" + h.handlerCode() + "'"
                     );
@@ -110,7 +110,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
                 // ↓↓ Обеспечиваем уникальность ключей (инструментов) в карте при сборке
                 var prev = map.putIfAbsent(ins, h);
                 if (prev != null) {
-                    throw new IllegalStateException("Instrument '" + ins.code() +
+                    throw new IllegalStateException("Instrument '" + ins.instrumentCode() +
                             "' is already bound to handler '" + prev.handlerCode() +
                             "' in provider '" + providerCode + "'");
                 }
@@ -121,8 +121,8 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         var instrumentCodes = new java.util.LinkedHashSet<String>();
         var instrumentTypes = java.util.EnumSet.noneOf(InstrumentType.class);
         for (Instrument instrument : map.keySet()) {
-            instrumentCodes.add(instrument.code());
-            instrumentTypes.add(instrument.type());
+            instrumentCodes.add(instrument.instrumentCode());
+            instrumentTypes.add(instrument.instrumentType());
         }
 
         // 4) Фиксируем структуру неизменяемых коллекций
@@ -190,7 +190,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         Objects.requireNonNull(instrument, "instrument must not be null");
         var handler = handlerOf(instrument);
         if (handler == null) {
-            throw new HandlerNotFoundException(instrument.code(), providerCode);
+            throw new HandlerNotFoundException(instrument.instrumentCode(), providerCode);
         }
         return handler.quote(instrument);
     }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/handler/AbstractInstrumentHandler.java
@@ -94,7 +94,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
         Objects.requireNonNull(instrument, "instrument must not be null");
         if (instrument.getClass() != instrumentClass) {
             throw new InstrumentWrongClassException(
-                    instrument.code(),
+                    instrument.instrumentCode(),
                     instrument.getClass(),
                     handlerCode,
                     instrumentClass
@@ -102,7 +102,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
         }
         if (!supportedInstruments.contains(instrument)) {
             throw new InstrumentNotSupportedException(
-                    instrument.code(),
+                    instrument.instrumentCode(),
                     handlerCode
             );
         }


### PR DESCRIPTION
## Summary
- rename the Instrument contract accessors to instrumentCode, instrumentSymbol, and instrumentType
- adjust the FX Spot instrument implementation and backend usage to the new method names
- update provider infrastructure to reference the renamed accessors

## Testing
- `./mvnw -pl domain test` *(fails: wget unable to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68ea23cad320832d951dc05f8c0a6ab2