### PR TITLE
Add provider sync DAO abstraction

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jdbc/PostgresProviderSyncDao.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jdbc/PostgresProviderSyncDao.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.catalog.persistence.jdbc;
 
 import com.alligator.market.backend.common.persistence.jpa.converter.DurationToSecondsConverter;
+import com.alligator.market.domain.provider.reconciliation.ProviderSyncDao;
 import com.alligator.market.domain.provider.reconciliation.dto.ProviderSnapshot;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -51,7 +52,7 @@ import java.util.Objects;
  * @see ProviderSnapshot
  */
 @Repository
-public class PostgresProviderSyncDao {
+public class PostgresProviderSyncDao implements ProviderSyncDao {
 
     // Spring JdbcTemplate: SQL/батчи через DataSource, управление ресурсами и перевод SQLException → DataAccessException.
     private final JdbcTemplate jdbc;
@@ -71,6 +72,7 @@ public class PostgresProviderSyncDao {
      * @param codes набор кодов провайдеров ({@code provider_code}) для удаления
      * @throws DataAccessException если БД вернула ошибку
      */
+    @Override
     public void deleteByCodes(Collection<String> codes) {
         if (codes == null || codes.isEmpty()) return;
 
@@ -99,6 +101,7 @@ public class PostgresProviderSyncDao {
      * @param snapshots коллекция снимков ({@link ProviderSnapshot}) для вставки/обновления
      * @throws DataAccessException если БД вернула ошибку
      */
+    @Override
     public void upsertAll(Collection<ProviderSnapshot> snapshots) {
         if (snapshots == null || snapshots.isEmpty()) return;
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/config/ProviderReconciliationConfiguration.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/config/ProviderReconciliationConfiguration.java
@@ -1,8 +1,9 @@
 package com.alligator.market.backend.provider.reconciliation.config;
 
 import com.alligator.market.domain.provider.repository.ProviderRepository;
-import com.alligator.market.domain.provider.reconciliation.scanner.ProviderContextScanner;
+import com.alligator.market.domain.provider.reconciliation.ProviderSyncDao;
 import com.alligator.market.domain.provider.reconciliation.ProviderSynchronizer;
+import com.alligator.market.domain.provider.reconciliation.scanner.ProviderContextScanner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,8 +17,9 @@ public class ProviderReconciliationConfiguration {
     @Bean
     public ProviderSynchronizer providerDescriptorSynchronizer(
             ProviderContextScanner scanner,
-            ProviderRepository repository
+            ProviderRepository repository,
+            ProviderSyncDao syncDao
     ) {
-        return new ProviderSynchronizer(scanner, repository);
+        return new ProviderSynchronizer(scanner, repository, syncDao);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSyncDao.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSyncDao.java
@@ -1,0 +1,21 @@
+package com.alligator.market.domain.provider.reconciliation;
+
+import com.alligator.market.domain.provider.reconciliation.dto.ProviderSnapshot;
+
+import java.util.Collection;
+
+/**
+ * Контракт DAO синхронизации провайдеров в базе данных.
+ */
+public interface ProviderSyncDao {
+
+    /**
+     * Удалить записи провайдеров по набору технических кодов.
+     */
+    void deleteByCodes(Collection<String> codes);
+
+    /**
+     * Выполнить пакетный UPSERT снимков провайдеров.
+     */
+    void upsertAll(Collection<ProviderSnapshot> snapshots);
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSynchronizer.java
@@ -18,13 +18,13 @@ public class ProviderSynchronizer {
     /* Репозиторий → извлекает коды провайдеров. */
     private final ProviderRepository repository;
 
-    /* Прямой доступ к БД для UPSERT/DELETE. */
-    private final PostgresProviderSyncDao syncDao;
+    /* Контракт синхронизации провайдеров в БД. */
+    private final ProviderSyncDao syncDao;
 
     /* Конструктор. */
     public ProviderSynchronizer(ProviderContextScanner contextScanner,
                                 ProviderRepository repository,
-                                PostgresProviderSyncDao syncDao) {
+                                ProviderSyncDao syncDao) {
         this.contextScanner = contextScanner;
         this.repository = repository;
         this.syncDao = syncDao;


### PR DESCRIPTION
## Summary
- introduce the ProviderSyncDao contract in the domain module and update ProviderSynchronizer to depend on it
- implement the contract in the backend PostgresProviderSyncDao and keep its batch logic intact
- wire the ProviderSyncDao bean into the provider reconciliation configuration

## Testing
- ./mvnw -pl domain,backend -am test *(fails: wget was unable to download Maven distribution in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f805501518832d9478021f38ce6158