### PR TITLE
Add FxSpotUpdateException

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
@@ -1,0 +1,52 @@
+package com.alligator.market.domain.instrument.type.forex.spot.exception;
+
+import java.util.Objects;
+
+/**
+ * Ошибка обновления инструмента FX_SPOT.
+ */
+public final class FxSpotUpdateException extends RuntimeException {
+
+    private final String instrumentCode;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param instrumentCode код инструмента
+     * @return текст сообщения
+     */
+    private static String msg(String instrumentCode) {
+        String code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "Failed to update FX_SPOT instrument (code=" + code + ")";
+    }
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    @SuppressWarnings("unused")
+    public FxSpotUpdateException(String instrumentCode) {
+        super(msg(instrumentCode));
+        this.instrumentCode = instrumentCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public FxSpotUpdateException(String instrumentCode, Throwable cause) {
+        super(msg(instrumentCode), cause);
+        this.instrumentCode = instrumentCode;
+    }
+
+    /**
+     * Возвращает код инструмента.
+     *
+     * @return код инструмента
+     */
+    public String getInstrumentCode() { return instrumentCode; }
+}


### PR DESCRIPTION
## Summary
- add FxSpotUpdateException mirroring the existing create exception for FX spot instruments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec19ecac44832dbfd8cb0d89a3624f