### PR TITLE
Унификация валидации `CurrencyCode` с `ProviderCode`

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/model/CurrencyCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/model/CurrencyCode.java
@@ -1,6 +1,8 @@
 package com.alligator.market.domain.instrument.type.forex.currency.model;
 
+import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Объект-значение уникального кода валюты.
@@ -13,31 +15,52 @@ public record CurrencyCode(
         String value
 ) {
 
+    /* Шаблон допустимых символов для кода валюты. */
+    public static final String PATTERN = "^[A-Z]{3}$";
+
+    private static final int CODE_LENGTH = 3;
+    private static final Pattern VALIDATION_PATTERN = Pattern.compile(PATTERN);
+
     /**
-     * Конструктор с проверками.
+     * Конструктор.
      */
     public CurrencyCode {
-        Objects.requireNonNull(value, "Currency code must not be null");
-        // Соответствие стандартам ISO-4217
-        if (!isIso4217(value)) {
-            throw new IllegalArgumentException("Currency code must match [A-Z]{3}");
-        }
+        value = normalize(value);
     }
 
     /**
      * Фабрика для создания объекта из строкового кода.
      */
-    public static CurrencyCode of(String code) {
-        return new CurrencyCode(code);
+    public static CurrencyCode of(String raw) {
+        return new CurrencyCode(raw);
     }
 
     /**
-     * Локальная проверка: три заглавные латинские буквы (согласно стандарту ISO-4217).
+     * Метод проверки и нормализации входящего значения кода валюты.
+     *
+     * @param raw исходное строковое значение кода валюты
+     * @return нормализованное значение кода валюты
      */
-    private static boolean isIso4217(String s) {
-        return s.length() == 3
-                && s.charAt(0) >= 'A' && s.charAt(0) <= 'Z'
-                && s.charAt(1) >= 'A' && s.charAt(1) <= 'Z'
-                && s.charAt(2) >= 'A' && s.charAt(2) <= 'Z';
+    private static String normalize(String raw) {
+        Objects.requireNonNull(raw, "currencyCode must not be null");
+
+        String normalized = raw.strip();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("currencyCode must not be blank");
+        }
+
+        normalized = normalized.toUpperCase(Locale.ROOT);
+
+        if (normalized.length() != CODE_LENGTH) {
+            throw new IllegalArgumentException("currencyCode length must be " + CODE_LENGTH);
+        }
+
+        if (!VALIDATION_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    "currencyCode must match pattern [A-Z]{3}: '" + normalized + "'"
+            );
+        }
+
+        return normalized;
     }
 }


### PR DESCRIPTION
### Motivation
- Привести поведение `CurrencyCode` к единому стандарту с `ProviderCode` для консистентной нормализации и валидации кодов.
- Обеспечить строгую проверку формата ISO-4217 и более понятные сообщения об ошибках.
- Упростить повторное использование и проверку кодов по проекту.

### Description
- Добавлен `PATTERN`, `CODE_LENGTH` и `VALIDATION_PATTERN`, и заменена старая логика проверки на регулярное выражение для валидации кода валюты.
- Конструктор `CurrencyCode` теперь вызывает `normalize`, который выполняет `strip()` и `toUpperCase(Locale.ROOT)` и проверяет длину и соответствие паттерну.
- Фабрика обновлена на `of(String raw)`, сообщения об ошибках унифицированы и сделаны более информативными.
- Изменён файл `domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/model/CurrencyCode.java`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950ff16e640832d842084aedd5f5e2b)