### PR TITLE
Align provider exceptions with domain style

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
@@ -1,10 +1,66 @@
 package com.alligator.market.domain.provider.exception;
 
+import java.util.Objects;
+
 /**
  * Обработчик для инструмента не найден.
  */
-public class HandlerNotFoundException extends RuntimeException {
-    public HandlerNotFoundException(String instrumentCode, String providerCode) {
-        super("Handler for instrument %s not found in provider %s".formatted(instrumentCode, providerCode));
+public final class HandlerNotFoundException extends RuntimeException {
+
+    private final String instrumentCode;
+    private final String providerCode;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param instrumentCode код инструмента
+     * @param providerCode код провайдера
+     * @return текст сообщения
+     */
+    private static String msg(String instrumentCode, String providerCode) {
+        String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        String pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
+        return "Handler not found (instrumentCode=" + ic + ", providerCode=" + pc + ")";
     }
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     * @param providerCode код провайдера
+     */
+    @SuppressWarnings("unused")
+    public HandlerNotFoundException(String instrumentCode, String providerCode) {
+        super(msg(instrumentCode, providerCode));
+        this.instrumentCode = instrumentCode;
+        this.providerCode = providerCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param providerCode код провайдера
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public HandlerNotFoundException(String instrumentCode, String providerCode, Throwable cause) {
+        super(msg(instrumentCode, providerCode), cause);
+        this.instrumentCode = instrumentCode;
+        this.providerCode = providerCode;
+    }
+
+    /**
+     * Возвращает код инструмента.
+     *
+     * @return код инструмента
+     */
+    public String getInstrumentCode() { return instrumentCode; }
+
+    /**
+     * Возвращает код провайдера.
+     *
+     * @return код провайдера
+     */
+    public String getProviderCode() { return providerCode; }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
@@ -1,13 +1,66 @@
 package com.alligator.market.domain.provider.exception;
 
+import java.util.Objects;
+
 /**
  * Инструмент не поддерживается обработчиком.
  */
-public class InstrumentNotSupportedException extends RuntimeException {
-    public InstrumentNotSupportedException(
-            String instrumentCode,
-            String handlerCode
-    ) {
-        super("Instrument %s not supported by handler %s".formatted(instrumentCode, handlerCode));
+public final class InstrumentNotSupportedException extends RuntimeException {
+
+    private final String instrumentCode;
+    private final String handlerCode;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param instrumentCode код инструмента
+     * @param handlerCode код обработчика
+     * @return текст сообщения
+     */
+    private static String msg(String instrumentCode, String handlerCode) {
+        String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        return "Instrument not supported (instrumentCode=" + ic + ", handlerCode=" + hc + ")";
     }
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     * @param handlerCode код обработчика
+     */
+    @SuppressWarnings("unused")
+    public InstrumentNotSupportedException(String instrumentCode, String handlerCode) {
+        super(msg(instrumentCode, handlerCode));
+        this.instrumentCode = instrumentCode;
+        this.handlerCode = handlerCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param handlerCode код обработчика
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public InstrumentNotSupportedException(String instrumentCode, String handlerCode, Throwable cause) {
+        super(msg(instrumentCode, handlerCode), cause);
+        this.instrumentCode = instrumentCode;
+        this.handlerCode = handlerCode;
+    }
+
+    /**
+     * Возвращает код инструмента.
+     *
+     * @return код инструмента
+     */
+    public String getInstrumentCode() { return instrumentCode; }
+
+    /**
+     * Возвращает код обработчика.
+     *
+     * @return код обработчика
+     */
+    public String getHandlerCode() { return handlerCode; }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
@@ -1,16 +1,111 @@
 package com.alligator.market.domain.provider.exception;
 
+import java.util.Objects;
+
 /**
  * Класс инструмента не соответствует обработчику.
  */
-public class InstrumentWrongClassException extends RuntimeException {
+public final class InstrumentWrongClassException extends RuntimeException {
+
+    private final String instrumentCode;
+    private final Class<?> instrumentClass;
+    private final String handlerCode;
+    private final Class<?> expectedClass;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param instrumentCode код инструмента
+     * @param instrumentClass фактический класс инструмента
+     * @param handlerCode код обработчика
+     * @param expectedClass ожидаемый класс инструмента
+     * @return текст сообщения
+     */
+    private static String msg(
+            String instrumentCode,
+            Class<?> instrumentClass,
+            String handlerCode,
+            Class<?> expectedClass
+    ) {
+        String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        Class<?> actual = Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
+        String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        Class<?> expected = Objects.requireNonNull(expectedClass, "expectedClass must not be null");
+        return "Instrument class mismatch (instrumentCode=" + ic + ", actualClass=" + actual.getName()
+                + ", handlerCode=" + hc + ", expectedClass=" + expected.getName() + ")";
+    }
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     * @param instrumentClass фактический класс инструмента
+     * @param handlerCode код обработчика
+     * @param expectedClass ожидаемый класс инструмента
+     */
+    @SuppressWarnings("unused")
     public InstrumentWrongClassException(
             String instrumentCode,
             Class<?> instrumentClass,
             String handlerCode,
             Class<?> expectedClass
     ) {
-        super("Instrument %s has class %s, but provider handler %s expects exact class %s"
-                .formatted(instrumentCode, instrumentClass.getName(), handlerCode, expectedClass.getName()));
+        super(msg(instrumentCode, instrumentClass, handlerCode, expectedClass));
+        this.instrumentCode = instrumentCode;
+        this.instrumentClass = instrumentClass;
+        this.handlerCode = handlerCode;
+        this.expectedClass = expectedClass;
     }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param instrumentClass фактический класс инструмента
+     * @param handlerCode код обработчика
+     * @param expectedClass ожидаемый класс инструмента
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public InstrumentWrongClassException(
+            String instrumentCode,
+            Class<?> instrumentClass,
+            String handlerCode,
+            Class<?> expectedClass,
+            Throwable cause
+    ) {
+        super(msg(instrumentCode, instrumentClass, handlerCode, expectedClass), cause);
+        this.instrumentCode = instrumentCode;
+        this.instrumentClass = instrumentClass;
+        this.handlerCode = handlerCode;
+        this.expectedClass = expectedClass;
+    }
+
+    /**
+     * Возвращает код инструмента.
+     *
+     * @return код инструмента
+     */
+    public String getInstrumentCode() { return instrumentCode; }
+
+    /**
+     * Возвращает фактический класс инструмента.
+     *
+     * @return фактический класс инструмента
+     */
+    public Class<?> getInstrumentClass() { return instrumentClass; }
+
+    /**
+     * Возвращает код обработчика.
+     *
+     * @return код обработчика
+     */
+    public String getHandlerCode() { return handlerCode; }
+
+    /**
+     * Возвращает ожидаемый класс инструмента.
+     *
+     * @return ожидаемый класс инструмента
+     */
+    public Class<?> getExpectedClass() { return expectedClass; }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderCodeDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderCodeDuplicateException.java
@@ -1,11 +1,52 @@
 package com.alligator.market.domain.provider.exception;
 
+import java.util.Objects;
+
 /**
  * Дублирование кодов провайдеров.
  */
-public class ProviderCodeDuplicateException extends RuntimeException {
+public final class ProviderCodeDuplicateException extends RuntimeException {
 
-    public ProviderCodeDuplicateException(String providerCode) {
-        super("Duplicate provider code detected: '%s'".formatted(providerCode));
+    private final String providerCode;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param providerCode код провайдера
+     * @return текст сообщения
+     */
+    private static String msg(String providerCode) {
+        String pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
+        return "Duplicate provider code detected (code=" + pc + ")";
     }
+
+    /**
+     * Создает исключение.
+     *
+     * @param providerCode код провайдера
+     */
+    @SuppressWarnings("unused")
+    public ProviderCodeDuplicateException(String providerCode) {
+        super(msg(providerCode));
+        this.providerCode = providerCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param providerCode код провайдера
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public ProviderCodeDuplicateException(String providerCode, Throwable cause) {
+        super(msg(providerCode), cause);
+        this.providerCode = providerCode;
+    }
+
+    /**
+     * Возвращает код провайдера.
+     *
+     * @return код провайдера
+     */
+    public String getProviderCode() { return providerCode; }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDisplayNameDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDisplayNameDuplicateException.java
@@ -1,11 +1,52 @@
 package com.alligator.market.domain.provider.exception;
 
+import java.util.Objects;
+
 /**
  * Дублирование отображаемых имен провайдеров.
  */
-public class ProviderDisplayNameDuplicateException extends RuntimeException {
+public final class ProviderDisplayNameDuplicateException extends RuntimeException {
 
-    public ProviderDisplayNameDuplicateException(String displayName) {
-        super("Duplicate provider display name detected: '%s'".formatted(displayName));
+    private final String displayName;
+
+    /**
+     * Формирует сообщение об ошибке.
+     *
+     * @param displayName отображаемое имя провайдера
+     * @return текст сообщения
+     */
+    private static String msg(String displayName) {
+        String dn = Objects.requireNonNull(displayName, "displayName must not be null");
+        return "Duplicate provider display name detected (displayName=" + dn + ")";
     }
+
+    /**
+     * Создает исключение.
+     *
+     * @param displayName отображаемое имя провайдера
+     */
+    @SuppressWarnings("unused")
+    public ProviderDisplayNameDuplicateException(String displayName) {
+        super(msg(displayName));
+        this.displayName = displayName;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param displayName отображаемое имя провайдера
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public ProviderDisplayNameDuplicateException(String displayName, Throwable cause) {
+        super(msg(displayName), cause);
+        this.displayName = displayName;
+    }
+
+    /**
+     * Возвращает отображаемое имя провайдера.
+     *
+     * @return отображаемое имя провайдера
+     */
+    public String getDisplayName() { return displayName; }
 }


### PR DESCRIPTION
## Summary
- update provider exception classes to follow the standardized exception structure used across the domain
- add message builders with null checks and provide getters for exception context data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f93dd20994832dbdbae4f725ee709e