### PR TITLE
Remove redundant FX spot currency code conversions

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
@@ -41,13 +41,13 @@ public class FxSpotAssembler {
 
         FxSpotCodec.FxSpotCodeParts parts = FxSpotCodec.parseFxSpotCode(instrumentCode);
 
-        String baseCode = parts.baseCode().value();
-        String quoteCode = parts.quoteCode().value();
+        CurrencyCode baseCode = parts.baseCode();
+        CurrencyCode quoteCode = parts.quoteCode();
 
-        Currency base = currencyRepository.findByCode(CurrencyCode.of(baseCode))
-                .orElseThrow(() -> new CurrencyNotFoundException(CurrencyCode.of(baseCode)));
-        Currency quote = currencyRepository.findByCode(CurrencyCode.of(quoteCode))
-                .orElseThrow(() -> new CurrencyNotFoundException(CurrencyCode.of(quoteCode)));
+        Currency base = currencyRepository.findByCode(baseCode)
+                .orElseThrow(() -> new CurrencyNotFoundException(baseCode));
+        Currency quote = currencyRepository.findByCode(quoteCode)
+                .orElseThrow(() -> new CurrencyNotFoundException(quoteCode));
         return new FxSpot(base, quote, parts.valueDate(), dto.defaultQuoteFractionDigits());
     }
 }


### PR DESCRIPTION
## Summary
- reuse parsed CurrencyCode values from FxSpotCodec instead of converting through String
- pass CurrencyCode instances directly to the currency repository and exceptions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed7503c4d0832db0754a7324f86716