### PR TITLE
fix(frontend): hide provider code in descriptors

### DIFF
--- a/frontend/src/app/features/provider_descriptor/models/descriptor-dto.model.ts
+++ b/frontend/src/app/features/provider_descriptor/models/descriptor-dto.model.ts
@@ -1,8 +1,14 @@
-/** DTO дескриптора провайдера, соответствующее backend-контракту DescriptorDto. */
+/**
+ * DTO дескриптора провайдера, соответствующее backend-контракту DescriptorDto.
+ * Код провайдера backend может возвращать дополнительно, но на UI он не используется.
+ */
 export interface DescriptorDto {
-  providerCode: string;
+  /* Отображаемое имя провайдера (user friendly). */
   displayName: string;
+  /* Режим доставки рыночных данных. */
   deliveryMode: string;
+  /* Метод доступа к данным. */
   accessMethod: string;
+  /* Признак поддержки массовой подписки. */
   bulkSubscription: boolean;
 }

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
@@ -7,11 +7,6 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="providerCode">
-          <th mat-header-cell *matHeaderCellDef>Code</th>
-          <td mat-cell *matCellDef="let descriptor">{{ descriptor.providerCode }}</td>
-        </ng-container>
-
         <ng-container matColumnDef="displayName">
           <th mat-header-cell *matHeaderCellDef>Provider</th>
           <td mat-cell *matCellDef="let descriptor">{{ descriptor.displayName }}</td>

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -14,9 +14,8 @@ import { DescriptorDto } from '../../models/descriptor-dto.model';
 })
 export class DescriptorListComponent implements OnInit {
 
-  /* Список колонок таблицы. */
+  /* Список колонок таблицы (код провайдера намеренно скрыт — используем только дружелюбное имя). */
   displayed: string[] = [
-    'providerCode',
     'displayName',
     'deliveryMode',
     'accessMethod',


### PR DESCRIPTION
## Summary
- drop the internal provider code from the descriptor DTO and document that only UI-friendly names are needed
- adjust the provider descriptor table to render columns for the display name and descriptor attributes only

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9491a1b28832d901f94e6684b958e