### PR TITLE
Fix currency update endpoint response type

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
@@ -51,7 +51,7 @@ public class CurrencyController {
             @RequestBody @Valid UpdateCurrencyDto dto) {
 
         service.update(mapper.toDomain(code, dto));
-        return ResponseEntity.noContent().build();
+        return ResponseEntityFactory.ok((Void) null);
     }
 
     /** Удалить валюту. */


### PR DESCRIPTION
## Summary
- align the currency update endpoint with the standardized ApiResponse envelope
- return a 200 OK response that frontend clients can unwrap consistently

## Testing
- ./mvnw -pl backend -am test *(fails: missing network access to download Maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5e5ea444832d9e5aca08722cc887