### PR TITLE
feat: add detailed fx spot not found exception

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
@@ -1,12 +1,52 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
-import com.alligator.market.domain.common.exception.NotFoundException;
+import java.util.Objects;
 
 /**
- * Инструмент не найден.
+ * Инструмент FxSpot не найден.
  */
-public class FxSpotNotFoundException extends NotFoundException {
-    public FxSpotNotFoundException(String code) {
-        super("FX_SPOT instrument '%s' not found".formatted(code));
+public final class FxSpotNotFoundException extends RuntimeException {
+
+    private final String code;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param instrumentCode код инструмента
+     * @return текст сообщения
+     */
+    private static String msg(String instrumentCode) {
+        String c = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "FxSpot instrument not found (code=" + c + ")";
     }
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    @SuppressWarnings("unused")
+    public FxSpotNotFoundException(String instrumentCode) {
+        super(msg(instrumentCode));
+        this.code = instrumentCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public FxSpotNotFoundException(String instrumentCode, Throwable cause) {
+        super(msg(instrumentCode), cause);
+        this.code = instrumentCode;
+    }
+
+    /**
+     * Возвращает код инструмента.
+     *
+     * @return код инструмента
+     */
+    public String getCode() { return code; }
 }


### PR DESCRIPTION
## Summary
- align FxSpotNotFoundException with other domain exceptions by storing the instrument code
- generate detailed error messages and accessors similar to CurrencyNotFoundException

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec11f4b528832d83d247de665528ee