### PR TITLE
Добавить временный smoke-runner потока котировок (local/dev)

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamSmokeRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamSmokeRunner.java
@@ -1,0 +1,57 @@
+package com.alligator.market.backend.quote.streaming;
+
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.Currency;
+import com.alligator.market.domain.instrument.type.forex.ref.currency.model.CurrencyCode;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotValueDate;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+/* Временный smoke-тест: подписка на поток котировок для одного инструмента. */
+@Component
+@Profile({"local", "dev"})
+public class QuoteStreamSmokeRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(QuoteStreamSmokeRunner.class);
+
+    /* Оркестратор построения потока котировок. */
+    private final QuoteStreamingOrchestrator orchestrator;
+
+    /* Храним подписку, чтобы корректно остановить при выключении приложения. */
+    private Disposable subscription;
+
+    public QuoteStreamSmokeRunner(QuoteStreamingOrchestrator orchestrator) {
+        this.orchestrator = orchestrator;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void run() {
+        // Строим доменную модель инструмента, поддерживаемого MOEX ISS.
+        Currency cny = new Currency(CurrencyCode.of("CNY"), "Chinese Yuan", "China", 2);
+        Currency rub = new Currency(CurrencyCode.of("RUB"), "Russian Ruble", "Russian Federation", 2);
+        FxSpot instrument = new FxSpot(cny, rub, FxSpotValueDate.TOM, 4);
+
+        subscription = Flux.from(orchestrator.buildQuoteStream(instrument))
+        // Показываем интервалы между тиками (полезно для проверки "1 сек" + время запроса).
+                .elapsed()
+                .take(5)
+                .doOnNext(t -> log.info("Tick received after {} ms: {}", t.getT1(), t.getT2()))
+                .doOnComplete(() -> log.info("Quote stream smoke test completed"))
+                .doOnError(ex -> log.error("Quote stream smoke test failed", ex))
+                .subscribe();
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (subscription != null && !subscription.isDisposed()) {
+            subscription.dispose();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить простой временный smoke-тест для проверки подписки на поток котировок и интеграции с оркестратором провайдеров.
- Ограничить выполнение теста профилями `local` и `dev`, чтобы избежать побочных эффектов в других средах.
- Создать корректный доменный `FxSpot` инструмент через модели `Currency`/`CurrencyCode` для совместимости с существующими адаптерами.
- Обеспечить корректное завершение подписки при остановке приложения.

### Description
- Добавлен компонент `QuoteStreamSmokeRunner` с аннотациями `@Component` и `@Profile({"local","dev"})` для запуска после `ApplicationReadyEvent`.
- В `run()` строится доменный `FxSpot` (`CurrencyCode.of("CNY")`, `CurrencyCode.of("RUB")`) и выполняется подписка на поток из `QuoteStreamingOrchestrator.buildQuoteStream(instrument)`.
- Для диагностики используется `Flux.from(...).elapsed().take(5)` с логированием интервалов между тиками и обработкой ошибок; подпись хранится в поле `Disposable`.
- Добавлен метод `shutdown()` с `@PreDestroy`, который корректно вызывает `dispose()` для закрытия подписки.

### Testing
- Автоматические тесты не запускались (не запрошено).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ed3d7920832d9f287b4decb83cde)