### PR TITLE
Добавить фильтр dev-аудита для HTTP-запросов

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/config/audit/DevAuditContextFilter.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/audit/DevAuditContextFilter.java
@@ -1,0 +1,45 @@
+package com.alligator.market.backend.config.audit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/* Фильтр для установки контекста аудита на время HTTP-запроса (actor = dev_admin, via = dev_http). */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE) // Выполнить как можно раньше
+public class DevAuditContextFilter extends OncePerRequestFilter {
+
+    private static final String DEV_ACTOR = "dev_admin";
+    private static final String DEV_VIA = "dev_http";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        var ctx = new AuditContext(DEV_ACTOR, DEV_VIA);
+        try {
+            // Устанавливаем контекст на время обработки запроса и гарантированно восстанавливаем его после.
+            AuditContextHolder.runWith(ctx, () -> {
+                try {
+                    chain.doFilter(request, response);
+                } catch (IOException | ServletException e) {
+                    // Пробрасываем checked-исключения далее по цепочке
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (RuntimeException ex) {
+            // Восстанавливаем checked-типы, чтобы не менять поведение контейнера
+            var cause = ex.getCause();
+            if (cause instanceof IOException io) throw io;
+            if (cause instanceof ServletException se) throw se;
+            throw ex;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- добавить HTTP-фильтр OncePerRequestFilter, который на время запроса устанавливает актор dev_admin и канал dev_http
- сохранить корректный проброс checked-исключений при работе фильтра

## Testing
- ./mvnw -pl backend -am -DskipTests compile *(failed: wget не смог скачать зависимости из Maven Central в окружении выполнения)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df11a3d28832d869bd790c97cecdd)