### PR TITLE
Fix Moex ISS FX spot live test imports

### DIFF
--- a/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
@@ -15,7 +15,6 @@ import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**


### PR DESCRIPTION
## Summary
- remove outdated JUnit 4 assert import from MoexIssFxSpotHandlerQuoteLiveTest to use JUnit Jupiter assertions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c20742d8832d852cff0b4190adab)