### PR TITLE
Implement standardized API response envelope

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/handler/ApplicationExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.common.web.handler;
 
 import com.alligator.market.backend.common.web.http.ApiResponse;
+import com.alligator.market.backend.common.web.http.ErrorCode;
 import com.alligator.market.backend.common.web.http.ResponseEntityFactory;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.exception.CurrencyAlreadyExistsException;
 import com.alligator.market.domain.instrument.type.forex.ref.currency.exception.CurrencyCreateException;
@@ -30,158 +31,111 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /**
- * Централизованный обработчик доменных исключений, относящихся к бизнес-логике приложения.
+ * Централизованный обработчик доменных исключений приложения.
  */
 @Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice
 public class ApplicationExceptionHandler {
 
-    /** Валюта с таким кодом уже существует. */
+    /** Валюта с таким кодом уже существует → 409. */
     @ExceptionHandler(CurrencyAlreadyExistsException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyAlreadyExists(CurrencyAlreadyExistsException ex) {
-        return warn(HttpStatus.CONFLICT, ex);
+    public ResponseEntity<ApiResponse<Void>> currencyAlreadyExists(CurrencyAlreadyExistsException ex) {
+        log.warn("Currency already exists: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(ErrorCode.CURRENCY_ALREADY_EXISTS.name(), ex.getMessage());
     }
 
-    /** Валюта с таким именем уже существует. */
+    /** Валюта с таким именем уже существует → 409. */
     @ExceptionHandler(CurrencyNameDuplicateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyNameDuplicate(CurrencyNameDuplicateException ex) {
-        return warn(HttpStatus.CONFLICT, ex);
+    public ResponseEntity<ApiResponse<Void>> currencyNameDuplicate(CurrencyNameDuplicateException ex) {
+        log.warn("Currency name duplicate: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(ErrorCode.CURRENCY_NAME_DUPLICATE.name(), ex.getMessage());
     }
 
-    /** Валюта используется в инструментах FX_SPOT. */
+    /** Валюта используется в инструментах FX_SPOT → 409. */
     @ExceptionHandler(CurrencyUsedInFxSpotException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyUsedInFxSpot(CurrencyUsedInFxSpotException ex) {
-        return warn(HttpStatus.CONFLICT, ex);
+    public ResponseEntity<ApiResponse<Void>> currencyUsedInFxSpot(CurrencyUsedInFxSpotException ex) {
+        log.warn("Currency used in FX Spot: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(ErrorCode.CURRENCY_USED_IN_FX_SPOT.name(), ex.getMessage());
     }
 
-    /** Ошибка создания валюты. */
-    @ExceptionHandler(CurrencyCreateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyCreate(CurrencyCreateException ex) {
-        return error(ex);
-    }
-
-    /** Ошибка обновления валюты. */
-    @ExceptionHandler(CurrencyUpdateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyUpdate(CurrencyUpdateException ex) {
-        return error(ex);
-    }
-
-    /** Ошибка удаления валюты. */
-    @ExceptionHandler(CurrencyDeleteException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyDelete(CurrencyDeleteException ex) {
-        return error(ex);
-    }
-
-    /** Валюта не найдена. */
+    /** Валюта не найдена → 404. */
     @ExceptionHandler(CurrencyNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCurrencyNotFound(CurrencyNotFoundException ex) {
-        return notFound(ex);
+    public ResponseEntity<ApiResponse<Void>> currencyNotFound(CurrencyNotFoundException ex) {
+        log.warn("Currency not found: {}", ex.getMessage());
+        return ResponseEntityFactory.notFound(ErrorCode.CURRENCY_NOT_FOUND.name(), ex.getMessage());
     }
 
-    /** Дублирование кода провайдера. */
-    @ExceptionHandler(ProviderCodeDuplicateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleProviderCodeDuplicate(ProviderCodeDuplicateException ex) {
-        return warn(HttpStatus.CONFLICT, ex);
-    }
-
-    /** Дублирование отображаемого имени провайдера. */
-    @ExceptionHandler(ProviderDisplayNameDuplicateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleProviderDisplayNameDuplicate(ProviderDisplayNameDuplicateException ex) {
-        return warn(HttpStatus.CONFLICT, ex);
-    }
-
-    /** Инструмент FX_SPOT уже существует. */
+    /** Валюта уже используется при создании FX_SPOT → 409. */
     @ExceptionHandler(FxSpotAlreadyExistsException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFxSpotAlreadyExists(FxSpotAlreadyExistsException ex) {
-        return warn(HttpStatus.CONFLICT, ex);
+    public ResponseEntity<ApiResponse<Void>> fxSpotAlreadyExists(FxSpotAlreadyExistsException ex) {
+        log.warn("FX Spot already exists: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(ErrorCode.FX_SPOT_ALREADY_EXISTS.name(), ex.getMessage());
     }
 
-    /** Ошибка создания инструмента FX_SPOT. */
-    @ExceptionHandler(FxSpotCreateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFxSpotCreate(FxSpotCreateException ex) {
-        return error(ex);
-    }
-
-    /** Ошибка обновления инструмента FX_SPOT. */
-    @ExceptionHandler(FxSpotUpdateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFxSpotUpdate(FxSpotUpdateException ex) {
-        return error(ex);
-    }
-
-    /** Ошибка удаления инструмента FX_SPOT. */
-    @ExceptionHandler(FxSpotDeleteException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFxSpotDelete(FxSpotDeleteException ex) {
-        return error(ex);
-    }
-
-    /** Инструмент FX_SPOT не найден. */
+    /** Инструмент FX_SPOT не найден → 404. */
     @ExceptionHandler(FxSpotNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFxSpotNotFound(FxSpotNotFoundException ex) {
-        return notFound(ex);
+    public ResponseEntity<ApiResponse<Void>> fxSpotNotFound(FxSpotNotFoundException ex) {
+        log.warn("FX Spot not found: {}", ex.getMessage());
+        return ResponseEntityFactory.notFound(ErrorCode.FX_SPOT_NOT_FOUND.name(), ex.getMessage());
     }
 
-    /** Базовая и котируемая валюты совпадают. */
+    /** Указаны одинаковые валюты для FX_SPOT → 400. */
     @ExceptionHandler(FxSpotSameCurrenciesException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFxSpotSameCurrencies(FxSpotSameCurrenciesException ex) {
-        return warn(HttpStatus.BAD_REQUEST, ex);
+    public ResponseEntity<ApiResponse<Void>> fxSpotSameCurrencies(FxSpotSameCurrenciesException ex) {
+        log.warn("FX Spot same currencies: {}", ex.getMessage());
+        return ResponseEntityFactory.badRequest(ErrorCode.FX_SPOT_SAME_CURRENCIES.name(), ex.getMessage());
     }
 
-    /** Тип инструмента не поддерживается провайдером. */
+    /** Инструмент не поддерживается провайдером → 400. */
     @ExceptionHandler(InstrumentNotSupportedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInstrumentNotSupported(InstrumentNotSupportedException ex) {
-        return warn(HttpStatus.BAD_REQUEST, ex);
+    public ResponseEntity<ApiResponse<Void>> instrumentNotSupported(InstrumentNotSupportedException ex) {
+        log.warn("Instrument not supported: {}", ex.getMessage());
+        return ResponseEntityFactory.badRequest(ErrorCode.INSTRUMENT_NOT_SUPPORTED.name(), ex.getMessage());
     }
 
-    /** Обработчик для инструмента не найден. */
+    /** Обработчик инструмента не найден → 404. */
     @ExceptionHandler(HandlerNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleHandlerNotFound(HandlerNotFoundException ex) {
-        return warn(HttpStatus.BAD_REQUEST, ex);
+    public ResponseEntity<ApiResponse<Void>> handlerNotFound(HandlerNotFoundException ex) {
+        log.warn("Handler not found: {}", ex.getMessage());
+        return ResponseEntityFactory.notFound(ErrorCode.HANDLER_NOT_FOUND.name(), ex.getMessage());
     }
 
-    /** Класс инструмента не соответствует ожиданиям обработчика. */
-    @ExceptionHandler(InstrumentWrongClassException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInstrumentWrongClass(InstrumentWrongClassException ex) {
-        return error(ex);
+    /** Некорректный класс или тип инструмента → 400. */
+    @ExceptionHandler({InstrumentWrongClassException.class, InstrumentWrongTypeException.class})
+    public ResponseEntity<ApiResponse<Void>> instrumentWrong(RuntimeException ex) {
+        log.warn("Instrument mismatch: {}", ex.getMessage());
+        String code = ex instanceof InstrumentWrongClassException
+                ? ErrorCode.INSTRUMENT_WRONG_CLASS.name()
+                : ErrorCode.INSTRUMENT_WRONG_TYPE.name();
+        return ResponseEntityFactory.badRequest(code, ex.getMessage());
     }
 
-    /** Тип инструмента не соответствует ожиданиям обработчика. */
-    @ExceptionHandler(InstrumentWrongTypeException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInstrumentWrongType(InstrumentWrongTypeException ex) {
-        return error(ex);
+    /** Дублирование кода провайдера → 409. */
+    @ExceptionHandler(ProviderCodeDuplicateException.class)
+    public ResponseEntity<ApiResponse<Void>> providerCodeDuplicate(ProviderCodeDuplicateException ex) {
+        log.warn("Provider code duplicate: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(ErrorCode.PROVIDER_CODE_DUPLICATE.name(), ex.getMessage());
     }
 
-    /**
-     * Формирует ответ с уровнем логирования WARN.
-     *
-     * @param status HTTP-статус
-     * @param ex     доменное исключение
-     * @return готовый HTTP-ответ
-     */
-    private ResponseEntity<ApiResponse<Void>> warn(HttpStatus status, RuntimeException ex) {
-        log.warn("{}: {}", ex.getClass().getSimpleName(), ex.getMessage());
-        return ResponseEntityFactory.error(status, ex.getMessage());
+    /** Дублирование отображаемого имени провайдера → 409. */
+    @ExceptionHandler(ProviderDisplayNameDuplicateException.class)
+    public ResponseEntity<ApiResponse<Void>> providerDisplayNameDuplicate(ProviderDisplayNameDuplicateException ex) {
+        log.warn("Provider display name duplicate: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(ErrorCode.PROVIDER_DISPLAY_NAME_DUPLICATE.name(), ex.getMessage());
     }
 
-    /**
-     * Формирует ответ 404 Not Found с уровнем WARN.
-     *
-     * @param ex доменное исключение
-     * @return готовый HTTP-ответ
-     */
-    private ResponseEntity<ApiResponse<Void>> notFound(RuntimeException ex) {
-        log.warn("{}: {}", ex.getClass().getSimpleName(), ex.getMessage());
-        return ResponseEntityFactory.notFound(ex.getMessage());
-    }
-
-    /**
-     * Формирует ответ с уровнем логирования ERROR и стеком исключения.
-     *
-     * @param ex доменное исключение
-     * @return готовый HTTP-ответ
-     */
-    private ResponseEntity<ApiResponse<Void>> error(RuntimeException ex) {
-        log.error("{}: {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
-        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    /** Технические ошибки доменных операций → 500. */
+    @ExceptionHandler({
+            CurrencyCreateException.class,
+            CurrencyUpdateException.class,
+            CurrencyDeleteException.class,
+            FxSpotCreateException.class,
+            FxSpotUpdateException.class,
+            FxSpotDeleteException.class
+    })
+    public ResponseEntity<ApiResponse<Void>> domainTechnicalError(RuntimeException ex) {
+        log.error("Domain operation failed: {}", ex.getMessage(), ex);
+        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.UNEXPECTED_ERROR.name(), ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/common/web/handler/GlobalRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/handler/GlobalRestExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.common.web.handler;
 
 import com.alligator.market.backend.common.web.http.ApiResponse;
+import com.alligator.market.backend.common.web.http.ErrorCode;
 import com.alligator.market.backend.common.web.http.ResponseEntityFactory;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -15,104 +16,67 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.stream.Collectors;
 
 /**
- * Глобальный обработчик исключений REST-слоя.
+ * Глобальный обработчик технических исключений REST-слоя.
  */
 @Slf4j
 @RestControllerAdvice
 public class GlobalRestExceptionHandler {
 
-    /** Ошибки валидации тела запроса (@Valid) 422. */
+    /** Ошибки валидации тела запроса (@Valid) → 422. */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        // Собираем все ошибки валидации в одно сообщение
         String message = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .map(error -> error.getField() + " " + error.getDefaultMessage())
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.joining("; "));
-
-        log.warn("MethodArgumentNotValidException: {}", message);
-        return ResponseEntityFactory.error(
-                HttpStatus.UNPROCESSABLE_ENTITY,
-                message
-        );
+        log.warn("Validation failed: {}", message);
+        return ResponseEntityFactory.unprocessableEntity(ErrorCode.VALIDATION_ERROR.name(), message);
     }
 
-    /** Ошибки валидации параметров (@Validated) 400. */
+    /** Ошибки валидации параметров (@Validated) → 400. */
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(ConstraintViolationException ex) {
-        // Собираем все ошибки валидации в одно сообщение
         String message = ex.getConstraintViolations()
                 .stream()
-                .map(v -> v.getPropertyPath() + " " + v.getMessage())
+                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
                 .collect(Collectors.joining("; "));
-
-        log.warn("ConstraintViolationException: {}", message);
-        return ResponseEntityFactory.error(
-                HttpStatus.BAD_REQUEST,
-                message
-        );
+        log.warn("Constraint violation: {}", message);
+        return ResponseEntityFactory.badRequest(ErrorCode.BAD_ARGUMENT.name(), message);
     }
 
-    /** Тело запроса не удалось распарсить 400. */
+    /** Тело запроса не удалось распарсить → 400. */
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
-        Throwable cause = ex.getMostSpecificCause();
-        String message = cause.getMessage() != null ? cause.getMessage() : ex.getMessage();
-        log.warn("HttpMessageNotReadableException: {}", message);
-        return ResponseEntityFactory.error(
-                HttpStatus.BAD_REQUEST,
-                "Request body is not readable"
-        );
+        log.warn("Malformed JSON: {}", ex.getMessage());
+        return ResponseEntityFactory.badRequest(ErrorCode.MALFORMED_JSON.name(), "Malformed JSON");
     }
 
-    /** Ошибки клиента при передаче аргументов 400. */
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
-        log.warn("IllegalArgumentException: {}", ex.getMessage());
-        return ResponseEntityFactory.error(
-                HttpStatus.BAD_REQUEST,
-                ex.getMessage()
-        );
-    }
-
-    /** Конфликт целостности данных 409. */
+    /** Нарушение целостности данных → 409. */
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
-        log.warn("DataIntegrityViolationException: {}", ex.getMessage());
-        return ResponseEntityFactory.error(
-                HttpStatus.CONFLICT,
-                "Resource already exists or violates integrity constraints"
-        );
+        log.warn("Data integrity violation: {}", ex.getMostSpecificCause().getMessage());
+        return ResponseEntityFactory.conflict(ErrorCode.DATA_INTEGRITY_VIOLATION.name(), "Data integrity violation");
     }
 
-    /** Некорректное состояние сервера 500. */
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalState(IllegalStateException ex) {
-        log.error("IllegalStateException: {}", ex.getMessage());
-        return ResponseEntityFactory.error(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                ex.getMessage()
-        );
+    /** Некорректно переданные аргументы → 400. */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        log.warn("Illegal argument: {}", ex.getMessage());
+        return ResponseEntityFactory.badRequest(ErrorCode.BAD_ARGUMENT.name(), ex.getMessage());
     }
 
-    /** Операция не поддерживается 500. */
-    @ExceptionHandler(UnsupportedOperationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleUnsupportedOperation(UnsupportedOperationException ex) {
-        log.error("UnsupportedOperationException: {}", ex.getMessage());
-        return ResponseEntityFactory.error(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                ex.getMessage()
-        );
+    /** Неподдерживаемые операции → 500. */
+    @ExceptionHandler({IllegalStateException.class, UnsupportedOperationException.class})
+    public ResponseEntity<ApiResponse<Void>> handleIllegalState(RuntimeException ex) {
+        log.error("Illegal state: {}", ex.getMessage(), ex);
+        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.UNEXPECTED_ERROR.name(), ex.getMessage());
     }
 
-    /** Непредвиденные ошибки 500. */
+    /** Непредвиденные ошибки → 500. */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex) {
         log.error("Unhandled exception", ex);
-        return ResponseEntityFactory.error(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                "Unexpected server error"
-        );
+        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.UNEXPECTED_ERROR.name(), "Unexpected server error");
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/common/web/http/ApiResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/http/ApiResponse.java
@@ -1,17 +1,28 @@
 package com.alligator.market.backend.common.web.http;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.Instant;
 
 /**
- * Простой унифицированный конверт для любых API REST ответов.
+ * Унифицированный конверт REST-ответов.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(
         T data,
+        boolean success,
+        String errorCode,
         String message,
         Instant timestamp
 ) {
-    /** Статическая «фабрика» для создания конверта. */
-    public static <T> ApiResponse<T> build(T data, String message) {
-        return new ApiResponse<>(data, message, Instant.now());
+
+    /** Фабрика успешного ответа. */
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(data, true, null, "success", Instant.now());
+    }
+
+    /** Фабрика ошибочного ответа. */
+    public static ApiResponse<Void> error(String code, String message) {
+        return new ApiResponse<>(null, false, code, message, Instant.now());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/common/web/http/ErrorCode.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/http/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.alligator.market.backend.common.web.http;
+
+/**
+ * Перечень стабильных кодов ошибок для фронта.
+ */
+public enum ErrorCode {
+    /* Общие ошибки */
+    UNEXPECTED_ERROR,
+    MALFORMED_JSON,
+    BAD_ARGUMENT,
+    VALIDATION_ERROR,
+    DATA_INTEGRITY_VIOLATION,
+
+    /* Провайдеры */
+    PROVIDER_CODE_DUPLICATE,
+    PROVIDER_DISPLAY_NAME_DUPLICATE,
+    HANDLER_NOT_FOUND,
+    INSTRUMENT_NOT_SUPPORTED,
+    INSTRUMENT_WRONG_CLASS,
+    INSTRUMENT_WRONG_TYPE,
+
+    /* Валюты */
+    CURRENCY_ALREADY_EXISTS,
+    CURRENCY_NAME_DUPLICATE,
+    CURRENCY_NOT_FOUND,
+    CURRENCY_USED_IN_FX_SPOT,
+
+    /* FX Spot */
+    FX_SPOT_ALREADY_EXISTS,
+    FX_SPOT_NOT_FOUND,
+    FX_SPOT_SAME_CURRENCIES
+}

--- a/backend/src/main/java/com/alligator/market/backend/common/web/http/ResponseEntityFactory.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/http/ResponseEntityFactory.java
@@ -6,39 +6,52 @@ import org.springframework.http.ResponseEntity;
 import java.net.URI;
 
 /**
- * Фабрика готовых унифицированных HTTP-ответов, использующих конверт {@link ApiResponse}.
+ * Фабрика готовых HTTP-ответов, использующих конверт {@link ApiResponse}.
  */
 public final class ResponseEntityFactory {
 
-    private ResponseEntityFactory() {}
+    private ResponseEntityFactory() {
+    }
 
     /** Успех: 200 OK. */
     public static <T> ResponseEntity<ApiResponse<T>> ok(T data) {
-        return ResponseEntity.ok(ApiResponse.build(data, "success"));
+        return ResponseEntity.ok(ApiResponse.ok(data));
     }
 
-    /** Успех: частный случай - 201 Created + Location. */
+    /** Успех: 201 Created. */
     public static <T> ResponseEntity<ApiResponse<T>> created(URI location, T data) {
-        return ResponseEntity.created(location)
-                .body(ApiResponse.build(data, "created"));
+        return ResponseEntity.created(location).body(ApiResponse.ok(data));
     }
 
     /**
-     * Успех: частный случай - 204 No Content.
-     * Возвращаем ответ без конверта, потому что тело должно отсутствовать.
+     * Успех: 204 No Content без тела.
      */
     public static ResponseEntity<Void> noContent() {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    /** Ошибка: общая. */
-    public static ResponseEntity<ApiResponse<Void>> error(HttpStatus status, String message) {
-        return ResponseEntity.status(status)
-                .body(ApiResponse.build(null, message));
+    /** Ошибка: общий конструктор. */
+    public static ResponseEntity<ApiResponse<Void>> error(HttpStatus status, String code, String message) {
+        return ResponseEntity.status(status).body(ApiResponse.error(code, message));
     }
 
-    /** Ошибка: частный случай - 404 Not Found. */
-    public static ResponseEntity<ApiResponse<Void>> notFound(String message) {
-        return error(HttpStatus.NOT_FOUND, message);
+    /** Ошибка: 400 Bad Request. */
+    public static ResponseEntity<ApiResponse<Void>> badRequest(String code, String message) {
+        return error(HttpStatus.BAD_REQUEST, code, message);
+    }
+
+    /** Ошибка: 404 Not Found. */
+    public static ResponseEntity<ApiResponse<Void>> notFound(String code, String message) {
+        return error(HttpStatus.NOT_FOUND, code, message);
+    }
+
+    /** Ошибка: 409 Conflict. */
+    public static ResponseEntity<ApiResponse<Void>> conflict(String code, String message) {
+        return error(HttpStatus.CONFLICT, code, message);
+    }
+
+    /** Ошибка: 422 Unprocessable Entity. */
+    public static ResponseEntity<ApiResponse<Void>> unprocessableEntity(String code, String message) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, code, message);
     }
 }

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,13 +1,19 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 import { routes } from './app.routes';
-import {provideHttpClient} from '@angular/common/http';
+import { ApiEnvelopeInterceptor } from './shared/http/api-envelope.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient()
+    provideHttpClient(withInterceptorsFromDi()),
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: ApiEnvelopeInterceptor,
+      multi: true
+    }
   ]
 };

--- a/frontend/src/app/features/currency/services/currency.service.ts
+++ b/frontend/src/app/features/currency/services/currency.service.ts
@@ -1,48 +1,47 @@
 import { Injectable } from '@angular/core';
-import {CurrencyDto} from '../models/currency.model';
-import {map, Observable} from 'rxjs';
-import {HttpClient} from '@angular/common/http';
-import {ApiResponse} from '../../../shared/api-response.model';
-import {UpdateCurrencyDto} from "../models/currency-update.model";
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
 
-/* Сервис для взаимодействия с API по работе с валютами */
+import { CurrencyDto } from '../models/currency.model';
+import { ApiResponse } from '../../../shared/api/api-response.model';
+import { UpdateCurrencyDto } from '../models/currency-update.model';
+
+/* Сервис для взаимодействия с API по работе с валютами. */
 @Injectable({
   providedIn: 'root'
 })
 export class CurrencyService {
 
-
   constructor(private http: HttpClient) { }
 
-  /* Базовый URL (через proxy уйдёт на Spring) */
+  /* Базовый URL (через proxy уйдёт на Spring). */
   private readonly baseUrl = '/api/v1/currencies';
 
-  /* Получить список всех валют */
+  /* Получить список всех валют. */
   list(): Observable<CurrencyDto[]> {
     return this.http
       .get<ApiResponse<CurrencyDto[]>>(this.baseUrl)
-      .pipe(map(res => res.data));
+      .pipe(map(res => res.data ?? []));
   }
 
-  /* Добавить валюту, backend вернёт её код */
+  /* Добавить валюту, backend вернёт её код. */
   add(dto: CurrencyDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
-      .pipe(map(res => res.data));
+      .pipe(map(res => res.data ?? ''));
   }
 
-  /* Удалить валюту по коду */
+  /* Удалить валюту по коду. */
   delete(code: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${code}`)
+      .delete<void>(`${this.baseUrl}/${code}`)
       .pipe(map(() => undefined));
   }
 
-  /* Обновить валюту по коду */
+  /* Обновить валюту по коду. */
   update(code: string, dto: UpdateCurrencyDto): Observable<void> {
     return this.http
-      .put<ApiResponse<void>>(`${this.baseUrl}/${code}`, dto)
+      .put<void>(`${this.baseUrl}/${code}`, dto)
       .pipe(map(() => undefined));
   }
-
 }

--- a/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
+++ b/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
-import { ApiResponse } from '../../../shared/api-response.model';
+
+import { ApiResponse } from '../../../shared/api/api-response.model';
 import { FxSpotCreateDto } from '../models/fx-spot-create.model';
 import { FxSpotListItemDto } from '../models/fx-spot.model';
 import { FxSpotUpdateDto } from '../models/fx-spot-update.model';
 
-/* Сервис для взаимодействия с API по работе с инструментами FX_SPOT */
+/* Сервис для взаимодействия с API по работе с инструментами FX_SPOT. */
 @Injectable({
   providedIn: 'root'
 })
@@ -14,34 +15,34 @@ export class FxSpotService {
 
   constructor(private http: HttpClient) { }
 
-  /* Базовый URL (через proxy уйдёт на Spring) */
+  /* Базовый URL (через proxy уйдёт на Spring). */
   private readonly baseUrl = '/api/v1/fx-spot';
 
-  /* Получить список всех инструментов FX_SPOT */
+  /* Получить список всех инструментов FX_SPOT. */
   list(): Observable<FxSpotListItemDto[]> {
     return this.http
       .get<ApiResponse<FxSpotListItemDto[]>>(this.baseUrl)
-      .pipe(map(res => res.data));
+      .pipe(map(res => res.data ?? []));
   }
 
-  /* Добавить инструмент FX_SPOT, backend вернёт его код */
+  /* Добавить инструмент FX_SPOT, backend вернёт его код. */
   add(dto: FxSpotCreateDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
-      .pipe(map(res => res.data));
+      .pipe(map(res => res.data ?? ''));
   }
 
-  /* Удалить инструмент FX_SPOT по коду */
+  /* Удалить инструмент FX_SPOT по коду. */
   delete(code: string): Observable<void> {
     return this.http
-      .delete<ApiResponse<void>>(`${this.baseUrl}/${code}`)
+      .delete<void>(`${this.baseUrl}/${code}`)
       .pipe(map(() => undefined));
   }
 
-  /* Обновить инструмент FX_SPOT по коду */
+  /* Обновить инструмент FX_SPOT по коду. */
   update(code: string, dto: FxSpotUpdateDto): Observable<void> {
     return this.http
-      .patch<ApiResponse<void>>(`${this.baseUrl}/${code}`, dto)
+      .patch<void>(`${this.baseUrl}/${code}`, dto)
       .pipe(map(() => undefined));
   }
 }

--- a/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
+++ b/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
-import { ApiResponse } from '../../../shared/api-response.model';
+
+import { ApiResponse } from '../../../shared/api/api-response.model';
 import { ProviderDto } from '../models/provider-dto.model';
 
 /* Сервис для чтения дескрипторов провайдеров. */
@@ -19,6 +20,6 @@ export class ProviderDescriptorService {
   list(): Observable<ProviderDto[]> {
     return this.http
       .get<ApiResponse<ProviderDto[]>>(this.baseUrl)
-      .pipe(map(res => res.data));
+      .pipe(map(res => res.data ?? []));
   }
 }

--- a/frontend/src/app/shared/api-response.model.ts
+++ b/frontend/src/app/shared/api-response.model.ts
@@ -1,6 +1,0 @@
-/* Единый ответ backend'а */
-export interface ApiResponse<T> {
-  data: T;
-  message: string;
-  timestamp: string;
-}

--- a/frontend/src/app/shared/api/api-response.model.ts
+++ b/frontend/src/app/shared/api/api-response.model.ts
@@ -1,0 +1,8 @@
+/* Контракт универсального ответа backend'а. */
+export interface ApiResponse<T> {
+  data: T | null;
+  success: boolean;
+  errorCode?: string;
+  message: string;
+  timestamp: string;
+}

--- a/frontend/src/app/shared/http/api-envelope.interceptor.ts
+++ b/frontend/src/app/shared/http/api-envelope.interceptor.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { ApiResponse } from '../api/api-response.model';
+
+/* Перехватчик для конверта ответов API. */
+@Injectable()
+export class ApiEnvelopeInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(
+      catchError((error: HttpErrorResponse) => {
+        const body = error.error as ApiResponse<unknown> | undefined;
+
+        if (body && body.success === false && body.errorCode) {
+          // Здесь можно централизованно обрабатывать известные errorCode.
+        }
+
+        return throwError(() => error);
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- expand the backend ApiResponse envelope with success flags, error codes and timestamps and provide an ErrorCode catalog
- update response factories and exception handlers to emit unified envelopes and appropriate HTTP statuses
- adjust Angular client to consume the new envelope, register an interceptor and relax void responses

## Testing
- `./mvnw -pl backend test` *(fails: build tooling download blocked in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da957820c832d80eba557f21c4a69)