### PR TITLE
Заменить `minUpdateInterval` в `ProviderCatalogItem` на `ProviderPolicy`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogItem.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogItem.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.provider.catalog.service;
 
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 
-import java.time.Duration;
 import java.util.Objects;
 
 /**
@@ -13,12 +13,12 @@ import java.util.Objects;
 public record ProviderCatalogItem(
         String providerCode,
         ProviderDescriptor descriptor,
-        Duration minUpdateInterval
+        ProviderPolicy policy
 ) {
     public ProviderCatalogItem {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(descriptor, "descriptor must not be null");
-        Objects.requireNonNull(minUpdateInterval, "minUpdateInterval must not be null");
+        Objects.requireNonNull(policy, "policy must not be null");
 
         if (providerCode.isBlank()) {
             throw new IllegalArgumentException("providerCode must not be blank");

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogService.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.catalog.service;
 import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderEntity;
 import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderJpaRepository;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,11 +47,12 @@ public class ProviderCatalogService implements ProviderCatalogUseCase {
                 policyEmbeddable.getMinUpdateInterval(),
                 "minUpdateInterval must not be null"
         );
+        var policy = new ProviderPolicy(minUpdateInterval);
 
         return new ProviderCatalogItem(
                 entity.getProviderCode(),
                 descriptor,
-                minUpdateInterval
+                policy
         );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/mapper/ProviderDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/mapper/ProviderDtoMapper.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.catalog.web.dto.mapper;
 import com.alligator.market.backend.provider.catalog.service.ProviderCatalogItem;
 import com.alligator.market.backend.provider.catalog.web.dto.out.ProviderResponseDto;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
+import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -24,7 +25,8 @@ public final class ProviderDtoMapper {
         Objects.requireNonNull(item, "item must not be null");
 
         ProviderDescriptor descriptor = item.descriptor();
-        Duration minUpdateInterval = item.minUpdateInterval();
+        ProviderPolicy policy = item.policy();
+        Duration minUpdateInterval = policy.minUpdateInterval();
 
         return new ProviderResponseDto(
                 item.providerCode(),


### PR DESCRIPTION
### Motivation

- Устранить несоответствие между моделью каталога и доменной моделью, где политика провайдера (`ProviderPolicy`) содержит `minUpdateInterval`. 
- Сделать структуру объекта каталога более однородной и аналогичной полю `descriptor`. 
- Подготовить почву для расширения `ProviderPolicy` дополнительными параметрами в будущем. 

### Description

- Заменено поле `Duration minUpdateInterval` на `ProviderPolicy policy` в `ProviderCatalogItem`. 
- В `ProviderCatalogService` при маппинге из `ProviderEntity` теперь создаётся `ProviderPolicy` с `minUpdateInterval` из `ProviderPolicyEmbeddable`. 
- В `ProviderDtoMapper` чтение интервала обновления теперь производится через `item.policy().minUpdateInterval()`. 
- Обновлены соответствующие импорты и проверки на `null` для нового поля `policy`. 

### Testing

- Автоматические тесты не запускались. 
- Нет записей о сборке или прогоне тестов в изменениях, поэтому состояния тестов не подтверждены.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504c557984832da5432b1188237fa8)