### PR TITLE
Add REST endpoint for market data provider catalog

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogItem.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogItem.java
@@ -1,0 +1,24 @@
+package com.alligator.market.backend.provider.catalog.service;
+
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Иммутабельная модель каталога провайдера для слоя приложения.
+ */
+public record ProviderCatalogItem(
+        String providerCode,
+        ProviderDescriptor descriptor,
+        Duration minUpdateInterval
+) {
+    public ProviderCatalogItem {
+        Objects.requireNonNull(providerCode, "providerCode must not be null");
+        Objects.requireNonNull(descriptor, "descriptor must not be null");
+        Objects.requireNonNull(minUpdateInterval, "minUpdateInterval must not be null");
+        if (providerCode.isBlank()) {
+            throw new IllegalArgumentException("providerCode must not be blank");
+        }
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogService.java
@@ -1,0 +1,56 @@
+package com.alligator.market.backend.provider.catalog.service;
+
+import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderEntity;
+import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderJpaRepository;
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Реализация сервиса {@link ProviderCatalogUseCase}.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProviderCatalogService implements ProviderCatalogUseCase {
+
+    private final ProviderJpaRepository repository;
+
+    @Override
+    public List<ProviderCatalogItem> findAll() {
+        return repository.findAll().stream()
+                .map(this::toCatalogItem)
+                .toList();
+    }
+
+    private ProviderCatalogItem toCatalogItem(ProviderEntity entity) {
+        Objects.requireNonNull(entity, "entity must not be null");
+
+        var descriptorEmbeddable = Objects.requireNonNull(
+                entity.getDescriptor(),
+                "descriptor must not be null"
+        );
+        var descriptor = new ProviderDescriptor(
+                descriptorEmbeddable.getDisplayName(),
+                descriptorEmbeddable.getDeliveryMode(),
+                descriptorEmbeddable.getAccessMethod(),
+                descriptorEmbeddable.isBulkSubscription()
+        );
+
+        var policyEmbeddable = Objects.requireNonNull(entity.getPolicy(), "policy must not be null");
+        var minUpdateInterval = Objects.requireNonNull(
+                policyEmbeddable.getMinUpdateInterval(),
+                "minUpdateInterval must not be null"
+        );
+
+        return new ProviderCatalogItem(
+                entity.getProviderCode(),
+                descriptor,
+                minUpdateInterval
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogUseCase.java
@@ -1,0 +1,12 @@
+package com.alligator.market.backend.provider.catalog.service;
+
+import java.util.List;
+
+/**
+ * Application-сервис (use case) для чтения каталога провайдеров рыночных данных.
+ */
+public interface ProviderCatalogUseCase {
+
+    /** Вернуть все провайдеры с дескрипторами и параметрами. */
+    List<ProviderCatalogItem> findAll();
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/ProviderController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/ProviderController.java
@@ -1,0 +1,34 @@
+package com.alligator.market.backend.provider.catalog.web;
+
+import com.alligator.market.backend.common.web.http.ApiResponse;
+import com.alligator.market.backend.common.web.http.ResponseEntityFactory;
+import com.alligator.market.backend.provider.catalog.service.ProviderCatalogUseCase;
+import com.alligator.market.backend.provider.catalog.web.dto.ProviderDescriptorDto;
+import com.alligator.market.backend.provider.catalog.web.dto.ProviderDescriptorDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST-контроллер каталога провайдеров рыночных данных.
+ */
+@RestController
+@RequestMapping("/api/v1/providers")
+@RequiredArgsConstructor
+public class ProviderController {
+
+    private final ProviderCatalogUseCase service;
+
+    /** Вернуть все дескрипторы провайдеров. */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ProviderDescriptorDto>>> getAll() {
+        List<ProviderDescriptorDto> list = service.findAll().stream()
+                .map(ProviderDescriptorDtoMapper::toDto)
+                .toList();
+        return ResponseEntityFactory.ok(list);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDescriptorDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDescriptorDto.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.provider.catalog.web.dto;
+
+/**
+ * DTO дескриптора провайдера для REST-контроллера.
+ */
+public record ProviderDescriptorDto(
+        String providerCode,
+        String displayName,
+        String deliveryMode,
+        String accessMethod,
+        boolean bulkSubscription,
+        long minUpdateIntervalSeconds
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDescriptorDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDescriptorDtoMapper.java
@@ -1,0 +1,33 @@
+package com.alligator.market.backend.provider.catalog.web.dto;
+
+import com.alligator.market.backend.provider.catalog.service.ProviderCatalogItem;
+import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Маппер доменных моделей каталога провайдеров в DTO.
+ */
+public final class ProviderDescriptorDtoMapper {
+
+    private ProviderDescriptorDtoMapper() {
+    }
+
+    /** Преобразовать элемент каталога в DTO. */
+    public static ProviderDescriptorDto toDto(ProviderCatalogItem item) {
+        Objects.requireNonNull(item, "item must not be null");
+
+        ProviderDescriptor descriptor = item.descriptor();
+        Duration minUpdateInterval = item.minUpdateInterval();
+
+        return new ProviderDescriptorDto(
+                item.providerCode(),
+                descriptor.displayName(),
+                descriptor.deliveryMode().name(),
+                descriptor.accessMethod().name(),
+                descriptor.bulkSubscription(),
+                minUpdateInterval.getSeconds()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add application service for reading provider catalog data
- expose `/api/v1/providers` REST endpoint returning provider descriptor DTOs

## Testing
- ./mvnw -pl backend test *(fails: unable to download Maven distribution because the environment blocks network access)*

------
https://chatgpt.com/codex/tasks/task_e_68fa48d74fa8832d84e7af7a3a8a685d