### PR TITLE
Ввести общий Currency DTO и алиасы in/out

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/CurrencyController.java
@@ -3,8 +3,9 @@ package com.alligator.market.backend.instrument.type.forex.currency.catalog.web;
 import com.alligator.market.backend.common.web.http.ApiResponse;
 import com.alligator.market.backend.common.web.http.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.service.CurrencyUseCase;
-import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.common.CurrencyDto;
+import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.in.CreateCurrencyDto;
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.in.UpdateCurrencyDto;
+import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.out.CurrencyResponseDto;
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.mapper.CurrencyDtoMapper;
 import com.alligator.market.domain.instrument.type.forex.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
@@ -34,7 +35,7 @@ public class CurrencyController {
      * Создать валюту.
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid CurrencyDto dto) {
+    public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid CreateCurrencyDto dto) {
 
         Currency created = service.create(CurrencyDtoMapper.toDomain(dto));
         URI location = ServletUriComponentsBuilder
@@ -72,11 +73,11 @@ public class CurrencyController {
      * Вернуть все валюты.
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CurrencyDto>>> getAll() {
+    public ResponseEntity<ApiResponse<List<CurrencyResponseDto>>> getAll() {
 
-        List<CurrencyDto> currencyDtoList = service.findAll()
+        List<CurrencyResponseDto> currencyDtoList = service.findAll()
                 .stream()
-                .map(CurrencyDtoMapper::toDto)
+                .map(CurrencyDtoMapper::toResponseDto)
                 .toList();
         return ResponseEntityFactory.ok(currencyDtoList);
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/common/CurrencyDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/common/CurrencyDto.java
@@ -1,27 +1,31 @@
 package com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.common;
 
 import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
- * Универсальный DTO валюты – используется для создания валюты и получения списка валют.
+ * Общий DTO валюты для in/out контрактов.
  */
-public record CurrencyDto(
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CurrencyDto {
 
-        @NotBlank
-        @Pattern(regexp = "^[A-Z]{3}$")
-        String code,
+    @NotBlank
+    @Pattern(regexp = "^[A-Z]{3}$")
+    private String code;
 
-        @NotBlank
-        @Size(max = 50)
-        String name,
+    @NotBlank
+    @Size(max = 50)
+    private String name;
 
-        @NotBlank
-        @Size(max = 100)
-        String country,
+    @NotBlank
+    @Size(max = 100)
+    private String country;
 
-        @NotNull
-        @Min(0) @Max(10)
-        Integer fractionDigits
-) {
+    @NotNull
+    @Min(0) @Max(10)
+    private Integer fractionDigits;
 }
-

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/in/CreateCurrencyDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/in/CreateCurrencyDto.java
@@ -1,0 +1,20 @@
+package com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.in;
+
+import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.common.CurrencyDto;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO создания валюты (in).
+ */
+@NoArgsConstructor
+public class CreateCurrencyDto extends CurrencyDto {
+
+    public CreateCurrencyDto(
+            String code,
+            String name,
+            String country,
+            Integer fractionDigits
+    ) {
+        super(code, name, country, fractionDigits);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.instrument.type.forex.currency.catalog.web.
 
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.common.CurrencyDto;
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.in.UpdateCurrencyDto;
+import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.out.CurrencyResponseDto;
 import com.alligator.market.domain.instrument.type.forex.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
@@ -26,10 +27,10 @@ public final class CurrencyDtoMapper {
         Objects.requireNonNull(dto, "dto must not be null");
 
         return new Currency(
-                CurrencyCode.of(dto.code()),
-                dto.name(),
-                dto.country(),
-                dto.fractionDigits()
+                CurrencyCode.of(dto.getCode()),
+                dto.getName(),
+                dto.getCountry(),
+                dto.getFractionDigits()
         );
     }
 
@@ -49,12 +50,12 @@ public final class CurrencyDtoMapper {
     }
 
     /**
-     * Преобразует доменную модель в основной DTO.
+     * Преобразует доменную модель в DTO ответа.
      */
-    public static CurrencyDto toDto(Currency currency) {
+    public static CurrencyResponseDto toResponseDto(Currency currency) {
         Objects.requireNonNull(currency, "currency must not be null");
 
-        return new CurrencyDto(
+        return new CurrencyResponseDto(
                 currency.code().value(),
                 currency.name(),
                 currency.country(),

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/out/CurrencyResponseDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/out/CurrencyResponseDto.java
@@ -1,0 +1,20 @@
+package com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.out;
+
+import com.alligator.market.backend.instrument.type.forex.currency.catalog.web.dto.common.CurrencyDto;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO ответа по валюте (out).
+ */
+@NoArgsConstructor
+public class CurrencyResponseDto extends CurrencyDto {
+
+    public CurrencyResponseDto(
+            String code,
+            String name,
+            String country,
+            Integer fractionDigits
+    ) {
+        super(code, name, country, fractionDigits);
+    }
+}

--- a/frontend/src/app/features/currency/models/currency.model.ts
+++ b/frontend/src/app/features/currency/models/currency.model.ts
@@ -1,7 +1,13 @@
-/** DTO для валюты аналогичный backend. */
+/** Общий DTO валюты (общий контракт). */
 export interface CurrencyDto {
   code: string;
   name: string;
   country: string;
   fractionDigits: number;
 }
+
+/** DTO создания валюты (in). */
+export type CreateCurrencyDto = CurrencyDto;
+
+/** DTO ответа по валюте (out). */
+export type CurrencyResponseDto = CurrencyDto;

--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
@@ -14,7 +14,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCardModule } from '@angular/material/card';
 
-import { CurrencyDto } from '../../models/currency.model';
+import { CreateCurrencyDto, CurrencyResponseDto } from '../../models/currency.model';
 import { UpdateCurrencyDto } from '../../models/currency-update.model';
 import { CurrencyService } from '../../services/currency.service';
 
@@ -41,7 +41,7 @@ export class CurrencyAdminComponent implements OnInit {
   // Табличные данные
   //=================
   displayed: string[] = ['code', 'name', 'country', 'fractionDigits', 'actions'];
-  dataSource = new MatTableDataSource<CurrencyDto>([]);
+  dataSource = new MatTableDataSource<CurrencyResponseDto>([]);
 
   //========================
   // Форма добавления валюты
@@ -110,7 +110,7 @@ export class CurrencyAdminComponent implements OnInit {
 
     this.locked = true; // блокируем кнопку
 
-    const dto: CurrencyDto = this.form.value;
+    const dto: CreateCurrencyDto = this.form.value;
 
     this.service.add(dto).subscribe({
       next: code => {
@@ -137,7 +137,7 @@ export class CurrencyAdminComponent implements OnInit {
   }
 
   /* клик по иконке Edit */
-  onEdit(c: CurrencyDto): void {
+  onEdit(c: CurrencyResponseDto): void {
     this.editing = true;
     this.editCode = c.code;
     this.form.setValue({

--- a/frontend/src/app/features/currency/services/currency.service.ts
+++ b/frontend/src/app/features/currency/services/currency.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 
-import { CurrencyDto } from '../models/currency.model';
+import { CreateCurrencyDto, CurrencyResponseDto } from '../models/currency.model';
 import { ApiResponse } from '../../../shared/api/api-response.model';
 import { UpdateCurrencyDto } from '../models/currency-update.model';
 
@@ -18,14 +18,14 @@ export class CurrencyService {
   private readonly baseUrl = '/api/v1/currencies';
 
   /* Получить список всех валют. */
-  list(): Observable<CurrencyDto[]> {
+  list(): Observable<CurrencyResponseDto[]> {
     return this.http
-      .get<ApiResponse<CurrencyDto[]>>(this.baseUrl)
+      .get<ApiResponse<CurrencyResponseDto[]>>(this.baseUrl)
       .pipe(map(res => res.data ?? []));
   }
 
   /* Добавить валюту, backend вернёт её код. */
-  add(dto: CurrencyDto): Observable<string> {
+  add(dto: CreateCurrencyDto): Observable<string> {
     return this.http
       .post<ApiResponse<string>>(this.baseUrl, dto)
       .pipe(map(res => res.data ?? ''));

--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -14,7 +14,7 @@ import { FxSpotCreateDto } from '../../models/fx-spot-create.model';
 import { FxSpotService } from '../../services/fx-spot.service';
 import { FxSpotUpdateDto } from '../../models/fx-spot-update.model';
 import { CurrencyService } from '../../../currency/services/currency.service';
-import { CurrencyDto } from '../../../currency/models/currency.model';
+import { CurrencyResponseDto } from '../../../currency/models/currency.model';
 import { FxSpotValueDate } from '../../models/fx-spot-value-date.model';
 
 @Component({
@@ -52,7 +52,7 @@ export class FxSpotAdminComponent implements OnInit {
   editing = false; // режим редактирования
   editCode: string | null = null; // внутренний код инструмента для редактирования (получаем с backend)
   editSymbol: string | null = null; // символ инструмента для уведомления
-  currencies: CurrencyDto[] = [];
+  currencies: CurrencyResponseDto[] = [];
   valueDates = Object.values(FxSpotValueDate);
 
   constructor(


### PR DESCRIPTION
### Motivation
- Сохранить архитектурное разделение входных/выходных контрактов (in/out) без дублирования полей.
- Обеспечить единый базовый контракт для DTO, чтобы уменьшить копипаст при сохранении ясности API.

### Description
- Заменён Java `record` `CurrencyDto` на обычный класс с Lombok-генерируемыми геттерами/конструкторами и общими полями (`code`, `name`, `country`, `fractionDigits`).
- Добавлены алиасы: `CreateCurrencyDto` (in) и `CurrencyResponseDto` (out), и в маппере реализован `toResponseDto` вместо прямого создания общего DTO, используя `CurrencyDtoMapper`.
- Обновлён контроллер `CurrencyController` для приёма `CreateCurrencyDto` и возвращения списка `CurrencyResponseDto` через `CurrencyDtoMapper`.
- На фронтенде добавлены типы-алиасы в `currency.model.ts` (`CreateCurrencyDto`, `CurrencyResponseDto`) и скорректированы `CurrencyService`, `CurrencyAdminComponent` и `FxSpotAdminComponent` для использования новых контрактов.

### Testing
- Автоматические тесты не запускались.
- Изменения зафиксированы в коммите `Define currency in/out DTO aliases`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc8b8263c832db959388dbd314e5d)