### PR TITLE
Align frontend services with backend no-content responses

### DIFF
--- a/frontend/src/app/features/currency/services/currency.service.ts
+++ b/frontend/src/app/features/currency/services/currency.service.ts
@@ -35,14 +35,14 @@ export class CurrencyService {
   delete(code: string): Observable<void> {
     return this.http
       .delete<ApiResponse<void>>(`${this.baseUrl}/${code}`)
-      .pipe(map(res => res.data));
+      .pipe(map(() => undefined));
   }
 
   /* Обновить валюту по коду */
   update(code: string, dto: UpdateCurrencyDto): Observable<void> {
     return this.http
       .put<ApiResponse<void>>(`${this.baseUrl}/${code}`, dto)
-      .pipe(map(res => res.data));
+      .pipe(map(() => undefined));
   }
 
 }

--- a/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
+++ b/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
@@ -35,13 +35,13 @@ export class FxSpotService {
   delete(code: string): Observable<void> {
     return this.http
       .delete<ApiResponse<void>>(`${this.baseUrl}/${code}`)
-      .pipe(map(res => res.data));
+      .pipe(map(() => undefined));
   }
 
   /* Обновить инструмент FX_SPOT по коду */
   update(code: string, dto: FxSpotUpdateDto): Observable<void> {
     return this.http
       .patch<ApiResponse<void>>(`${this.baseUrl}/${code}`, dto)
-      .pipe(map(res => res.data));
+      .pipe(map(() => undefined));
   }
 }


### PR DESCRIPTION
## Summary
- update currency and FX spot frontend services to tolerate 204 No Content responses from backend CRUD endpoints

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f93e8c6a04832d98d5913d766ed3f6