### PR TITLE
feat: show provider code in catalog

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDto.java
@@ -4,6 +4,7 @@ package com.alligator.market.backend.provider.catalog.web.dto;
  * DTO дескриптора провайдера для REST-контроллера.
  */
 public record ProviderDto(
+        String providerCode,
         String displayName,
         String deliveryMode,
         String accessMethod,

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/ProviderDtoMapper.java
@@ -22,6 +22,7 @@ public final class ProviderDtoMapper {
         Duration minUpdateInterval = item.minUpdateInterval();
 
         return new ProviderDto(
+                item.providerCode(),
                 descriptor.displayName(),
                 descriptor.deliveryMode().name(),
                 descriptor.accessMethod().name(),

--- a/frontend/src/app/features/provider_descriptor/models/provider-dto.model.ts
+++ b/frontend/src/app/features/provider_descriptor/models/provider-dto.model.ts
@@ -2,6 +2,8 @@
  * DTO провайдера, соответствующее backend-контракту ProviderDto.
  */
 export interface ProviderDto {
+  /* Технический код провайдера. */
+  providerCode: string;
   /* Отображаемое имя провайдера (user friendly). */
   displayName: string;
   /* Режим доставки рыночных данных. */

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.html
@@ -7,6 +7,11 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
+        <ng-container matColumnDef="providerCode">
+          <th mat-header-cell *matHeaderCellDef>Code</th>
+          <td mat-cell *matCellDef="let descriptor">{{ descriptor.providerCode }}</td>
+        </ng-container>
+
         <ng-container matColumnDef="displayName">
           <th mat-header-cell *matHeaderCellDef>Provider</th>
           <td mat-cell *matCellDef="let descriptor">{{ descriptor.displayName }}</td>

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -14,8 +14,9 @@ import { ProviderDto } from '../../models/provider-dto.model';
 })
 export class DescriptorListComponent implements OnInit {
 
-  /* Список колонок таблицы (код провайдера намеренно скрыт на уровне API — используем только дружелюбное имя). */
+  /* Список колонок таблицы. */
   displayed: string[] = [
+    'providerCode',
     'displayName',
     'deliveryMode',
     'accessMethod',


### PR DESCRIPTION
## Summary
- add provider code to provider catalog DTO exposed by the backend
- extend Angular provider descriptor model and table to render provider codes

## Testing
- ./mvnw -pl backend test *(fails: wget unable to download apache-maven-3.9.9-bin.zip)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dde571740832db42f1e13035d352a)