### PR TITLE
Make update use cases void

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCase.java
@@ -13,8 +13,11 @@ public interface CurrencyUseCase {
     /** Создать новую валюту. */
     Currency create(Currency currency);
 
-    /** Обновить существующую валюту. */
-    Currency update(Currency currency);
+    /**
+     * Обновить существующую валюту.
+     * Возвращает управление без результата, т.к. контроллеру достаточно статуса операции.
+     */
+    void update(Currency currency);
 
     /** Удалить валюту по коду. */
     void delete(CurrencyCode code);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/service/CurrencyUseCaseImpl.java
@@ -38,7 +38,7 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
 
     @Override
     @Transactional
-    public Currency update(Currency currency) {
+    public void update(Currency currency) {
         Objects.requireNonNull(currency, "currency must not be null");
 
         // Находим валюту к обновлению
@@ -48,13 +48,12 @@ public class CurrencyUseCaseImpl implements CurrencyUseCase {
         // Если изменений нет — возвращаем текущее состояние без записи в БД
         if (current.equals(currency)) {
             log.debug("Currency {} update skipped: nothing to change", currency.code().value());
-            return current;
+            return;
         }
 
         // Уникальность имени проверит БД, адаптер распознает и замаппит в доменную ошибку
         Currency updated = currencyRepository.update(currency);
         log.info("Currency {} updated", updated.code().value());
-        return updated;
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
@@ -12,8 +12,11 @@ public interface FxSpotUseCase {
     /** Создать новый инструмент. */
     FxSpot create(FxSpot fxSpot);
 
-    /** Обновить существующий инструмент. */
-    FxSpot update(FxSpot fxSpot);
+    /**
+     * Обновить существующий инструмент.
+     * Возвращаем void, так как REST-клиенту достаточно статуса выполнения.
+     */
+    void update(FxSpot fxSpot);
 
     /** Удалить инструмент по коду. */
     void delete(String instrumentCode);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -34,7 +34,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
     @Override
     @Transactional
-    public FxSpot update(FxSpot fxSpot) {
+    public void update(FxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         // Ищем инструмент к обновлению
@@ -44,7 +44,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
         // Если изменений нет — возвращаем текущее состояние без записи в БД
         if (current.equals(fxSpot)) {
             log.debug("FX_SPOT instrument {} update skipped: nothing to change", fxSpot.instrumentCode());
-            return current;
+            return;
         }
 
         // Проверки целостности (валидация JPA/ограничения БД) и маппинг ошибок выполнит адаптер.
@@ -52,7 +52,6 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
         // в случае сбоев адаптер бросит FxSpotUpdateException.
         FxSpot updated = fxSpotRepository.update(fxSpot);
         log.info("FX_SPOT instrument {} updated", updated.instrumentCode());
-        return updated;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- switch CurrencyUseCase.update and FxSpotUseCase.update to return void and document the intent
- adjust the service implementations to exit early without returning a value when nothing changes

## Testing
- ./mvnw -pl backend test *(fails: wget could not fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68f15378f0f0832dbfc664308a856f40