### PR TITLE
Normalize frontend formatting style

### DIFF
--- a/frontend/src/app/features/currency/currency-routing.module.ts
+++ b/frontend/src/app/features/currency/currency-routing.module.ts
@@ -14,4 +14,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class CurrencyRoutingModule { }
+export class CurrencyRoutingModule {}

--- a/frontend/src/app/features/currency/currency.module.ts
+++ b/frontend/src/app/features/currency/currency.module.ts
@@ -5,9 +5,6 @@ import { CurrencyRoutingModule } from './currency-routing.module';
 
 @NgModule({
   declarations: [],
-  imports: [
-    CommonModule,
-    CurrencyRoutingModule,
-  ]
+  imports: [CommonModule, CurrencyRoutingModule]
 })
-export class CurrencyModule { }
+export class CurrencyModule {}

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.html
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.html
@@ -12,11 +12,7 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Code</mat-label>
-          <input
-            matInput
-            formControlName="code"
-            maxlength="3"
-          />
+          <input matInput formControlName="code" maxlength="3" />
           <mat-error *ngIf="this.form.controls['code'].hasError('required')">
             Is required
           </mat-error>
@@ -27,11 +23,7 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Currency Name</mat-label>
-          <input
-            matInput
-            formControlName="name"
-            maxlength="50"
-          />
+          <input matInput formControlName="name" maxlength="50" />
           <mat-error *ngIf="form.controls['name'].hasError('required')">
             Is required
           </mat-error>
@@ -39,11 +31,7 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Country/Region</mat-label>
-          <input
-            matInput
-            formControlName="country"
-            maxlength="100"
-          />
+          <input matInput formControlName="country" maxlength="100" />
           <mat-error *ngIf="form.controls['country'].hasError('required')">
             Is required
           </mat-error>
@@ -51,32 +39,43 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Fraction digits</mat-label>
-          <input
-            matInput
-            type="number"
-            formControlName="fractionDigits"
-          />
+          <input matInput type="number" formControlName="fractionDigits" />
           <mat-error *ngIf="form.controls['fractionDigits'].hasError('required')">
             Is required
           </mat-error>
-          <mat-error *ngIf="form.controls['fractionDigits'].hasError('min')
-               || form.controls['fractionDigits'].hasError('max')">
+          <mat-error
+            *ngIf="
+              form.controls['fractionDigits'].hasError('min')
+              || form.controls['fractionDigits'].hasError('max')
+            "
+          >
             0 – 10 allowed
           </mat-error>
         </mat-form-field>
 
         <ng-container *ngIf="!editing; else editButtons">
-          <button mat-raised-button
-                  type="button"
-                  (click)="onAdd()" [disabled]="form.invalid || locked"> Add
+          <button
+            mat-raised-button
+            type="button"
+            (click)="onAdd()"
+            [disabled]="form.invalid || locked"
+          >
+            Add
           </button>
         </ng-container>
         <ng-template #editButtons>
-          <button mat-raised-button color="primary"
-                  type="button"
-                  (click)="onSave()" [disabled]="form.invalid || locked"> Save
+          <button
+            mat-raised-button
+            color="primary"
+            type="button"
+            (click)="onSave()"
+            [disabled]="form.invalid || locked"
+          >
+            Save
           </button>
-          <button mat-raised-button type="button" (click)="cancelEdit()">Cancel</button>
+          <button mat-raised-button type="button" (click)="cancelEdit()">
+            Cancel
+          </button>
         </ng-template>
       </form>
     </mat-card-content>
@@ -91,23 +90,23 @@
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
         <ng-container matColumnDef="code">
-          <th mat-header-cell *matHeaderCellDef> Code</th>
-          <td mat-cell *matCellDef="let c"> {{ c.code }}</td>
+          <th mat-header-cell *matHeaderCellDef>Code</th>
+          <td mat-cell *matCellDef="let c">{{ c.code }}</td>
         </ng-container>
 
         <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef> Currency Name</th>
-          <td mat-cell *matCellDef="let c"> {{ c.name }}</td>
+          <th mat-header-cell *matHeaderCellDef>Currency Name</th>
+          <td mat-cell *matCellDef="let c">{{ c.name }}</td>
         </ng-container>
 
         <ng-container matColumnDef="country">
-          <th mat-header-cell *matHeaderCellDef> Country/Region</th>
-          <td mat-cell *matCellDef="let c"> {{ c.country }}</td>
+          <th mat-header-cell *matHeaderCellDef>Country/Region</th>
+          <td mat-cell *matCellDef="let c">{{ c.country }}</td>
         </ng-container>
 
         <ng-container matColumnDef="fractionDigits">
-          <th mat-header-cell *matHeaderCellDef> Fraction digits</th>
-          <td mat-cell *matCellDef="let c"> {{ c.fractionDigits }}</td>
+          <th mat-header-cell *matHeaderCellDef>Fraction digits</th>
+          <td mat-cell *matCellDef="let c">{{ c.fractionDigits }}</td>
         </ng-container>
 
         <ng-container matColumnDef="actions">

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.spec.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.spec.ts
@@ -9,8 +9,7 @@ describe('CurrencyAdminComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CurrencyAdminComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CurrencyAdminComponent);
     component = fixture.componentInstance;

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
@@ -1,17 +1,22 @@
-import {Component, OnInit} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
-import {MatTableDataSource, MatTableModule} from '@angular/material/table';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatInputModule} from '@angular/material/input';
-import {MatIconModule} from '@angular/material/icon';
-import {MatButtonModule} from '@angular/material/button';
-import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
-import {CurrencyDto} from '../../models/currency.model';
-import {CurrencyService} from '../../services/currency.service';
-import {MatCardModule} from "@angular/material/card";
-import {UpdateCurrencyDto} from "../../models/currency-update.model";
-import {RouterLink} from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatCardModule } from '@angular/material/card';
+
+import { CurrencyDto } from '../../models/currency.model';
+import { UpdateCurrencyDto } from '../../models/currency-update.model';
+import { CurrencyService } from '../../services/currency.service';
 
 @Component({
   selector: 'app-currency-admin',
@@ -25,8 +30,7 @@ import {RouterLink} from '@angular/router';
     MatIconModule,
     MatButtonModule,
     MatSnackBarModule,
-    MatCardModule,
-    RouterLink
+    MatCardModule
   ],
   templateUrl: './currency-admin.component.html',
   styleUrl: './currency-admin.component.scss'
@@ -37,7 +41,7 @@ export class CurrencyAdminComponent implements OnInit {
   // Табличные данные
   //=================
   displayed: string[] = ['code', 'name', 'country', 'fractionDigits', 'actions'];
-  dataSource  = new MatTableDataSource<CurrencyDto>([]);
+  dataSource = new MatTableDataSource<CurrencyDto>([]);
 
   //========================
   // Форма добавления валюты
@@ -100,7 +104,9 @@ export class CurrencyAdminComponent implements OnInit {
 
   /* нажата кнопка Add */
   onAdd(): void {
-    if (this.form.invalid || this.locked) { return; }
+    if (this.form.invalid || this.locked) {
+      return;
+    }
 
     this.locked = true; // блокируем кнопку
 
@@ -109,19 +115,23 @@ export class CurrencyAdminComponent implements OnInit {
     this.service.add(dto).subscribe({
       next: code => {
         // Если все ОК
-        this.snack.open(                   // уведомление
-          `Currency '${code}' added`, 'OK', { duration: 2500 }
+        // уведомление
+        this.snack.open(
+          `Currency '${code}' added`,
+          'OK',
+          { duration: 2500 }
         );
-        this.refresh();                    // обновляем таблицу
-        this.form.reset({ fractionDigits: 2 });   // оставляем количество знаков по-умолчанию
-        this.locked = false;               // разблокируем кнопку
+        this.refresh(); // обновляем таблицу
+        this.form.reset({ fractionDigits: 2 }); // оставляем количество знаков по-умолчанию
+        this.locked = false; // разблокируем кнопку
       },
       error: err => {
         // Если ошибка
-        const msg = err.error?.message ?? err.message ?? 'Add failed';   // ловим сообщение ошибки сервера
-        const ref =
-          this.snack.open(msg, 'Close', { duration: 0 });               // уведомление с ошибкой
-        ref.afterDismissed().subscribe(() => this.locked = false);    // Close для разблокировки Add
+        const msg = err.error?.message ?? err.message ?? 'Add failed'; // ловим сообщение ошибки сервера
+        const ref = this.snack.open(msg, 'Close', { duration: 0 }); // уведомление с ошибкой
+        ref.afterDismissed().subscribe(() => {
+          this.locked = false;
+        }); // Close для разблокировки Add
       }
     });
   }
@@ -141,7 +151,9 @@ export class CurrencyAdminComponent implements OnInit {
 
   /* нажата кнопка Save */
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editCode) { return; }
+    if (this.form.invalid || this.locked || !this.editCode) {
+      return;
+    }
 
     this.locked = true;
 
@@ -161,7 +173,9 @@ export class CurrencyAdminComponent implements OnInit {
       error: err => {
         const msg = err.error?.message ?? err.message ?? 'Update failed';
         const ref = this.snack.open(msg, 'Close', { duration: 0 });
-        ref.afterDismissed().subscribe(() => this.locked = false);
+        ref.afterDismissed().subscribe(() => {
+          this.locked = false;
+        });
       }
     });
   }
@@ -182,8 +196,9 @@ export class CurrencyAdminComponent implements OnInit {
         this.snack.open(`Currency '${code}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
-      error: err =>
-        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close')
+      error: err => {
+        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close');
+      }
     });
   }
 
@@ -193,8 +208,12 @@ export class CurrencyAdminComponent implements OnInit {
   /* утилита: перезагрузить список */
   private refresh(): void {
     this.service.list().subscribe({
-      next: list => this.dataSource.data = list,
-      error: err => this.snack.open(err.message ?? 'Load failed', 'Close')
+      next: list => {
+        this.dataSource.data = list;
+      },
+      error: err => {
+        this.snack.open(err.message ?? 'Load failed', 'Close');
+      }
     });
   }
 

--- a/frontend/src/app/features/currency/services/currency.service.ts
+++ b/frontend/src/app/features/currency/services/currency.service.ts
@@ -12,7 +12,7 @@ import { UpdateCurrencyDto } from '../models/currency-update.model';
 })
 export class CurrencyService {
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   /* Базовый URL (через proxy уйдёт на Spring). */
   private readonly baseUrl = '/api/v1/currencies';

--- a/frontend/src/app/features/fx_spot/fx-spot-routing.module.ts
+++ b/frontend/src/app/features/fx_spot/fx-spot-routing.module.ts
@@ -14,4 +14,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class FxSpotRoutingModule { }
+export class FxSpotRoutingModule {}

--- a/frontend/src/app/features/fx_spot/fx-spot.module.ts
+++ b/frontend/src/app/features/fx_spot/fx-spot.module.ts
@@ -5,9 +5,6 @@ import { FxSpotRoutingModule } from './fx-spot-routing.module';
 
 @NgModule({
   declarations: [],
-  imports: [
-    CommonModule,
-    FxSpotRoutingModule,
-  ]
+  imports: [CommonModule, FxSpotRoutingModule]
 })
-export class FxSpotModule { }
+export class FxSpotModule {}

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.html
@@ -48,32 +48,43 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Default Quote Fraction Digits</mat-label>
-          <input
-            matInput
-            type="number"
-            formControlName="defaultQuoteFractionDigits"
-          />
+          <input matInput type="number" formControlName="defaultQuoteFractionDigits" />
           <mat-error *ngIf="form.controls['defaultQuoteFractionDigits'].hasError('required')">
             Is required
           </mat-error>
-          <mat-error *ngIf="form.controls['defaultQuoteFractionDigits'].hasError('min')
-               || form.controls['defaultQuoteFractionDigits'].hasError('max')">
+          <mat-error
+            *ngIf="
+              form.controls['defaultQuoteFractionDigits'].hasError('min')
+              || form.controls['defaultQuoteFractionDigits'].hasError('max')
+            "
+          >
             0 – 10 allowed
           </mat-error>
         </mat-form-field>
 
         <ng-container *ngIf="!editing; else editButtons">
-          <button mat-raised-button
-                  type="button"
-                  (click)="onAdd()" [disabled]="form.invalid || locked"> Add
+          <button
+            mat-raised-button
+            type="button"
+            (click)="onAdd()"
+            [disabled]="form.invalid || locked"
+          >
+            Add
           </button>
         </ng-container>
         <ng-template #editButtons>
-          <button mat-raised-button color="primary"
-                  type="button"
-                  (click)="onSave()" [disabled]="form.invalid || locked"> Save
+          <button
+            mat-raised-button
+            color="primary"
+            type="button"
+            (click)="onSave()"
+            [disabled]="form.invalid || locked"
+          >
+            Save
           </button>
-          <button mat-raised-button type="button" (click)="cancelEdit()">Cancel</button>
+          <button mat-raised-button type="button" (click)="cancelEdit()">
+            Cancel
+          </button>
         </ng-template>
       </form>
     </mat-card-content>
@@ -88,33 +99,33 @@
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
         <ng-container matColumnDef="instrumentCode">
-          <th mat-header-cell *matHeaderCellDef> Code</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.instrumentCode }}</td>
+          <th mat-header-cell *matHeaderCellDef>Code</th>
+          <td mat-cell *matCellDef="let spot">{{ spot.instrumentCode }}</td>
         </ng-container>
 
         <ng-container matColumnDef="symbol">
-          <th mat-header-cell *matHeaderCellDef> Symbol</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.symbol }}</td>
+          <th mat-header-cell *matHeaderCellDef>Symbol</th>
+          <td mat-cell *matCellDef="let spot">{{ spot.symbol }}</td>
         </ng-container>
 
         <ng-container matColumnDef="baseCurrency">
-          <th mat-header-cell *matHeaderCellDef> Base Currency</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.baseCurrency }}</td>
+          <th mat-header-cell *matHeaderCellDef>Base Currency</th>
+          <td mat-cell *matCellDef="let spot">{{ spot.baseCurrency }}</td>
         </ng-container>
 
         <ng-container matColumnDef="quoteCurrency">
-          <th mat-header-cell *matHeaderCellDef> Quote Currency</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.quoteCurrency }}</td>
+          <th mat-header-cell *matHeaderCellDef>Quote Currency</th>
+          <td mat-cell *matCellDef="let spot">{{ spot.quoteCurrency }}</td>
         </ng-container>
 
         <ng-container matColumnDef="valueDate">
-          <th mat-header-cell *matHeaderCellDef> Value Date</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.valueDate }}</td>
+          <th mat-header-cell *matHeaderCellDef>Value Date</th>
+          <td mat-cell *matCellDef="let spot">{{ spot.valueDate }}</td>
         </ng-container>
 
         <ng-container matColumnDef="defaultQuoteFractionDigits">
-          <th mat-header-cell *matHeaderCellDef> Default Quote Fraction Digits</th>
-          <td mat-cell *matCellDef="let spot"> {{ spot.defaultQuoteFractionDigits }}</td>
+          <th mat-header-cell *matHeaderCellDef>Default Quote Fraction Digits</th>
+          <td mat-cell *matCellDef="let spot">{{ spot.defaultQuoteFractionDigits }}</td>
         </ng-container>
 
         <ng-container matColumnDef="actions">

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.spec.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.spec.ts
@@ -9,8 +9,7 @@ describe('FxSpotAdminComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FxSpotAdminComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(FxSpotAdminComponent);
     component = fixture.componentInstance;

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -15,7 +15,6 @@ import { FxSpotService } from '../../services/fx-spot.service';
 import { FxSpotUpdateDto } from '../../models/fx-spot-update.model';
 import { CurrencyService } from '../../../currency/services/currency.service';
 import { CurrencyDto } from '../../../currency/models/currency.model';
-import { RouterLink } from '@angular/router';
 import { FxSpotValueDate } from '../../models/fx-spot-value-date.model';
 
 @Component({
@@ -31,8 +30,7 @@ import { FxSpotValueDate } from '../../models/fx-spot-value-date.model';
     MatIconModule,
     MatButtonModule,
     MatSnackBarModule,
-    MatCardModule,
-    RouterLink
+    MatCardModule
   ],
   templateUrl: './fx-spot-admin.component.html',
   styleUrl: './fx-spot-admin.component.scss'
@@ -98,14 +96,20 @@ export class FxSpotAdminComponent implements OnInit {
   ngOnInit(): void {
     this.refresh();
     this.currencyService.list().subscribe({
-      next: c => this.currencies = c,
-      error: err => this.snack.open(err.message ?? 'Load currencies failed', 'Close')
+      next: c => {
+        this.currencies = c;
+      },
+      error: err => {
+        this.snack.open(err.message ?? 'Load currencies failed', 'Close');
+      }
     });
   }
 
   /* нажата кнопка Add */
   onAdd(): void {
-    if (this.form.invalid || this.locked) { return; }
+    if (this.form.invalid || this.locked) {
+      return;
+    }
 
     this.locked = true; // блокируем кнопку
 
@@ -115,7 +119,9 @@ export class FxSpotAdminComponent implements OnInit {
       next: code => {
         // Если все ОК
         this.snack.open(
-          `FX Spot '${code}' added`, 'OK', { duration: 2500 }
+          `FX Spot '${code}' added`,
+          'OK',
+          { duration: 2500 }
         );
         this.refresh();
         this.form.reset({
@@ -128,9 +134,10 @@ export class FxSpotAdminComponent implements OnInit {
       },
       error: err => {
         const msg = err.error?.message ?? err.message ?? 'Add failed';
-        const ref =
-          this.snack.open(msg, 'Close', { duration: 0 });
-        ref.afterDismissed().subscribe(() => this.locked = false);
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => {
+          this.locked = false;
+        });
       }
     });
   }
@@ -153,7 +160,9 @@ export class FxSpotAdminComponent implements OnInit {
 
   /* нажата кнопка Save */
   onSave(): void {
-    if (this.form.invalid || this.locked || !this.editCode) { return; }
+    if (this.form.invalid || this.locked || !this.editCode) {
+      return;
+    }
 
     this.locked = true;
 
@@ -172,7 +181,9 @@ export class FxSpotAdminComponent implements OnInit {
       error: err => {
         const msg = err.error?.message ?? err.message ?? 'Update failed';
         const ref = this.snack.open(msg, 'Close', { duration: 0 });
-        ref.afterDismissed().subscribe(() => this.locked = false);
+        ref.afterDismissed().subscribe(() => {
+          this.locked = false;
+        });
       }
     });
   }
@@ -201,8 +212,9 @@ export class FxSpotAdminComponent implements OnInit {
         this.snack.open(`FX Spot '${spot.symbol}' deleted`, 'OK', { duration: 2500 });
         this.refresh();
       },
-      error: err =>
-        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close')
+      error: err => {
+        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close');
+      }
     });
   }
 
@@ -212,8 +224,12 @@ export class FxSpotAdminComponent implements OnInit {
   /* утилита: перезагрузить список */
   private refresh(): void {
     this.service.list().subscribe({
-      next: list => this.dataSource.data = list,
-      error: err => this.snack.open(err.message ?? 'Load failed', 'Close')
+      next: list => {
+        this.dataSource.data = list;
+      },
+      error: err => {
+        this.snack.open(err.message ?? 'Load failed', 'Close');
+      }
     });
   }
 

--- a/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
+++ b/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
@@ -13,7 +13,7 @@ import { FxSpotUpdateDto } from '../models/fx-spot-update.model';
 })
 export class FxSpotService {
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   /* Базовый URL (через proxy уйдёт на Spring). */
   private readonly baseUrl = '/api/v1/fx-spot';

--- a/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
+++ b/frontend/src/app/features/provider_descriptor/pages/descriptor-list/descriptor-list.component.ts
@@ -10,7 +10,7 @@ import { ProviderDto } from '../../models/provider-dto.model';
   standalone: true,
   imports: [CommonModule, MatTableModule, MatCardModule],
   templateUrl: './descriptor-list.component.html',
-  styleUrls: ['./descriptor-list.component.scss']
+  styleUrl: './descriptor-list.component.scss'
 })
 export class DescriptorListComponent implements OnInit {
 
@@ -36,8 +36,12 @@ export class DescriptorListComponent implements OnInit {
   /* Получить список дескрипторов и обновить таблицу. */
   private refresh(): void {
     this.service.list().subscribe({
-      next: list => this.dataSource.data = list,
-      error: err => console.error(err)
+      next: list => {
+        this.dataSource.data = list;
+      },
+      error: err => {
+        console.error(err);
+      }
     });
   }
 }

--- a/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
+++ b/frontend/src/app/features/provider_descriptor/services/provider-descriptor.service.ts
@@ -11,7 +11,7 @@ import { ProviderDto } from '../models/provider-dto.model';
 })
 export class ProviderDescriptorService {
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   /* Базовый URL (через proxy уйдёт на Spring). */
   private readonly baseUrl = '/api/v1/providers';

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -1,10 +1,7 @@
 import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
-
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [RouterLink],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss'
 })


### PR DESCRIPTION
## Summary
- reformat Angular currency admin component files to a consistent spacing and template layout
- tidy FX Spot admin module, component, service, and template to match the shared style conventions
- align provider descriptor and shared components with the same formatting rules and remove unused imports

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f63ebdac4832dbef76ca8d2835d43)