### PR TITLE
Return 204 No Content for mutation endpoints

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/ResponseEntityFactory.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/ResponseEntityFactory.java
@@ -23,6 +23,11 @@ public final class ResponseEntityFactory {
                 .body(ApiResponse.build(data, "created"));
     }
 
+    /** Успех: частный случай - 204 No Content. */
+    public static ResponseEntity<ApiResponse<Void>> noContent() {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     /** Ошибка: общая. */
     public static ResponseEntity<ApiResponse<Void>> error(HttpStatus status, String message) {
         return ResponseEntity.status(status)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
@@ -50,7 +50,7 @@ public class CurrencyController {
             @RequestBody @Valid UpdateCurrencyDto dto) {
 
         service.update(CurrencyDtoMapper.toDomain(code, dto));
-        return ResponseEntityFactory.ok(null);
+        return ResponseEntityFactory.noContent();
     }
 
     /** Удалить валюту. */
@@ -59,7 +59,7 @@ public class CurrencyController {
             @PathVariable @Pattern(regexp = "^[A-Z]{3}$") String code) {
 
         service.delete(CurrencyCode.of(code));
-        return ResponseEntityFactory.ok(null);
+        return ResponseEntityFactory.noContent();
     }
 
     /** Вернуть все валюты. */

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
@@ -48,7 +48,7 @@ public class FxSpotController {
                                                     @RequestBody @Valid FxSpotUpdateDto dto) {
 
         service.update(assembler.toDomainByCode(instrumentCode, dto));
-        return ResponseEntityFactory.ok(null);
+        return ResponseEntityFactory.noContent();
     }
 
     /** Удалить инструмент. */
@@ -56,7 +56,7 @@ public class FxSpotController {
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String instrumentCode) {
 
         service.delete(instrumentCode);
-        return ResponseEntityFactory.ok(null);
+        return ResponseEntityFactory.noContent();
     }
 
     /** Вернуть все инструменты. */


### PR DESCRIPTION
## Summary
- add a factory helper for 204 No Content responses
- update currency and FX spot controllers to return 204 for update/delete operations

## Testing
- `./mvnw -pl backend test` *(fails: wget could not fetch Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed78e67f5c832da6f5d472fee5fcea