### PR TITLE
Add `ProviderCode` value object and unify provider code handling

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProps;
 import com.alligator.market.backend.provider.adapter.moex.iss.handler.forex.spot.MoexIssFxSpotHandler;
 import com.alligator.market.backend.provider.contract.SpringMarketDataProvider;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.AccessMethod;
 import com.alligator.market.domain.provider.contract.descriptor.DeliveryMode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
@@ -24,7 +25,7 @@ import java.util.Set;
 public class MoexIssAdapter extends SpringMarketDataProvider<MoexIssAdapter> {
 
     /* Технический код провайдера: UPPERCASE, формат [A-Z0-9_]+. */
-    public static final String PROVIDER_CODE = "MOEX_ISS";
+    public static final ProviderCode PROVIDER_CODE = ProviderCode.of("MOEX_ISS");
 
     /* Отображаемое имя провайдера. */
     private static final String DISPLAY_NAME = "MOEX Informational & Statistical Server";

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
@@ -256,7 +256,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
         Instant receivedTs = Instant.now();
 
         // 10) Берём код провайдера из прикреплённого адаптера
-        String providerCode = provider().providerCode();
+        var providerCode = provider().providerCode();
 
         // 11) Собираем итоговый QuoteTick
         return QuoteTick.lastTrade(

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/ProFinanceAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/ProFinanceAdapter.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.adapter.profinance;
 import com.alligator.market.backend.provider.adapter.profinance.config.ProFinanceAdapterProps;
 import com.alligator.market.backend.provider.adapter.profinance.handler.forex.spot.ProFinanceFxSpotHandler;
 import com.alligator.market.backend.provider.contract.SpringMarketDataProvider;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.AccessMethod;
 import com.alligator.market.domain.provider.contract.descriptor.DeliveryMode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
@@ -21,7 +22,7 @@ import java.util.Set;
 public class ProFinanceAdapter extends SpringMarketDataProvider<ProFinanceAdapter> {
 
     /* Технический код провайдера: UPPERCASE, формат [A-Z0-9_]+. */
-    private static final String PROVIDER_CODE = "PROFINANCE";
+    private static final ProviderCode PROVIDER_CODE = ProviderCode.of("PROFINANCE");
 
     /* Отображаемое имя провайдера. */
     private static final String DISPLAY_NAME = "ProFinance HTML parse";

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.adapter.twelve.free;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
 import com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.spot.TwelveFreeFxSpotHandler;
 import com.alligator.market.backend.provider.contract.SpringMarketDataProvider;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.AccessMethod;
 import com.alligator.market.domain.provider.contract.descriptor.DeliveryMode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
@@ -21,7 +22,7 @@ import java.util.Set;
 public class TwelveFreeAdapterV2 extends SpringMarketDataProvider<TwelveFreeAdapterV2> {
 
     /* Технический код провайдера: UPPERCASE, формат [A-Z0-9_]+. */
-    private static final String PROVIDER_CODE = "TWELVE_FREE";
+    private static final ProviderCode PROVIDER_CODE = ProviderCode.of("TWELVE_FREE");
 
     /* Отображаемое имя провайдера. */
     private static final String DISPLAY_NAME = "TwelveData Free Plan";

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jdbc/ProviderSyncDaoPostgresAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jdbc/ProviderSyncDaoPostgresAdapter.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.catalog.persistence.jdbc;
 
 import com.alligator.market.backend.common.persistence.jpa.converter.DurationToSecondsConverter;
 import com.alligator.market.backend.config.audit.context.AuditContextHolder;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.reconciliation.ProviderSyncDao;
 import com.alligator.market.domain.provider.reconciliation.dto.ProviderSnapshot;
 import org.springframework.dao.DataAccessException;
@@ -74,7 +75,7 @@ public class ProviderSyncDaoPostgresAdapter implements ProviderSyncDao {
      * @throws DataAccessException если БД вернула ошибку
      */
     @Override
-    public void deleteByCodes(Collection<String> codes) {
+    public void deleteByCodes(Collection<ProviderCode> codes) {
         if (codes == null || codes.isEmpty()) return;
 
         // SQL-команда
@@ -82,7 +83,10 @@ public class ProviderSyncDaoPostgresAdapter implements ProviderSyncDao {
 
         // Преобразуем коллекцию в массив — нужен индекс для BatchPreparedStatementSetter и фиксированный размер батча.
         // Предполагаем, что коды пришли из БД (или модели ProviderSnapshot) и уже нормализованы.
-        var arr = codes.stream().filter(Objects::nonNull).toArray(String[]::new);
+        var arr = codes.stream()
+                .filter(Objects::nonNull)
+                .map(ProviderCode::value)
+                .toArray(String[]::new);
 
         // Пакетно выполняем DELETE: привязываем provider_code по индексу и задаём размер батча.
         jdbc.batchUpdate(sql, new BatchPreparedStatementSetter() {
@@ -171,7 +175,7 @@ public class ProviderSyncDaoPostgresAdapter implements ProviderSyncDao {
         // Примечание: иные проверки не обязательны — корректность данных гарантируется моделью ProviderSnapshot
 
         // 1) provider_code (натуральный ключ)
-        ps.setString(1, s.code());
+        ps.setString(1, s.code().value());
 
         // 2) descriptor.*
         var d = s.descriptor();

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/jpa/ProviderEntity.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.catalog.persistence.jpa;
 import com.alligator.market.backend.common.persistence.jpa.entity.BaseEntity;
 import com.alligator.market.backend.provider.catalog.persistence.jpa.descriptor.ProviderDescriptorEmbeddable;
 import com.alligator.market.backend.provider.catalog.persistence.jpa.policy.ProviderPolicyEmbeddable;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.reconciliation.ProviderSynchronizer;
 import jakarta.persistence.*;
@@ -44,7 +45,7 @@ import java.util.Objects;
         // CHECK: при DDL-генерации создаётся Hibernate; иначе — «живая» спецификация для миграций.
         constraints = "min_update_interval_seconds >= 1 " +
                 "AND provider_code = upper(provider_code) " +
-                "AND provider_code ~ '^[A-Z0-9_.-]+$' " +
+                "AND provider_code ~ '" + ProviderCode.PATTERN + "' " +
                 "AND delivery_mode IN ('PULL', 'PUSH') " +
                 "AND access_method IN ('API_POLL', 'WEBSOCKET', 'FIX_PROTOCOL')"
 )
@@ -73,7 +74,7 @@ public class ProviderEntity extends BaseEntity {
      */
     @NotBlank
     @Size(max = 50)
-    @Pattern(regexp = "^[A-Z0-9_.-]+$")
+    @Pattern(regexp = ProviderCode.PATTERN)
     @NaturalId() // <-- Помечаем поле как натуральный ключ
     @Column(name = "provider_code", length = 50, nullable = false, updatable = false)
     private String providerCode;
@@ -102,18 +103,15 @@ public class ProviderEntity extends BaseEntity {
      * @param policy       Иммутабельный набор параметров "политики провайдера"
      */
     ProviderEntity(
-            String providerCode,
+            ProviderCode providerCode,
             ProviderDescriptorEmbeddable descriptor,
             ProviderPolicyEmbeddable policy
     ) {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(descriptor, "descriptor must not be null");
         Objects.requireNonNull(policy, "policy must not be null");
-        if (providerCode.isBlank()) {
-            throw new IllegalArgumentException("providerCode must not be blank");
-        }
 
-        this.providerCode = providerCode;
+        this.providerCode = providerCode.value();
         this.descriptor = descriptor;
         this.policy = policy;
     }
@@ -123,7 +121,7 @@ public class ProviderEntity extends BaseEntity {
      */
     @SuppressWarnings("unused")
     public static ProviderEntity of(
-            String providerCode,
+            ProviderCode providerCode,
             ProviderDescriptorEmbeddable descriptor,
             ProviderPolicyEmbeddable policy
     ) {

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/repository/ProviderRepositoryJpaAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/persistence/repository/ProviderRepositoryJpaAdapter.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.catalog.persistence.repository;
 
 import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderJpaRepository;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.repository.ProviderRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +27,9 @@ public class ProviderRepositoryJpaAdapter implements ProviderRepository {
      * Найти все коды провайдеров (натуральные ключи).
      */
     @Override
-    public List<String> findAllCodes() {
-        return jpa.findAllCodes(); // <-- Читаем дешёвую проекцию, без загрузки сущностей
+    public List<ProviderCode> findAllCodes() {
+        return jpa.findAllCodes().stream()
+                .map(ProviderCode::of)
+                .toList(); // <-- Читаем дешёвую проекцию, без загрузки сущностей
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogItem.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogItem.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.provider.catalog.service;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 
@@ -11,7 +12,7 @@ import java.util.Objects;
  * <p>Применяется только в backend-слое приложения.</p>
  */
 public record ProviderCatalogItem(
-        String providerCode,
+        ProviderCode providerCode,
         ProviderDescriptor descriptor,
         ProviderPolicy policy
 ) {
@@ -19,9 +20,5 @@ public record ProviderCatalogItem(
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(descriptor, "descriptor must not be null");
         Objects.requireNonNull(policy, "policy must not be null");
-
-        if (providerCode.isBlank()) {
-            throw new IllegalArgumentException("providerCode must not be blank");
-        }
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/service/ProviderCatalogService.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.catalog.service;
 
 import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderEntity;
 import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderJpaRepository;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +51,7 @@ public class ProviderCatalogService implements ProviderCatalogUseCase {
         var policy = new ProviderPolicy(minUpdateInterval);
 
         return new ProviderCatalogItem(
-                entity.getProviderCode(),
+                ProviderCode.of(entity.getProviderCode()),
                 descriptor,
                 policy
         );

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/mapper/ProviderDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/web/dto/mapper/ProviderDtoMapper.java
@@ -29,7 +29,7 @@ public final class ProviderDtoMapper {
         Duration minUpdateInterval = policy.minUpdateInterval();
 
         return new ProviderResponseDto(
-                item.providerCode(),
+                item.providerCode().value(),
                 descriptor.displayName(),
                 descriptor.deliveryMode().name(),
                 descriptor.accessMethod().name(),

--- a/backend/src/main/java/com/alligator/market/backend/provider/contract/SpringMarketDataProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/contract/SpringMarketDataProvider.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.provider.contract;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.AbstractMarketDataProvider;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
@@ -31,7 +32,7 @@ public abstract class SpringMarketDataProvider<P extends MarketDataProvider>
      * Конструктор.
      */
     protected SpringMarketDataProvider(
-            String providerCode,
+            ProviderCode providerCode,
             ProviderDescriptor descriptor,
             ProviderPolicy policy,
             ProviderSettings settings,
@@ -66,10 +67,10 @@ public abstract class SpringMarketDataProvider<P extends MarketDataProvider>
      */
     @Override
     public void afterPropertiesSet() {
-        if (!beanName.equals(providerCode())) {
+        if (!beanName.equals(providerCode().value())) {
             throw new IllegalStateException(
                     "Bean name must equal providerCode (name='" + beanName + "', providerCode='" +
-                            providerCode() + "')"
+                            providerCode().value() + "')"
             );
         }
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/resolver/DefaultInstrumentProviderResolver.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/resolver/DefaultInstrumentProviderResolver.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.provider.resolver;
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssAdapter;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.resolver.InstrumentProviderResolver;
 import org.springframework.stereotype.Service;
 
@@ -19,10 +20,10 @@ import java.util.Objects;
 public class DefaultInstrumentProviderResolver implements InstrumentProviderResolver {
 
     /* Код провайдера MOEX ISS. */
-    private static final String MOEX_ISS_PROVIDER_CODE = MoexIssAdapter.PROVIDER_CODE;
+    private static final ProviderCode MOEX_ISS_PROVIDER_CODE = MoexIssAdapter.PROVIDER_CODE;
 
     @Override
-    public String resolveProvider(Instrument instrument) {
+    public ProviderCode resolveProvider(Instrument instrument) {
         Objects.requireNonNull(instrument, "instrument must not be null");
 
         // Пока что вся FX_SPOT-линейка обслуживается только MOEX ISS.

--- a/backend/src/main/java/com/alligator/market/backend/quote/feed/catalog/persistence/jpa/InstrumentFeedConfigEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/feed/catalog/persistence/jpa/InstrumentFeedConfigEntity.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.quote.feed.catalog.persistence.jpa;
 import com.alligator.market.backend.common.persistence.jpa.entity.BaseEntity;
 import com.alligator.market.backend.instrument.base.persistence.jpa.InstrumentBaseEntity;
 import com.alligator.market.backend.provider.catalog.persistence.jpa.ProviderEntity;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.quote.feed.InstrumentFeedRole;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -15,7 +16,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.Check;
 
-import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -51,7 +51,7 @@ import java.util.Objects;
 public class InstrumentFeedConfigEntity extends BaseEntity {
 
     /* Шаблон кода провайдера: только A-Z, 0-9 и символы "_.-". */
-    static final String PROVIDER_CODE_PATTERN = "^[A-Z0-9_.-]+$";
+    static final String PROVIDER_CODE_PATTERN = ProviderCode.PATTERN;
 
     /**
      * Суррогатный PK.
@@ -122,7 +122,7 @@ public class InstrumentFeedConfigEntity extends BaseEntity {
     ) {
         this.instrument = Objects.requireNonNull(instrument, "instrument must not be null");
         this.feedRole = Objects.requireNonNull(feedRole, "feedRole must not be null");
-        this.providerCode = normalizeProviderCode(providerCode);
+        this.providerCode = ProviderCode.of(providerCode).value();
         this.enabled = enabled;
     }
 
@@ -130,7 +130,7 @@ public class InstrumentFeedConfigEntity extends BaseEntity {
      * Меняет код провайдера.
      */
     public void updateProviderCode(String providerCode) {
-        this.providerCode = normalizeProviderCode(providerCode);
+        this.providerCode = ProviderCode.of(providerCode).value();
     }
 
     /**
@@ -140,25 +140,4 @@ public class InstrumentFeedConfigEntity extends BaseEntity {
         this.enabled = enabled;
     }
 
-    /**
-     * Нормализует и валидирует код провайдера.
-     */
-    private static String normalizeProviderCode(String providerCode) {
-        Objects.requireNonNull(providerCode, "providerCode must not be null");
-
-        String n = providerCode.strip(); // <-- обрезаем пробелы
-        if (n.isEmpty()) {
-            throw new IllegalArgumentException("providerCode must not be blank");
-        }
-
-        // Нормализуем в UPPERCASE
-        n = n.toUpperCase(Locale.ROOT);
-
-        // Fail-fast проверка формата (дублирует @Pattern/@Check, но даёт раннюю ошибку).
-        if (!n.matches(PROVIDER_CODE_PATTERN)) {
-            throw new IllegalArgumentException("providerCode has invalid format: " + n);
-        }
-
-        return n;
-    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamingOrchestrator.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamingOrchestrator.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.quote.streaming;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.contract.resolver.InstrumentProviderResolver;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
@@ -49,13 +50,13 @@ public class QuoteStreamingOrchestrator {
         Objects.requireNonNull(instrument, "instrument must not be null");
 
         // 1. Определяем, какой провайдер назначен для инструмента.
-        String providerCode = instrumentProviderResolver.resolveProvider(instrument);
+        ProviderCode providerCode = instrumentProviderResolver.resolveProvider(instrument);
 
         // 2. Находим бин провайдера по его коду.
-        MarketDataProvider provider = providersByCode.get(providerCode);
+        MarketDataProvider provider = providersByCode.get(providerCode.value());
         if (provider == null) {
             throw new IllegalStateException(
-                    "No MarketDataProvider bean found for code: " + providerCode
+                    "No MarketDataProvider bean found for code: " + providerCode.value()
             );
         }
 

--- a/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
@@ -59,7 +59,7 @@ class MoexIssFxSpotHandlerQuoteLiveTest {
 
                     assertNotNull(tick, "QuoteTick must not be null");
                     assertEquals(cnyRubTom.instrumentCode(), tick.instrumentCode(), "Instrument code must match");
-                    assertEquals("MOEX_ISS", tick.providerCode(), "Provider code must be MOEX_ISS");
+                    assertEquals("MOEX_ISS", tick.providerCode().value(), "Provider code must be MOEX_ISS");
 
                     assertNotNull(tick.last(), "LAST price must not be null");
                     assertTrue(tick.last().compareTo(BigDecimal.ZERO) > 0, "LAST price must be positive");

--- a/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteMockTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteMockTest.java
@@ -100,7 +100,7 @@ class MoexIssFxSpotHandlerQuoteMockTest {
                 .assertNext(tick -> {
                     assertNotNull(tick, "QuoteTick must not be null");
                     assertEquals(cnyRubTom.instrumentCode(), tick.instrumentCode());
-                    assertEquals("MOEX_ISS", tick.providerCode());
+                    assertEquals("MOEX_ISS", tick.providerCode().value());
 
                     assertEquals(new BigDecimal("10.95"), tick.last());
                     assertNull(tick.bid());

--- a/domain/src/main/java/com/alligator/market/domain/provider/code/ProviderCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/code/ProviderCode.java
@@ -1,0 +1,51 @@
+package com.alligator.market.domain.provider.code;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/* Объект-значение для технического кода провайдера. */
+public record ProviderCode(String value) {
+
+    /* Шаблон допустимых символов для кода провайдера. */
+    public static final String PATTERN = "^[A-Z0-9_.-]+$";
+
+    private static final int MAX_LENGTH = 50;
+    private static final Pattern VALIDATION_PATTERN = Pattern.compile(PATTERN);
+
+    public ProviderCode {
+        value = normalize(value);
+    }
+
+    public static ProviderCode of(String raw) {
+        return new ProviderCode(raw);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    private static String normalize(String raw) {
+        Objects.requireNonNull(raw, "providerCode must not be null");
+
+        String normalized = raw.strip();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("providerCode must not be blank");
+        }
+
+        normalized = normalized.toUpperCase(Locale.ROOT);
+
+        if (normalized.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("providerCode length must be <= " + MAX_LENGTH);
+        }
+
+        if (!VALIDATION_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    "providerCode must match pattern [A-Z0-9_.-]+: '" + normalized + "'"
+            );
+        }
+
+        return normalized;
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -2,6 +2,7 @@ package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.contract.handler.InstrumentHandler;
@@ -22,8 +23,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public abstract non-sealed class AbstractMarketDataProvider<P extends MarketDataProvider>
         implements MarketDataProvider {
 
-    /* Нормализованный технический код провайдера: UPPERCASE, формат [A-Z0-9_]+. */
-    protected final String normProviderCode;
+    /* Технический код провайдера. */
+    protected final ProviderCode providerCode;
 
     /* Дескриптор провайдера: иммутабельный набор статических атрибутов (только отображение). */
     protected final ProviderDescriptor descriptor;
@@ -51,7 +52,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      * <p>Проверяет инварианты, нормализует код провайдера, собирает карту "код инструмента --> обработчик",
      * прикрепляет обработчики к провайдеру.
      *
-     * @param providerCode код провайдера (UPPERCASE, формат [A-Z0-9_]+)
+     * @param providerCode код провайдера
      * @param descriptor   дескриптор провайдера
      * @param policy       политика провайдера
      * @param settings     настройки провайдера
@@ -60,7 +61,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      * @throws IllegalStateException    если обнаружены дубликаты обработчиков по коду или пересечения кодов инструментов
      */
     protected AbstractMarketDataProvider(
-            String providerCode,
+            ProviderCode providerCode,
             ProviderDescriptor descriptor,
             ProviderPolicy policy,
             ProviderSettings settings,
@@ -72,15 +73,12 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         Objects.requireNonNull(settings, "settings must not be null");
         Objects.requireNonNull(handlers, "handlers must not be null");
 
-        if (providerCode.isBlank()) {
-            throw new IllegalArgumentException("providerCode must not be blank");
-        }
         if (handlers.isEmpty()) {
             throw new IllegalArgumentException("handlers must not be empty");
         }
 
         // Инициализация базовых атрибутов провайдера
-        this.normProviderCode = normalizeProviderCode(providerCode);
+        this.providerCode = providerCode;
         this.descriptor = descriptor;
         this.policy = policy;
         this.settingsRef = new AtomicReference<>(settings);
@@ -90,7 +88,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         for (var h : handlers) {
             var code = h.handlerCode();
             if (!handlerCodes.add(code)) {
-                throw new IllegalStateException("Provider '" + providerCode +
+                throw new IllegalStateException("Provider '" + providerCode.value() +
                         "' contains multiple handlers with the same code '" + code + "'");
             }
         }
@@ -110,7 +108,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
                     // Запрещаем связывать один и тот же код с разными обработчиками
                     throw new IllegalStateException("Instrument code '" + upper +
                             "' is already bound to handler '" + prev.handlerCode() +
-                            "' in provider '" + providerCode + "'");
+                            "' in provider '" + providerCode.value() + "'");
                 }
                 allCodes.add(upper);
             }
@@ -136,8 +134,8 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      * Технический код провайдера.
      */
     @Override
-    public String providerCode() {
-        return normProviderCode;
+    public ProviderCode providerCode() {
+        return providerCode;
     }
 
     /**
@@ -193,7 +191,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
 
         var handler = handlerOf(instrument);
         if (handler == null) {
-            throw new HandlerNotFoundException(instrument.instrumentCode(), normProviderCode);
+            throw new HandlerNotFoundException(instrument.instrumentCode(), providerCode);
         }
         return handler.quote(instrument);
     }
@@ -218,27 +216,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     protected final void replaceSettings(ProviderSettings newSettings) {
         Objects.requireNonNull(newSettings, "newSettings must not be null");
         settingsRef.set(newSettings);
-    }
-
-    //=================================================================================================================
-    // УТИЛИТЫ
-    //=================================================================================================================
-
-    /**
-     * Нормализует и валидирует код провайдера: trim --> UPPERCASE --> проверка формата [A-Z0-9_]+.
-     *
-     * @throws IllegalArgumentException если код провайдера не соответствует формату
-     */
-    private static String normalizeProviderCode(String code) {
-        // Нормализуем код провайдера
-        var normalized = code.trim().toUpperCase(java.util.Locale.ROOT);
-        // Разрешены только латинские заглавные, цифры и подчёркивание
-        if (!normalized.chars().allMatch(ch ->
-                (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_')) {
-            throw new IllegalArgumentException(
-                    "providerCode must match pattern [A-Z0-9_]+: '" + normalized + "'");
-        }
-        return normalized;
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -2,6 +2,7 @@ package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
@@ -16,9 +17,9 @@ import java.util.Set;
 public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
 
     /**
-     * Технический код провайдера: UPPERCASE, формат [A-Z0-9_]+.
+     * Технический код провайдера.
      */
-    String providerCode();
+    ProviderCode providerCode();
 
     /**
      * Дескриптор провайдера: иммутабельный набор статических атрибутов (только отображение).

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/resolver/InstrumentProviderResolver.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/resolver/InstrumentProviderResolver.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.provider.contract.resolver;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.provider.code.ProviderCode;
 
 /**
  * Контракт сервиса, который разрешает соответствие «финансовый инструмент → провайдер рыночных данных».
@@ -16,5 +17,5 @@ public interface InstrumentProviderResolver {
      * провайдера и обработчика. Цель данного метода – вернуть код провайдера, который был назначен администраторами
      * или пользователями приложения для получения потока котировок для заданного инструмента.
      */
-    String resolveProvider(Instrument instrument);
+    ProviderCode resolveProvider(Instrument instrument);
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
+
 import java.util.Objects;
 
 /**
@@ -8,7 +10,7 @@ import java.util.Objects;
 public final class HandlerNotFoundException extends RuntimeException {
 
     private final String instrumentCode;
-    private final String providerCode;
+    private final ProviderCode providerCode;
 
     /**
      * Создает исключение.
@@ -16,7 +18,7 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @param instrumentCode код инструмента
      * @param providerCode   код провайдера
      */
-    public HandlerNotFoundException(String instrumentCode, String providerCode) {
+    public HandlerNotFoundException(String instrumentCode, ProviderCode providerCode) {
         super(msg(instrumentCode, providerCode));
         this.instrumentCode = instrumentCode;
         this.providerCode = providerCode;
@@ -30,7 +32,7 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @param cause          причина ошибки
      */
     @SuppressWarnings("unused")
-    public HandlerNotFoundException(String instrumentCode, String providerCode, Throwable cause) {
+    public HandlerNotFoundException(String instrumentCode, ProviderCode providerCode, Throwable cause) {
         super(msg(instrumentCode, providerCode), cause);
         this.instrumentCode = instrumentCode;
         this.providerCode = providerCode;
@@ -43,10 +45,10 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @param providerCode   код провайдера
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode, String providerCode) {
+    private static String msg(String instrumentCode, ProviderCode providerCode) {
         String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        String pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
-        return "Handler not found (instrumentCode=" + ic + ", providerCode=" + pc + ")";
+        ProviderCode pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
+        return "Handler not found (instrumentCode=" + ic + ", providerCode=" + pc.value() + ")";
     }
 
     /**
@@ -65,7 +67,7 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @return код провайдера
      */
     @SuppressWarnings("unused")
-    public String getProviderCode() {
+    public ProviderCode getProviderCode() {
         return providerCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderCodeDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderCodeDuplicateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
+
 import java.util.Objects;
 
 /**
@@ -7,14 +9,14 @@ import java.util.Objects;
  */
 public final class ProviderCodeDuplicateException extends RuntimeException {
 
-    private final String providerCode;
+    private final ProviderCode providerCode;
 
     /**
      * Создает исключение.
      *
      * @param providerCode код провайдера
      */
-    public ProviderCodeDuplicateException(String providerCode) {
+    public ProviderCodeDuplicateException(ProviderCode providerCode) {
         super(msg(providerCode));
         this.providerCode = providerCode;
     }
@@ -26,7 +28,7 @@ public final class ProviderCodeDuplicateException extends RuntimeException {
      * @param cause        причина ошибки
      */
     @SuppressWarnings("unused")
-    public ProviderCodeDuplicateException(String providerCode, Throwable cause) {
+    public ProviderCodeDuplicateException(ProviderCode providerCode, Throwable cause) {
         super(msg(providerCode), cause);
         this.providerCode = providerCode;
     }
@@ -37,9 +39,9 @@ public final class ProviderCodeDuplicateException extends RuntimeException {
      * @param providerCode код провайдера
      * @return текст сообщения
      */
-    private static String msg(String providerCode) {
-        String pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
-        return "Duplicate provider code detected (code=" + pc + ")";
+    private static String msg(ProviderCode providerCode) {
+        ProviderCode pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
+        return "Duplicate provider code detected (code=" + pc.value() + ")";
     }
 
     /**
@@ -48,7 +50,7 @@ public final class ProviderCodeDuplicateException extends RuntimeException {
      * @return код провайдера
      */
     @SuppressWarnings("unused")
-    public String getProviderCode() {
+    public ProviderCode getProviderCode() {
         return providerCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSyncDao.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSyncDao.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.reconciliation;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.reconciliation.dto.ProviderSnapshot;
 
 import java.util.Collection;
@@ -12,7 +13,7 @@ public interface ProviderSyncDao {
     /**
      * Удалить записи провайдеров по набору технических кодов.
      */
-    void deleteByCodes(Collection<String> codes);
+    void deleteByCodes(Collection<ProviderCode> codes);
 
     /**
      * Выполнить пакетный UPSERT снимков провайдеров.

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSynchronizer.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/ProviderSynchronizer.java
@@ -4,6 +4,8 @@ import com.alligator.market.domain.provider.reconciliation.dto.ProviderSnapshot;
 import com.alligator.market.domain.provider.reconciliation.scanner.ProviderContextScanner;
 import com.alligator.market.domain.provider.repository.ProviderRepository;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
+
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -37,8 +39,8 @@ public class ProviderSynchronizer {
      */
     public void synchronize() {
         // 1) Читаем снимки из контекста и коды из БД
-        Map<String, ProviderSnapshot> ctx = contextScanner.providerSnapshots();
-        Set<String> repoCodes = new LinkedHashSet<>(repository.findAllCodes());
+        Map<ProviderCode, ProviderSnapshot> ctx = contextScanner.providerSnapshots();
+        Set<ProviderCode> repoCodes = new LinkedHashSet<>(repository.findAllCodes());
 
         // Если в контексте пусто — чистим таблицу и выходим
         if (ctx.isEmpty()) {
@@ -49,7 +51,7 @@ public class ProviderSynchronizer {
         }
 
         // 2) Вычисляем устаревшие коды (есть в БД, нет в контексте) и удаляем их
-        Set<String> obsolete = new LinkedHashSet<>(repoCodes);
+        Set<ProviderCode> obsolete = new LinkedHashSet<>(repoCodes);
         obsolete.removeAll(ctx.keySet());
         if (!obsolete.isEmpty()) {
             syncDao.deleteByCodes(obsolete); // <-- batch DELETE

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/dto/ProviderSnapshot.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/dto/ProviderSnapshot.java
@@ -1,9 +1,9 @@
 package com.alligator.market.domain.provider.reconciliation.dto;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.descriptor.ProviderDescriptor;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 
-import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -14,27 +14,16 @@ import java.util.Objects;
  * приложения.
  */
 public record ProviderSnapshot(
-        String code,
+        ProviderCode code,
         ProviderDescriptor descriptor,
         ProviderPolicy policy
 ) {
     /**
-     * Конструктор с проверками и нормализацией.
+     * Конструктор с проверками.
      */
     public ProviderSnapshot {
         Objects.requireNonNull(code, "Provider code must not be null");
         Objects.requireNonNull(descriptor, "Provider descriptor must not be null");
         Objects.requireNonNull(policy, "Provider policy must not be null");
-
-        // Нормализуем код провайдера
-        String c = code.strip(); // Обрезаем пробелы
-        if (c.isEmpty()) throw new IllegalArgumentException("Provider code must not be blank");
-        // Проверяем ограничение домена: максимум 50 символов
-        if (c.length() > 50)
-            throw new IllegalArgumentException("Provider code length must be less or equal to 50 characters");
-        c = c.toUpperCase(Locale.ROOT);
-
-        // Присваиваем проверенное и нормализованное значение
-        code = c;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/AbstractProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/AbstractProviderContextScanner.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.reconciliation.scanner;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.exception.ProviderCodeDuplicateException;
 import com.alligator.market.domain.provider.exception.ProviderDisplayNameDuplicateException;
@@ -22,12 +23,12 @@ public abstract non-sealed class AbstractProviderContextScanner implements Provi
      * Содержит проверки на дублирование по коду провайдера и отображаемому имени.
      */
     @Override
-    public final Map<String, ProviderSnapshot> providerSnapshots() {
-        Map<String, ProviderSnapshot> snapshots = new LinkedHashMap<>();
+    public final Map<ProviderCode, ProviderSnapshot> providerSnapshots() {
+        Map<ProviderCode, ProviderSnapshot> snapshots = new LinkedHashMap<>();
         Set<String> displayNamesLower = new HashSet<>();
 
         for (MarketDataProvider provider : providers()) {
-            String code = provider.providerCode();
+            ProviderCode code = provider.providerCode();
             var descriptor = provider.descriptor();
             var policy = provider.policy();
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/ProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/ProviderContextScanner.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.reconciliation.scanner;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.reconciliation.dto.ProviderSnapshot;
 
 import java.util.Map;
@@ -14,5 +15,5 @@ public sealed interface ProviderContextScanner permits AbstractProviderContextSc
      *
      * <p>Снимок провайдера {@link ProviderSnapshot} содержит данные о провайдере: код провайдера, дескриптор, "политику".
      */
-    Map<String, ProviderSnapshot> providerSnapshots();
+    Map<ProviderCode, ProviderSnapshot> providerSnapshots();
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/repository/ProviderRepository.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.repository;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
+
 import java.util.List;
 
 /**
@@ -10,5 +12,5 @@ public interface ProviderRepository {
     /**
      * Найти все коды провайдеров (натуральные ключи).
      */
-    List<String> findAllCodes();
+    List<ProviderCode> findAllCodes();
 }

--- a/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.quote.tick.model;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 
 import java.math.BigDecimal;
@@ -28,7 +29,7 @@ public record QuoteTick(
         BigDecimal ask,
         Instant exchangeTimestamp,
         Instant receivedTimestamp,
-        String providerCode
+        ProviderCode providerCode
 ) {
     /**
      * Фабрика тика по последней сделке (LAST): Поля "bid"/"ask" {@code null}.
@@ -38,7 +39,7 @@ public record QuoteTick(
             BigDecimal last,
             Instant exchangeTimestamp,
             Instant receivedTimestamp,
-            String providerCode
+            ProviderCode providerCode
     ) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         Objects.requireNonNull(last, "last must not be null");
@@ -66,7 +67,7 @@ public record QuoteTick(
             BigDecimal ask,
             Instant exchangeTimestamp,
             Instant receivedTimestamp,
-            String providerCode
+            ProviderCode providerCode
     ) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         Objects.requireNonNull(bid, "bid must not be null");


### PR DESCRIPTION
### Motivation
- Устранить рассинхронизацию форматов и дублирование логики нормализации/валидации кода провайдера в разных слоях приложения. 
- Ввести единый инвариант для технического кода провайдера и сделать контракт явным на уровне домена. 
- Облегчить поддержку и снизить риск ошибок при преобразованиях между DB/Backend/Domain/Frontend. 

### Description
- Добавлен доменный объект-значение `ProviderCode` с нормализацией (trim -> UPPERCASE), валидацией по `PATTERN = "^[A-Z0-9_.-]+$"` и ограничением длины (50), а также фабрикой `ProviderCode.of(...)`.
- Контракт `MarketDataProvider.providerCode()` возвращает теперь `ProviderCode`, и `AbstractMarketDataProvider` хранит `ProviderCode` вместо `String` и использует `providerCode.value()` при выводе на границах текста/логов.
- Переведены на `ProviderCode` соответствующие доменные компоненты: `ProviderSnapshot`, `ProviderContextScanner`, `ProviderRepository`, `ProviderSyncDao`, `ProviderSynchronizer`, исключения (`ProviderCodeDuplicateException`, `HandlerNotFoundException`) и `QuoteTick` (поле `providerCode` теперь `ProviderCode`).
- На границах и в backend-слое выполнены конвертации: `ProviderEntity` принимает `ProviderCode` и сохраняет `String` через `providerCode.value()`, `ProviderRepositoryJpaAdapter` маппит строки в `ProviderCode`, `ProviderSyncDaoPostgresAdapter` и `InstrumentFeedConfigEntity` используют `ProviderCode.of(...)`, а DTO/мэпперы и адаптеры возвращают/используют `.value()` при необходимости.

### Testing
- Автоматические тесты не запускались.
- Обновлены тесты под новый тип: `MoexIssFxSpotHandlerQuoteMockTest` и `MoexIssFxSpotHandlerQuoteLiveTest` (ассерт на `tick.providerCode().value()`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69505083c590832daaa4ca74e1505ea1)