### PR TITLE
Add handler for unsupported operations

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/handler/GlobalRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/handler/GlobalRestExceptionHandler.java
@@ -96,6 +96,16 @@ public class GlobalRestExceptionHandler {
         );
     }
 
+    /** Операция не поддерживается 500. */
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnsupportedOperation(UnsupportedOperationException ex) {
+        log.error("UnsupportedOperationException: {}", ex.getMessage());
+        return ResponseEntityFactory.error(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ex.getMessage()
+        );
+    }
+
     /** Непредвиденные ошибки 500. */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex) {


### PR DESCRIPTION
## Summary
- add explicit handling for UnsupportedOperationException in the global REST exception handler to cover all thrown exceptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f94d64e098832dbd6251e1d83947c3