### PR TITLE
Rename provider descriptor DTO and align contracts

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDto.java
@@ -4,7 +4,6 @@ package com.alligator.market.backend.provider.catalog.web.dto;
  * DTO дескриптора провайдера для REST-контроллера.
  */
 public record ProviderDto(
-        String providerCode,
         String displayName,
         String deliveryMode,
         String accessMethod,

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDtoMapper.java
@@ -22,7 +22,6 @@ public final class ProviderDtoMapper {
         Duration minUpdateInterval = item.minUpdateInterval();
 
         return new ProviderDto(
-                item.providerCode(),
                 descriptor.displayName(),
                 descriptor.deliveryMode().name(),
                 descriptor.accessMethod().name(),

--- a/frontend/src/app/features/provider_descriptor/models/provider-dto.model.ts
+++ b/frontend/src/app/features/provider_descriptor/models/provider-dto.model.ts
@@ -1,8 +1,7 @@
 /**
- * DTO дескриптора провайдера, соответствующее backend-контракту DescriptorDto.
- * Код провайдера backend может возвращать дополнительно, но на UI он не используется.
+ * DTO провайдера, соответствующее backend-контракту ProviderDto.
  */
-export interface DescriptorDto {
+export interface ProviderDto {
   /* Отображаемое имя провайдера (user friendly). */
   displayName: string;
   /* Режим доставки рыночных данных. */

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
 import { ProviderDescriptorService } from '../../services/provider-descriptor.service';
-import { DescriptorDto } from '../../models/descriptor-dto.model';
+import { ProviderDto } from '../../models/provider-dto.model';
 
 @Component({
   selector: 'app-provider-descriptor-list',
@@ -14,7 +14,7 @@ import { DescriptorDto } from '../../models/descriptor-dto.model';
 })
 export class DescriptorListComponent implements OnInit {
 
-  /* Список колонок таблицы (код провайдера намеренно скрыт — используем только дружелюбное имя). */
+  /* Список колонок таблицы (код провайдера намеренно скрыт на уровне API — используем только дружелюбное имя). */
   displayed: string[] = [
     'displayName',
     'deliveryMode',
@@ -23,7 +23,7 @@ export class DescriptorListComponent implements OnInit {
     'minUpdateIntervalSeconds'
   ];
   /* Источник данных для таблицы. */
-  dataSource = new MatTableDataSource<DescriptorDto>([]);
+  dataSource = new MatTableDataSource<ProviderDto>([]);
 
   constructor(private readonly service: ProviderDescriptorService) {}
 

--- a/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
+++ b/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 import { ApiResponse } from '../../../shared/api-response.model';
-import { DescriptorDto } from '../models/descriptor-dto.model';
+import { ProviderDto } from '../models/provider-dto.model';
 
 /* Сервис для чтения дескрипторов провайдеров. */
 @Injectable({
@@ -16,9 +16,9 @@ export class ProviderDescriptorService {
   private readonly baseUrl = '/api/v1/providers';
 
   /* Получить все дескрипторы провайдеров. */
-  list(): Observable<DescriptorDto[]> {
+  list(): Observable<ProviderDto[]> {
     return this.http
-      .get<ApiResponse<DescriptorDto[]>>(this.baseUrl)
+      .get<ApiResponse<ProviderDto[]>>(this.baseUrl)
       .pipe(map(res => res.data));
   }
 }


### PR DESCRIPTION
## Summary
- rename the frontend provider descriptor DTO to ProviderDto and update usages
- drop the providerCode field from the backend ProviderDto contract
- ensure the provider list view and service use the updated DTO shape

## Testing
- `./mvnw -pl backend test` *(fails: wget could not download Maven binary due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_690d08cb647c832da21c9a24138883c8