### PR TITLE
Устранено дублирование проверки валют при создании FX Spot

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -1,7 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
 import com.alligator.market.domain.instrument.type.forex.ref.currency.exception.CurrencyNotFoundException;
-import com.alligator.market.domain.instrument.type.forex.ref.currency.repository.CurrencyRepository;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotAlreadyExistsException;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
@@ -23,7 +22,6 @@ import java.util.Objects;
 public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
     private final FxSpotRepository fxSpotRepository;
-    private final CurrencyRepository currencyRepository;
 
     @Override
     @Transactional
@@ -35,18 +33,15 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
             throw new FxSpotAlreadyExistsException(fxSpot.instrumentCode());
         }
 
-        // ↓↓ Проверяем, что существуют составные валюты
-        if (!currencyRepository.existsByCode(fxSpot.base().code())) {
-            throw new CurrencyNotFoundException(fxSpot.base().code());
+        // Сохраняем инструмент (адаптер проверит, что обе валюты существуют)
+        try {
+            FxSpot created = fxSpotRepository.create(fxSpot);
+            log.info("FxSpot instrument {} created", created.instrumentCode());
+            return created;
+        } catch (CurrencyNotFoundException ex) {
+            log.warn("Unable to create FX_SPOT {}: currency is missing", fxSpot.instrumentCode(), ex);
+            throw ex;
         }
-        if (!currencyRepository.existsByCode(fxSpot.quote().code())) {
-            throw new CurrencyNotFoundException(fxSpot.quote().code());
-        }
-
-        // Сохраняем инструмент
-        FxSpot created = fxSpotRepository.create(fxSpot);
-        log.info("FxSpot instrument {} created", created.instrumentCode());
-        return created;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- убрал проверку наличия валют из сервиса use-case и передал ответственность адаптеру
- добавил предупреждающий лог при ошибке создания из-за отсутствующей валюты

## Testing
- ./mvnw -pl backend test *(не удалось из-за отсутствия доступа к Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68ed7a39ca18832da56e6202fdb162b7