### PR TITLE
Fix ResponseEntityFactory no-content contract

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/http/ResponseEntityFactory.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/http/ResponseEntityFactory.java
@@ -23,8 +23,11 @@ public final class ResponseEntityFactory {
                 .body(ApiResponse.build(data, "created"));
     }
 
-    /** Успех: частный случай - 204 No Content. */
-    public static ResponseEntity<ApiResponse<Void>> noContent() {
+    /**
+     * Успех: частный случай - 204 No Content.
+     * Возвращаем ответ без конверта, потому что тело должно отсутствовать.
+     */
+    public static ResponseEntity<Void> noContent() {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/ref/currency/catalog/web/CurrencyController.java
@@ -45,7 +45,7 @@ public class CurrencyController {
 
     /** Обновить валюту. */
     @PutMapping("/{code}")
-    public ResponseEntity<ApiResponse<Void>> update(
+    public ResponseEntity<Void> update(
             @PathVariable @Pattern(regexp = "^[A-Z]{3}$") String code,
             @RequestBody @Valid UpdateCurrencyDto dto) {
 
@@ -55,7 +55,7 @@ public class CurrencyController {
 
     /** Удалить валюту. */
     @DeleteMapping("/{code}")
-    public ResponseEntity<ApiResponse<Void>> delete(
+    public ResponseEntity<Void> delete(
             @PathVariable @Pattern(regexp = "^[A-Z]{3}$") String code) {
 
         service.delete(CurrencyCode.of(code));

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
@@ -44,8 +44,8 @@ public class FxSpotController {
 
     /** Обновить инструмент. */
     @PatchMapping("/{instrumentCode}")
-    public ResponseEntity<ApiResponse<Void>> update(@PathVariable String instrumentCode,
-                                                    @RequestBody @Valid FxSpotUpdateDto dto) {
+    public ResponseEntity<Void> update(@PathVariable String instrumentCode,
+                                       @RequestBody @Valid FxSpotUpdateDto dto) {
 
         service.update(assembler.toDomainByCode(instrumentCode, dto));
         return ResponseEntityFactory.noContent();
@@ -53,7 +53,7 @@ public class FxSpotController {
 
     /** Удалить инструмент. */
     @DeleteMapping("/{instrumentCode}")
-    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String instrumentCode) {
+    public ResponseEntity<Void> delete(@PathVariable String instrumentCode) {
 
         service.delete(instrumentCode);
         return ResponseEntityFactory.noContent();


### PR DESCRIPTION
## Summary
- return plain `ResponseEntity<Void>` for 204 responses so 204 replies remain empty
- adjust FX spot and currency controllers to use the new no-content contract

## Testing
- ./mvnw -pl backend -am -DskipTests package *(fails: unable to download Maven distribution in container)*

------
https://chatgpt.com/codex/tasks/task_e_69063c1d4858832dbd371ceac8c4725d