### PR TITLE
Fix FX Spot add confirmation to use instrument code

### DIFF
--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -112,10 +112,10 @@ export class FxSpotAdminComponent implements OnInit {
     const dto = this.form.getRawValue() as FxSpotCreateDto;
 
     this.service.add(dto).subscribe({
-      next: symbol => {
+      next: code => {
         // Если все ОК
         this.snack.open(
-          `FX Spot '${symbol}' added`, 'OK', { duration: 2500 }
+          `FX Spot '${code}' added`, 'OK', { duration: 2500 }
         );
         this.refresh();
         this.form.reset({


### PR DESCRIPTION
## Summary
- align the FX Spot admin add flow with the backend returning an instrument code
- update the snackbar message to display the returned code after creation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ddbf43e18832dacf0add4623fd10f)