### PR TITLE
Добавить проверку длины кода провайдера

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/dto/ProviderSnapshot.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/dto/ProviderSnapshot.java
@@ -22,6 +22,8 @@ public record ProviderSnapshot(
         // ↓↓ Нормализуем код провайдера
         String c = code.strip(); // Обрезаем пробелы
         if (c.isEmpty()) throw new IllegalArgumentException("code must not be blank");
+        // Проверяем ограничение домена: максимум 50 символов
+        if (c.length() > 50) throw new IllegalArgumentException("code length must be less or equal to 50 characters");
         c = c.toUpperCase(Locale.ROOT); // UPPER-CASE
 
         // Присваиваем проверенное и нормализованное значение


### PR DESCRIPTION
## Summary
- добавить в ProviderSnapshot проверку ограничение длины кода провайдера 50 символами

## Testing
- mvn -pl domain test *(fails: невозможно скачать parent POM из Maven Central — 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fa1effec832d8aea4980d12760b1