### PR TITLE
Вынес regex кода провайдера в константу

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/quote/feed/catalog/persistence/jpa/InstrumentFeedConfigEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/feed/catalog/persistence/jpa/InstrumentFeedConfigEntity.java
@@ -40,7 +40,7 @@ import java.util.Objects;
         // CHECK: при DDL-генерации создаётся Hibernate; иначе — «живая» спецификация для миграций.
         constraints =
                 "provider_code = upper(provider_code) " +
-                        "AND provider_code ~ '^[A-Z0-9_.-]+$' " +
+                        "AND provider_code ~ '" + PROVIDER_CODE_PATTERN + "' " +
                         "AND feed_role IN ('PRIMARY','SECONDARY')"
 )
 @Getter
@@ -48,6 +48,9 @@ import java.util.Objects;
 // <-- Нельзя создавать вручную через new Entity(): конструктор без аргументов нужен только ORM
 @Access(AccessType.FIELD) // <-- Маппинг по полям: при чтении/записи ORM не вызывает геттеры/сеттеры
 public class InstrumentFeedConfigEntity extends BaseEntity {
+
+    /* Шаблон кода провайдера: только A-Z, 0-9 и символы _ . - */
+    private static final String PROVIDER_CODE_PATTERN = "^[A-Z0-9_.-]+$";
 
     /**
      * Суррогатный PK.
@@ -77,7 +80,7 @@ public class InstrumentFeedConfigEntity extends BaseEntity {
      */
     @NotBlank
     @Size(max = 50)
-    @Pattern(regexp = "^[A-Z0-9_.-]+$")
+    @Pattern(regexp = PROVIDER_CODE_PATTERN)
     @Column(name = "provider_code", length = 50, nullable = false)
     private String providerCode;
 
@@ -140,7 +143,7 @@ public class InstrumentFeedConfigEntity extends BaseEntity {
         n = n.toUpperCase(Locale.ROOT);
 
         // Fail-fast проверка формата (дублирует @Pattern/@Check, но даёт раннюю ошибку).
-        if (!n.matches("^[A-Z0-9_.-]+$")) {
+        if (!n.matches(PROVIDER_CODE_PATTERN)) {
             throw new IllegalArgumentException("providerCode has invalid format: " + n);
         }
 


### PR DESCRIPTION
### Motivation
- В нескольких местах использовался одинаковый регулярный шаблон `^[A-Z0-9_.-]+$`, что ведёт к дублированию и усложняет поддержку. 
- Желательно иметь «один источник правды» для формата кода провайдера, чтобы при необходимости изменить правило это было легко сделать. 

### Description
- Добавлена приватная статическая константа `PROVIDER_CODE_PATTERN` в `InstrumentFeedConfigEntity` с шаблоном `"^[A-Z0-9_.-]+$"` и коротким комментарием. 
- Заменены жёстко прописанные в коде вхождения регулярки на использование `PROVIDER_CODE_PATTERN` в `@Pattern`, в строке `@Check` и в проверке `normalizeProviderCode`. 
- Никакой дополнительной логики не менялось, только устранено дублирование строки шаблона. 

### Testing
- Автоматические тесты не запускались. 
- Изменение ограничено синтаксической правкой в одном файле и компиляционных изменений не добавляло новых зависимостей.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da8c17cd0832d89b9ed9769ae6ee8)