### PR TITLE
Add instrument code support to FX Spot admin list

### DIFF
--- a/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
+++ b/frontend/src/app/features/fx_spot/models/fx-spot.model.ts
@@ -14,6 +14,8 @@ export interface FxSpotDto {
 
 /** DTO строки списка с символом инструмента. */
 export interface FxSpotListItemDto {
+  /* Уникальный код инструмента (например, FX_SPOT_EURUSD_TOD) */
+  instrumentCode: string;
   /* Символ инструмента (например, EURUSD_TOD) */
   symbol: string;
   /* Код базовой валюты */

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
@@ -87,6 +87,11 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
+        <ng-container matColumnDef="instrumentCode">
+          <th mat-header-cell *matHeaderCellDef> Code</th>
+          <td mat-cell *matCellDef="let spot"> {{ spot.instrumentCode }}</td>
+        </ng-container>
+
         <ng-container matColumnDef="symbol">
           <th mat-header-cell *matHeaderCellDef> Symbol</th>
           <td mat-cell *matCellDef="let spot"> {{ spot.symbol }}</td>

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -42,7 +42,7 @@ export class FxSpotAdminComponent implements OnInit {
   //=================
   // Табличные данные
   //=================
-  displayed: string[] = ['symbol', 'baseCurrency', 'quoteCurrency', 'valueDate', 'defaultQuoteFractionDigits', 'actions'];
+  displayed: string[] = ['instrumentCode', 'symbol', 'baseCurrency', 'quoteCurrency', 'valueDate', 'defaultQuoteFractionDigits', 'actions'];
   dataSource = new MatTableDataSource<FxSpotListItemDto>([]);
 
   //=========================================
@@ -52,7 +52,7 @@ export class FxSpotAdminComponent implements OnInit {
 
   locked = false; // флаг блокировки кнопки Add
   editing = false; // режим редактирования
-  editCode: string | null = null; // внутренний код инструмента для редактирования (собирается на UI)
+  editCode: string | null = null; // внутренний код инструмента для редактирования (получаем с backend)
   editSymbol: string | null = null; // символ инструмента для уведомления
   currencies: CurrencyDto[] = [];
   valueDates = Object.values(FxSpotValueDate);
@@ -138,7 +138,7 @@ export class FxSpotAdminComponent implements OnInit {
   /* клик по иконке Edit */
   onEdit(spot: FxSpotListItemDto): void {
     this.editing = true;
-    this.editCode = this.composeCode(spot);
+    this.editCode = spot.instrumentCode;
     this.editSymbol = spot.symbol;
     this.form.setValue({
       baseCurrency: spot.baseCurrency,
@@ -196,8 +196,7 @@ export class FxSpotAdminComponent implements OnInit {
 
   /* клик по иконке Delete */
   onDelete(spot: FxSpotListItemDto): void {
-    const code = this.composeCode(spot);
-    this.service.delete(code).subscribe({
+    this.service.delete(spot.instrumentCode).subscribe({
       next: () => {
         this.snack.open(`FX Spot '${spot.symbol}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
@@ -216,11 +215,6 @@ export class FxSpotAdminComponent implements OnInit {
       next: list => this.dataSource.data = list,
       error: err => this.snack.open(err.message ?? 'Load failed', 'Close')
     });
-  }
-
-  /** Собираем внутренний код инструмента для запросов к backend. */
-  private composeCode(spot: Pick<FxSpotListItemDto, 'baseCurrency' | 'quoteCurrency' | 'valueDate'>): string {
-    return `FX_SPOT_${spot.baseCurrency}${spot.quoteCurrency}_${spot.valueDate}`;
   }
 
 }


### PR DESCRIPTION
## Summary
- expose the new instrumentCode field in the FxSpotListItemDto interface
- show the instrument code in the FX Spot admin table and reuse it for edit/delete actions

## Testing
- npm run lint *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd90640b0832d859a0e44ba19ffda)