### PR TITLE
Align AccessMethod parsing with FxSpotValueDate

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/AccessMethod.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/descriptor/AccessMethod.java
@@ -1,34 +1,53 @@
 package com.alligator.market.domain.provider.contract.descriptor;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
 /**
  * Список методов доступа к рыночным данным.
  */
 public enum AccessMethod {
-    /* ↓↓ Константы. */
-    API_POLL("API_POLL"),         // Метод периодического опроса API провайдера для получения рыночных данных
-    WEBSOCKET("WEBSOCKET"),       // Метод получения данных через WebSocket соединение в режиме реального времени
-    FIX_PROTOCOL("FIX_PROTOCOL"); // Метод доступа через FIX протокол для высокочастотной торговли
+    /* ↓↓ Константы: поддерживаемые методы доступа. */
+    API_POLL,    // Метод периодического опроса API провайдера для получения рыночных данных
+    WEBSOCKET,   // Метод получения данных через WebSocket соединение в режиме реального времени
+    FIX_PROTOCOL;// Метод доступа через FIX протокол для высокочастотной торговли
 
-    /* Поле enum. */
-    private final String code; // Строковое представление значения
+    /* ↓↓ Поддерживаемые коды в виде списка и единой строки (для сообщений об ошибках). */
+    private static final List<String> SUPPORTED_CODES = Arrays.stream(values()).map(Enum::name).toList();
+    private static final String SUPPORTED_CODES_JOINED = String.join(", ", SUPPORTED_CODES);
 
-    /** Конструктор enum (всегда неявно private). */
-    AccessMethod(String code) {
-        this.code = code;
-    }
-
-    /** Возвращает строковый код. */
+    /** Возвращает строковый код (= имя константы). */
     public String code() {
-        return code;
+        return name();
     }
 
-    /** Ищет значение enum по строковому коду. */
+    /** Парсит код (trim + upper-case). В ошибке подсказывает допустимые значения. */
     public static AccessMethod fromCode(String code) {
-        for (AccessMethod value : values()) {
-            if (value.code.equals(code)) {
-                return value;
-            }
+        Objects.requireNonNull(code, "code must not be null");
+
+        // Обрезаем пробелы
+        String trimmed = code.strip();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("AccessMethod code is blank");
         }
-        throw new IllegalArgumentException("Unsupported access method: " + code);
+
+        // Делаем нормализацию регистра
+        String normalized = trimmed.toUpperCase(Locale.ROOT);
+
+        // Парсинг
+        try {
+            return AccessMethod.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException(
+                    "Unsupported AccessMethod code: '" + code + "'. Supported: " + SUPPORTED_CODES_JOINED, ex);
+        }
+    }
+
+    /** Возвращает список поддерживаемых кодов (для валидации/документации). */
+    @SuppressWarnings("unused")
+    public static List<String> supportedCodes() {
+        return SUPPORTED_CODES;
     }
 }


### PR DESCRIPTION
## Summary
- update `AccessMethod` to mirror the parsing and error-handling style used by `FxSpotValueDate`
- expose normalized code parsing, supported code listing, and improved validation for access methods

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f926c10950832d9f2a92249f97639c