### PR TITLE
Fix quote fraction digits label naming

### DIFF
--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
@@ -47,7 +47,7 @@
         </mat-form-field>
 
         <mat-form-field appearance="outline">
-          <mat-label>Quote Decimal</mat-label>
+          <mat-label>Default Quote Fraction Digits</mat-label>
           <input
             matInput
             type="number"
@@ -108,7 +108,7 @@
         </ng-container>
 
         <ng-container matColumnDef="defaultQuoteFractionDigits">
-          <th mat-header-cell *matHeaderCellDef> Quote Decimal</th>
+          <th mat-header-cell *matHeaderCellDef> Default Quote Fraction Digits</th>
           <td mat-cell *matCellDef="let spot"> {{ spot.defaultQuoteFractionDigits }}</td>
         </ng-container>
 


### PR DESCRIPTION
## Summary
- align the frontend label and table header with the `defaultQuoteFractionDigits` naming used by the backend and domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f953f1279c832d878692fd93ed6271