### PR TITLE
Добавить тесты для DbErrors

### DIFF
--- a/backend/src/test/java/com/alligator/market/backend/common/persistence/jpa/constraint/DbErrorsTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/common/persistence/jpa/constraint/DbErrorsTest.java
@@ -1,0 +1,49 @@
+package com.alligator.market.backend.common.persistence.jpa.constraint;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/* Тесты для проверки распознавания нарушений ограничений БД. */
+class DbErrorsTest {
+
+    @Test
+    void shouldDetectByHibernateConstraintName() {
+        SQLException sqlEx = new SQLException("duplicate key");
+        ConstraintViolationException cve =
+                new ConstraintViolationException("violated", sqlEx, "uq_some_column");
+
+        RuntimeException ex = new RuntimeException("wrap", cve);
+
+        assertTrue(DbErrors.isViolationOf(ex, "UQ_SOME_COLUMN"));
+    }
+
+    @Test
+    void shouldDetectByMessageFallback() {
+        RuntimeException root = new RuntimeException("violates constraint uq_some_column");
+        RuntimeException ex = new RuntimeException("wrap", root);
+
+        assertTrue(DbErrors.isViolationOf(ex, "uq_some_column"));
+    }
+
+    @Test
+    void shouldReturnFalseWhenNotMatched() {
+        RuntimeException ex = new RuntimeException("some error");
+        assertFalse(DbErrors.isViolationOf(ex, "uq_some_column"));
+    }
+
+    @Test
+    void shouldNotHangOnCyclicCauseChain() {
+        RuntimeException a = new RuntimeException("a");
+        RuntimeException b = new RuntimeException("b");
+
+        a.initCause(b);
+        b.initCause(a); // цикл
+
+        assertFalse(DbErrors.isViolationOf(a, "uq_some_column"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Покрыть сценарии распознавания нарушений ограничений БД в утилите `DbErrors`.
- Обеспечить обнаружение по имени ограничения (через Hibernate) и по тексту сообщения как fallback.
- Обработать отрицательный сценарий и защиту от циклической цепочки причин.

### Description
- Добавлен тестовый класс `DbErrorsTest` в `backend/src/test/java/com/alligator/market/backend/common/persistence/jpa/constraint`.
- Тесты проверяют поиск по `ConstraintViolationException#getConstraintName()`, поиск по сообщению, отсутствие совпадения и поведение на циклической cause-цепочке.
- Тесты используют `org.junit.jupiter.api.Test` и имитируют `ConstraintViolationException` через его конструктор.

### Testing
- Автоматические тесты не запускались для этого изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf7b90224832d8dbcfa63611f40dc)