### PR TITLE
Make currency mappers utility classes

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/persistence/jpa/CurrencyEntityMapper.java
@@ -1,14 +1,11 @@
 package com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa;
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
-import org.springframework.stereotype.Component;
-
 import java.util.Objects;
 
 /**
  * Маппер: JPA-сущность ⇄ доменная модель.
  */
-@Component
 public final class CurrencyEntityMapper {
 
     /** Приватный конструктор (запрещает создание экземпляров). */

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
@@ -29,13 +29,12 @@ import java.util.List;
 public class CurrencyController {
 
     private final CurrencyUseCase service;
-    private final CurrencyDtoMapper mapper;
 
     /** Создать валюту. */
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid CurrencyDto dto) {
 
-        Currency created = service.create(mapper.toDomain(dto));
+        Currency created = service.create(CurrencyDtoMapper.toDomain(dto));
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{code}")
@@ -50,7 +49,7 @@ public class CurrencyController {
             @PathVariable @Pattern(regexp = "^[A-Z]{3}$") String code,
             @RequestBody @Valid UpdateCurrencyDto dto) {
 
-        service.update(mapper.toDomain(code, dto));
+        service.update(CurrencyDtoMapper.toDomain(code, dto));
         return ResponseEntityFactory.ok(null);
     }
 
@@ -69,7 +68,7 @@ public class CurrencyController {
 
         List<CurrencyDto> currencyDtoList = service.findAll()
                 .stream()
-                .map(mapper::toDto)
+                .map(CurrencyDtoMapper::toDto)
                 .toList();
         return ResponseEntityFactory.ok(currencyDtoList);
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
@@ -4,21 +4,18 @@ import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.w
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.web.dto.common.CurrencyDto;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
-import org.springframework.stereotype.Component;
-
 import java.util.Objects;
 
 /**
  * Маппер: модель валюты ⇄ DTO.
  */
-@Component
-public class CurrencyDtoMapper {
+public final class CurrencyDtoMapper {
 
     /** Приватный конструктор (запрещает создание экземпляров). */
     private CurrencyDtoMapper() { throw new UnsupportedOperationException("Utility class"); }
 
     /** Преобразует основной DTO в доменную модель. */
-    public Currency toDomain(CurrencyDto dto) {
+    public static Currency toDomain(CurrencyDto dto) {
         Objects.requireNonNull(dto, "dto must not be null");
 
         return new Currency(
@@ -30,7 +27,7 @@ public class CurrencyDtoMapper {
     }
 
     /** Преобразует DTO обновления и код в доменную модель. */
-    public Currency toDomain(String code, UpdateCurrencyDto dto) {
+    public static Currency toDomain(String code, UpdateCurrencyDto dto) {
         Objects.requireNonNull(code, "code must not be null");
         Objects.requireNonNull(dto, "dto must not be null");
 
@@ -43,7 +40,7 @@ public class CurrencyDtoMapper {
     }
 
     /** Преобразует доменную модель в основной DTO. */
-    public CurrencyDto toDto(Currency currency) {
+    public static CurrencyDto toDto(Currency currency) {
         Objects.requireNonNull(currency, "currency must not be null");
 
         return new CurrencyDto(


### PR DESCRIPTION
## Summary
- drop Spring component annotations from currency mappers and rely on the existing private constructors
- expose only static mapping helpers in `CurrencyDtoMapper`
- update the currency controller to call the static mapper methods directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed720a27e4832da1208e7a253a2212