### PR TITLE
Align provider constraint definition with migration

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
@@ -44,7 +44,9 @@ import java.util.Objects;
         // при отключённой — служит «живой спецификацией» для миграций.
         constraints = "min_update_interval_seconds >= 1 " +
                 "AND provider_code = upper(provider_code) " +
-                "AND provider_code NOT LIKE '% %'"
+                "AND provider_code ~ '^[A-Z0-9_.-]+$' " +
+                "AND delivery_mode IN ('PULL', 'PUSH') " +
+                "AND access_method IN ('API_POLL', 'WEBSOCKET', 'FIX_PROTOCOL')"
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // ← JPA-конструктор только для ORM в этом пакете и у наследников

--- a/backend/src/main/resources/db/migration/V4__create_market_data_provider_table.sql
+++ b/backend/src/main/resources/db/migration/V4__create_market_data_provider_table.sql
@@ -18,7 +18,6 @@ CREATE TABLE market_data_provider (
     CONSTRAINT chk_market_data_provider CHECK (
         min_update_interval_seconds >= 1
         AND provider_code = UPPER(provider_code)
-        AND provider_code NOT LIKE '% %'
         AND provider_code ~ '^[A-Z0-9_.-]+$'
         AND delivery_mode IN ('PULL', 'PUSH')
         AND access_method IN ('API_POLL', 'WEBSOCKET', 'FIX_PROTOCOL')


### PR DESCRIPTION
## Summary
- align the market data provider table check constraint in the migration and JPA entity
- drop the redundant space check and enforce delivery/access value lists consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f565d8cfa4832d9921a8aa7f8f71cd