### PR TITLE
feat: show provider min update interval

### DIFF
--- a/frontend/src/app/features/provider_descriptor/models/descriptor-dto.model.ts
+++ b/frontend/src/app/features/provider_descriptor/models/descriptor-dto.model.ts
@@ -11,4 +11,6 @@ export interface DescriptorDto {
   accessMethod: string;
   /* Признак поддержки массовой подписки. */
   bulkSubscription: boolean;
+  /* Минимальный интервал обновления данных в секундах. */
+  minUpdateIntervalSeconds: number;
 }

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
@@ -29,6 +29,13 @@
           </td>
         </ng-container>
 
+        <ng-container matColumnDef="minUpdateIntervalSeconds">
+          <th mat-header-cell *matHeaderCellDef>Min Update Interval (s)</th>
+          <td mat-cell *matCellDef="let descriptor">
+            {{ descriptor.minUpdateIntervalSeconds }}
+          </td>
+        </ng-container>
+
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>
         <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
       </table>

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -19,7 +19,8 @@ export class DescriptorListComponent implements OnInit {
     'displayName',
     'deliveryMode',
     'accessMethod',
-    'bulkSubscription'
+    'bulkSubscription',
+    'minUpdateIntervalSeconds'
   ];
   /* Источник данных для таблицы. */
   dataSource = new MatTableDataSource<DescriptorDto>([]);


### PR DESCRIPTION
## Summary
- add the minUpdateIntervalSeconds field to the provider descriptor DTO used on the frontend
- display the minimum update interval column in the provider descriptor list table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690cff7a2060832dad6bcdaa90b3cb6a