### PR TITLE
Сделать FX Spot мапперы утилитарными

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/adapter/FxSpotRepositoryAdapter.java
@@ -30,7 +30,6 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     private final FxSpotJpaRepository jpaRepository;
     private final CurrencyJpaRepository currencyRepository;
-    private final FxSpotEntityMapper mapper;
 
     @Override
     public FxSpot create(FxSpot fxSpot) {
@@ -48,7 +47,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         // Пробуем сохранить созданную сущность (ловим наиболее вероятные ошибки и пробрасываем их выше)
         try {
             FxSpotEntity saved = jpaRepository.saveAndFlush(entity);
-            return mapper.toDomain(saved);
+            return FxSpotEntityMapper.toDomain(saved);
         } catch (jakarta.validation.ConstraintViolationException | org.springframework.dao.DataAccessException ex) {
             throw new FxSpotCreateException(fxSpot.instrumentCode(), ex);
         }
@@ -68,7 +67,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         // Пробуем сохранить обновленную сущность (ловим наиболее вероятные ошибки и пробрасываем их выше)
         try {
             FxSpotEntity saved = jpaRepository.saveAndFlush(e);
-            return mapper.toDomain(saved);
+            return FxSpotEntityMapper.toDomain(saved);
         } catch (jakarta.validation.ConstraintViolationException | org.springframework.dao.DataAccessException ex) {
             throw new FxSpotUpdateException(fxSpot.instrumentCode(), ex);
         }
@@ -96,7 +95,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         return jpaRepository.findByCode(instrumentCode)
-                .map(mapper::toDomain);
+                .map(FxSpotEntityMapper::toDomain);
     }
 
     @Override
@@ -110,7 +109,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     public List<FxSpot> findAll() {
         return jpaRepository.findAll(Sort.by(Sort.Order.asc("code"))) // Сортируем по коду
                 .stream()
-                .map(mapper::toDomain)
+                .map(FxSpotEntityMapper::toDomain)
                 .toList();
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -3,14 +3,11 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.persiste
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.type.forex.ref.currency.catalog.persistence.jpa.CurrencyEntityMapper;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import org.springframework.stereotype.Component;
-
 import java.util.Objects;
 
 /**
  * Маппер: JPA-сущность ⇄ доменная модель.
  */
-@Component
 public class FxSpotEntityMapper {
 
     /** Приватный конструктор (запрещает создание экземпляров). */
@@ -35,7 +32,7 @@ public class FxSpotEntityMapper {
     }
 
     /** JPA-сущность ⇒ доменная модель. */
-    public FxSpot toDomain(FxSpotEntity e) {
+    public static FxSpot toDomain(FxSpotEntity e) {
         Objects.requireNonNull(e, "entity must not be null");
 
         // defaultQuoteFractionDigits задана как Integer в JPA-сущности и как int в модели ⇒ нужна null проверка

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
@@ -27,7 +27,6 @@ import java.util.List;
 public class FxSpotController {
 
     private final FxSpotUseCase service;
-    private final FxSpotDtoMapper mapper;
     private final FxSpotAssembler assembler;
 
     /** Создать инструмент. */
@@ -65,7 +64,7 @@ public class FxSpotController {
     public ResponseEntity<ApiResponse<List<FxSpotListItemDto>>> getAll() {
 
         List<FxSpotListItemDto> list = service.findAll().stream()
-                .map(mapper::toListItemDto)
+                .map(FxSpotDtoMapper::toListItemDto)
                 .toList();
         return ResponseEntityFactory.ok(list);
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
@@ -2,21 +2,18 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.
 
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.out.FxSpotListItemDto;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
-import org.springframework.stereotype.Component;
-
 import java.util.Objects;
 
 /**
  * Маппер: модель ⇄ DTO.
  */
-@Component
 public class FxSpotDtoMapper {
 
     /** Приватный конструктор (запрещает создание экземпляров). */
     private FxSpotDtoMapper() { throw new UnsupportedOperationException("Utility class"); }
 
     /** Преобразует доменную модель в DTO для списка. */
-    public FxSpotListItemDto toListItemDto(FxSpot fxSpot) {
+    public static FxSpotListItemDto toListItemDto(FxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         return new FxSpotListItemDto(


### PR DESCRIPTION
## Summary
- убрал необходимость в Spring-компонентах для FxSpotEntityMapper и FxSpotDtoMapper, оставив только статические методы
- адаптировал репозиторий и контроллер для работы со статическими мапперами

## Testing
- ./mvnw -pl backend -am compile *(падает при загрузке maven-wrapper из-за недоступности репозитория)*

------
https://chatgpt.com/codex/tasks/task_e_68ed7337fbf4832dad559c1d48a2aba6