### PR TITLE
Rename FX spot value date field

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/out/FxSpotListItemDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/out/FxSpotListItemDto.java
@@ -11,5 +11,5 @@ public record FxSpotListItemDto(
         String baseCurrency,
         String quoteCurrency,
         Integer defaultQuoteFractionDigits,
-        FxSpotValueDate valueDateCode
+        FxSpotValueDate valueDate
 ) {}

--- a/frontend/src/app/features/fx_spot/models/fx-spot-create.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot-create.model.ts
@@ -8,6 +8,6 @@ export interface FxSpotCreateDto {
   quoteCurrency: string;
   /* Количество знаков после запятой */
   quoteDecimal: number;
-  /* Код даты валютирования */
-  valueDateCode: FxSpotValueDate;
+  /* Дата валютирования */
+  valueDate: FxSpotValueDate;
 }

--- a/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
@@ -8,8 +8,8 @@ export interface FxSpotDto {
   quoteCurrency: string;
   /* Количество знаков после запятой */
   quoteDecimal: number;
-  /* Код даты валютирования */
-  valueDateCode: FxSpotValueDate;
+  /* Дата валютирования */
+  valueDate: FxSpotValueDate;
 }
 
 /** DTO строки списка с символом инструмента. */
@@ -22,6 +22,6 @@ export interface FxSpotListItemDto {
   quoteCurrency: string;
   /* Количество знаков после запятой */
   quoteDecimal: number;
-  /* Код даты валютирования */
-  valueDateCode: FxSpotValueDate;
+  /* Дата валютирования */
+  valueDate: FxSpotValueDate;
 }

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
@@ -36,12 +36,12 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Value Date</mat-label>
-          <mat-select formControlName="valueDateCode">
-            <mat-option *ngFor="let code of valueDateCodes" [value]="code">
-              {{ code }}
+          <mat-select formControlName="valueDate">
+            <mat-option *ngFor="let date of valueDates" [value]="date">
+              {{ date }}
             </mat-option>
           </mat-select>
-          <mat-error *ngIf="form.controls['valueDateCode'].hasError('required')">
+          <mat-error *ngIf="form.controls['valueDate'].hasError('required')">
             Is required
           </mat-error>
         </mat-form-field>
@@ -102,9 +102,9 @@
           <td mat-cell *matCellDef="let spot"> {{ spot.quoteCurrency }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="valueDateCode">
+        <ng-container matColumnDef="valueDate">
           <th mat-header-cell *matHeaderCellDef> Value Date</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.valueDateCode }}</td>
+          <td mat-cell *matCellDef="let spot"> {{ spot.valueDate }}</td>
         </ng-container>
 
         <ng-container matColumnDef="quoteDecimal">

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -42,7 +42,7 @@ export class FxSpotAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['symbol', 'baseCurrency', 'quoteCurrency', 'valueDateCode', 'quoteDecimal', 'actions'];
+  displayed: string[] = ['symbol', 'baseCurrency', 'quoteCurrency', 'valueDate', 'quoteDecimal', 'actions'];
   dataSource = new MatTableDataSource<FxSpotListItemDto>([]);
 
   //=========================================
@@ -55,7 +55,7 @@ export class FxSpotAdminComponent implements OnInit {
   editCode: string | null = null; // внутренний код инструмента для редактирования (собирается на UI)
   editSymbol: string | null = null; // символ инструмента для уведомления
   currencies: CurrencyDto[] = [];
-  valueDateCodes = Object.values(FxSpotValueDate);
+  valueDates = Object.values(FxSpotValueDate);
 
   constructor(
     private readonly service: FxSpotService,
@@ -83,7 +83,7 @@ export class FxSpotAdminComponent implements OnInit {
         ]
       ],
 
-      valueDateCode: [
+      valueDate: [
         FxSpotValueDate.TOD,
         [Validators.required]
       ]
@@ -122,7 +122,7 @@ export class FxSpotAdminComponent implements OnInit {
           baseCurrency: '',
           quoteCurrency: '',
           quoteDecimal: 4,
-          valueDateCode: FxSpotValueDate.TOD
+          valueDate: FxSpotValueDate.TOD
         });
         this.locked = false;
       },
@@ -144,11 +144,11 @@ export class FxSpotAdminComponent implements OnInit {
       baseCurrency: spot.baseCurrency,
       quoteCurrency: spot.quoteCurrency,
       quoteDecimal: spot.quoteDecimal,
-      valueDateCode: spot.valueDateCode
+      valueDate: spot.valueDate
     });
     this.form.controls['baseCurrency'].disable();
     this.form.controls['quoteCurrency'].disable();
-    this.form.controls['valueDateCode'].disable();
+    this.form.controls['valueDate'].disable();
   }
 
   /* нажата кнопка Save */
@@ -186,11 +186,11 @@ export class FxSpotAdminComponent implements OnInit {
       baseCurrency: '',
       quoteCurrency: '',
       quoteDecimal: 4,
-      valueDateCode: FxSpotValueDate.TOD
+      valueDate: FxSpotValueDate.TOD
     });
     this.form.controls['baseCurrency'].enable();
     this.form.controls['quoteCurrency'].enable();
-    this.form.controls['valueDateCode'].enable();
+    this.form.controls['valueDate'].enable();
     this.locked = false;
   }
 
@@ -219,8 +219,8 @@ export class FxSpotAdminComponent implements OnInit {
   }
 
   /** Собираем внутренний код инструмента для запросов к backend. */
-  private composeCode(spot: Pick<FxSpotListItemDto, 'baseCurrency' | 'quoteCurrency' | 'valueDateCode'>): string {
-    return `FX_SPOT_${spot.baseCurrency}${spot.quoteCurrency}_${spot.valueDateCode}`;
+  private composeCode(spot: Pick<FxSpotListItemDto, 'baseCurrency' | 'quoteCurrency' | 'valueDate'>): string {
+    return `FX_SPOT_${spot.baseCurrency}${spot.quoteCurrency}_${spot.valueDate}`;
   }
 
 }


### PR DESCRIPTION
## Summary
- rename the FX Spot list item DTO field from `valueDateCode` to `valueDate`
- align Angular DTOs, form controls, and table columns with the updated field name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed74fc7c7c832d95d62b015e31a38b