### PR TITLE
Add instrument code existence check to FX spot repository

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -106,6 +106,13 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
+    public boolean existsByInstrumentCode(String instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        return jpaRepository.existsByCode(instrumentCode);
+    }
+
+    @Override
     public List<FxSpot> findAll() {
         return jpaRepository.findAll(Sort.by(Sort.Order.asc("code"))) // Сортируем по коду
                 .stream()

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotJpaRepository.java
@@ -13,6 +13,9 @@ public interface FxSpotJpaRepository extends JpaRepository<FxSpotEntity, Long> {
     /** Найти сущность инструмента по коду. */
     Optional<FxSpotEntity> findByCode(String instrumentCode);
 
+    /** Проверить существование инструмента по его коду. */
+    boolean existsByCode(String instrumentCode);
+
     /** Проверить, используется ли заданная валюта хотя бы в одном инструменте. */
     boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(CurrencyCode baseCurrency, CurrencyCode quoteCurrency);
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
@@ -23,6 +23,9 @@ public interface FxSpotRepository {
     /** Найти инструмент по коду. */
     Optional<FxSpot> findByCode(String instrumentCode);
 
+    /** Проверить существование инструмента по его коду. */
+    boolean existsByInstrumentCode(String instrumentCode);
+
     /** Вернуть все инструменты. */
     List<FxSpot> findAll();
 


### PR DESCRIPTION
## Summary
- add domain-level API to check FX spot instrument presence by instrument code
- expose existsByCode query in the JPA repository and wire it through the adapter implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed05fa88ac832daa7e1b3150c37531