### PR TITLE
Add FxSpotDeleteException

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
@@ -1,0 +1,52 @@
+package com.alligator.market.domain.instrument.type.forex.spot.exception;
+
+import java.util.Objects;
+
+/**
+ * Ошибка удаления инструмента FX_SPOT.
+ */
+public final class FxSpotDeleteException extends RuntimeException {
+
+    private final String instrumentCode;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param instrumentCode код инструмента
+     * @return текст сообщения
+     */
+    private static String msg(String instrumentCode) {
+        String code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "Failed to delete FX_SPOT instrument (code=" + code + ")";
+    }
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    @SuppressWarnings("unused")
+    public FxSpotDeleteException(String instrumentCode) {
+        super(msg(instrumentCode));
+        this.instrumentCode = instrumentCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public FxSpotDeleteException(String instrumentCode, Throwable cause) {
+        super(msg(instrumentCode), cause);
+        this.instrumentCode = instrumentCode;
+    }
+
+    /**
+     * Возвращает код инструмента.
+     *
+     * @return код инструмента
+     */
+    public String getInstrumentCode() { return instrumentCode; }
+}


### PR DESCRIPTION
## Summary
- add a dedicated FxSpotDeleteException for FX_SPOT instrument deletion failures
- align message and API with existing create/update exceptions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec1e498be4832da96e37049186d00f