### PR TITLE
Align FX spot frontend DTO names with backend

### DIFF
--- a/frontend/src/app/features/fx_spot/models/fx-spot-create.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot-create.model.ts
@@ -7,7 +7,7 @@ export interface FxSpotCreateDto {
   /* Код котируемой валюты */
   quoteCurrency: string;
   /* Количество знаков после запятой */
-  quoteDecimal: number;
+  defaultQuoteFractionDigits: number;
   /* Дата валютирования */
   valueDate: FxSpotValueDate;
 }

--- a/frontend/src/app/features/fx_spot/models/fx-spot-update.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot-update.model.ts
@@ -1,4 +1,4 @@
 /** DTO для обновления инструмента FX_SPOT аналогичный backend. */
 export interface FxSpotUpdateDto {
-  quoteDecimal: number;
+  defaultQuoteFractionDigits: number;
 }

--- a/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
@@ -7,7 +7,7 @@ export interface FxSpotDto {
   /* Код котируемой валюты */
   quoteCurrency: string;
   /* Количество знаков после запятой */
-  quoteDecimal: number;
+  defaultQuoteFractionDigits: number;
   /* Дата валютирования */
   valueDate: FxSpotValueDate;
 }
@@ -21,7 +21,7 @@ export interface FxSpotListItemDto {
   /* Код котируемой валюты */
   quoteCurrency: string;
   /* Количество знаков после запятой */
-  quoteDecimal: number;
+  defaultQuoteFractionDigits: number;
   /* Дата валютирования */
   valueDate: FxSpotValueDate;
 }

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
@@ -51,13 +51,13 @@
           <input
             matInput
             type="number"
-            formControlName="quoteDecimal"
+            formControlName="defaultQuoteFractionDigits"
           />
-          <mat-error *ngIf="form.controls['quoteDecimal'].hasError('required')">
+          <mat-error *ngIf="form.controls['defaultQuoteFractionDigits'].hasError('required')">
             Is required
           </mat-error>
-          <mat-error *ngIf="form.controls['quoteDecimal'].hasError('min')
-               || form.controls['quoteDecimal'].hasError('max')">
+          <mat-error *ngIf="form.controls['defaultQuoteFractionDigits'].hasError('min')
+               || form.controls['defaultQuoteFractionDigits'].hasError('max')">
             0 – 10 allowed
           </mat-error>
         </mat-form-field>
@@ -107,9 +107,9 @@
           <td mat-cell *matCellDef="let spot"> {{ spot.valueDate }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="quoteDecimal">
+        <ng-container matColumnDef="defaultQuoteFractionDigits">
           <th mat-header-cell *matHeaderCellDef> Quote Decimal</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.quoteDecimal }}</td>
+          <td mat-cell *matCellDef="let spot"> {{ spot.defaultQuoteFractionDigits }}</td>
         </ng-container>
 
         <ng-container matColumnDef="actions">

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -42,7 +42,7 @@ export class FxSpotAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['symbol', 'baseCurrency', 'quoteCurrency', 'valueDate', 'quoteDecimal', 'actions'];
+  displayed: string[] = ['symbol', 'baseCurrency', 'quoteCurrency', 'valueDate', 'defaultQuoteFractionDigits', 'actions'];
   dataSource = new MatTableDataSource<FxSpotListItemDto>([]);
 
   //=========================================
@@ -74,7 +74,7 @@ export class FxSpotAdminComponent implements OnInit {
         [Validators.required]
       ],
 
-      quoteDecimal: [
+      defaultQuoteFractionDigits: [
         4,
         [
           Validators.required,
@@ -121,7 +121,7 @@ export class FxSpotAdminComponent implements OnInit {
         this.form.reset({
           baseCurrency: '',
           quoteCurrency: '',
-          quoteDecimal: 4,
+          defaultQuoteFractionDigits: 4,
           valueDate: FxSpotValueDate.TOD
         });
         this.locked = false;
@@ -143,7 +143,7 @@ export class FxSpotAdminComponent implements OnInit {
     this.form.setValue({
       baseCurrency: spot.baseCurrency,
       quoteCurrency: spot.quoteCurrency,
-      quoteDecimal: spot.quoteDecimal,
+      defaultQuoteFractionDigits: spot.defaultQuoteFractionDigits,
       valueDate: spot.valueDate
     });
     this.form.controls['baseCurrency'].disable();
@@ -158,7 +158,7 @@ export class FxSpotAdminComponent implements OnInit {
     this.locked = true;
 
     const dto: FxSpotUpdateDto = {
-      quoteDecimal: this.form.controls['quoteDecimal'].value
+      defaultQuoteFractionDigits: this.form.controls['defaultQuoteFractionDigits'].value
     } as FxSpotUpdateDto;
 
     this.service.update(this.editCode, dto).subscribe({
@@ -185,7 +185,7 @@ export class FxSpotAdminComponent implements OnInit {
     this.form.reset({
       baseCurrency: '',
       quoteCurrency: '',
-      quoteDecimal: 4,
+      defaultQuoteFractionDigits: 4,
       valueDate: FxSpotValueDate.TOD
     });
     this.form.controls['baseCurrency'].enable();


### PR DESCRIPTION
## Summary
- rename FX spot frontend DTO properties to defaultQuoteFractionDigits to mirror backend contracts
- update the admin UI form and table bindings to use the new property name

## Testing
- npm install
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68f93effbfc4832daa1cfc72f8fdd9d8