### PR TITLE
Добавить резолвер провайдера для FX_SPOT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
@@ -24,7 +24,7 @@ import java.util.Set;
 public class MoexIssAdapter extends SpringMarketDataProvider<MoexIssAdapter> {
 
     /* Технический код провайдера: UPPERCASE, формат [A-Z0-9_]+. */
-    private static final String PROVIDER_CODE = "MOEX_ISS";
+    public static final String PROVIDER_CODE = "MOEX_ISS";
 
     /* Отображаемое имя провайдера. */
     private static final String DISPLAY_NAME = "MOEX Informational & Statistical Server";

--- a/backend/src/main/java/com/alligator/market/backend/provider/resolver/DefaultInstrumentProviderResolver.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/resolver/DefaultInstrumentProviderResolver.java
@@ -1,0 +1,38 @@
+package com.alligator.market.backend.provider.resolver;
+
+import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssAdapter;
+import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.provider.contract.resolver.InstrumentProviderResolver;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+/**
+ * Реализация резолвера провайдера для инструментов.
+ * <p>
+ * Пока что: для всех FX_SPOT возвращает MOEX ISS.
+ * Точка роста: заменить логику на чтение из БД.
+ */
+@Service
+public class DefaultInstrumentProviderResolver implements InstrumentProviderResolver {
+
+    /* Код провайдера MOEX ISS. */
+    private static final String MOEX_ISS_PROVIDER_CODE = MoexIssAdapter.PROVIDER_CODE;
+
+    @Override
+    public String resolveProvider(Instrument instrument) {
+        Objects.requireNonNull(instrument, "instrument must not be null");
+
+        // Пока что вся FX_SPOT-линейка обслуживается только MOEX ISS.
+        if (instrument instanceof FxSpot) {
+            return MOEX_ISS_PROVIDER_CODE;
+        }
+
+        // Для прочих типов инструментов провайдеры пока не настроены.
+        throw new IllegalArgumentException(
+                "No market data provider configured for instrument type: "
+                        + instrument.getClass().getSimpleName()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add default instrument provider resolver that routes FX_SPOT instruments to the MOEX ISS provider
- expose the MOEX ISS provider code constant for reuse

## Testing
- mvn -pl backend test *(fails: unable to download Maven due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dc1fb0124832d816c2f3e776f9913)