### PR TITLE
Добавить предохранители старта для синхронизации провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/bootstrap/ProviderSyncBootstrap.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/reconciliation/bootstrap/ProviderSyncBootstrap.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.config.audit.context.AuditContextHolder;
 import com.alligator.market.backend.provider.reconciliation.service.ProviderSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -20,16 +21,41 @@ public class ProviderSyncBootstrap implements ApplicationRunner {
     /* Backend реализация сервиса синхронизации. */
     private final ProviderSyncService syncService;
 
+    /* Флаг: запускать ли синхронизацию при старте приложения (по умолчанию сохраняем текущее поведение). */
+    @Value("${provider.sync.on-startup:true}")
+    private boolean runOnStartup;
+
+    /* Флаг: падать ли приложению при ошибке синхронизации (по умолчанию выключено). */
+    @Value("${provider.sync.fail-fast:false}")
+    private boolean failFast;
+
     @Override
     public void run(ApplicationArguments args) {
-        log.info("Starting provider synchronization");
+        if (!runOnStartup) {
+            log.info("Provider sync on startup is disabled (property 'provider.sync.on-startup=false')");
+            return;
+        }
+
+        log.info("Starting provider synchronization on application startup");
 
         // Задаем контекст для аудита
         AuditContext ctx = new AuditContext(AuditContextHolder.SYSTEM_ACTOR, "bootstrap:provider-sync");
 
-        AuditContextHolder.runWith(ctx, () -> {
-            syncService.runSync();
-            log.info("Provider synchronization completed");
-        });
+        try {
+            AuditContextHolder.runWith(ctx, () -> {
+                // Запускаем процедуру синхронизации
+                syncService.runSync();
+            });
+
+            log.info("Provider synchronization completed successfully");
+        } catch (Exception ex) {
+            log.error("Provider synchronization failed on startup", ex);
+            if (failFast) {
+                if (ex instanceof RuntimeException runtimeException) {
+                    throw runtimeException;
+                }
+                throw new IllegalStateException("Provider sync failed", ex);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add configuration flags to control provider synchronization on startup
- log synchronization results and honor the fail-fast behaviour
- prevent application crash when synchronization fails unless fail-fast is enabled

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df948f5c8832d95d61b9319ad6621)