### PR TITLE
Добавить объект-значение InstrumentCode

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/code/InstrumentCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/code/InstrumentCode.java
@@ -1,0 +1,69 @@
+package com.alligator.market.domain.instrument.code;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Объект-значение уникального кода инструмента.
+ *
+ * <p>Причина создания – необходимость соблюдения единого формата кода инструмента в рамках проекта.</p>
+ *
+ * @param value строковое значение кода инструмента
+ */
+public record InstrumentCode(
+        String value
+) {
+
+    /* Шаблон допустимых символов для кода инструмента. */
+    public static final String PATTERN = "^[A-Z0-9_]+$";
+
+    /* Максимальная длина кода инструмента. */
+    private static final int MAX_LENGTH = 50;
+
+    /* Шаблон для валидации кода инструмента. */
+    private static final Pattern VALIDATION_PATTERN = Pattern.compile(PATTERN);
+
+    /**
+     * Конструктор.
+     */
+    public InstrumentCode {
+        value = normalize(value);
+    }
+
+    /**
+     * Фабрика для создания объекта из строкового кода.
+     */
+    public static InstrumentCode of(String raw) {
+        return new InstrumentCode(raw);
+    }
+
+    /**
+     * Метод проверки и нормализации входящего значения кода инструмента.
+     *
+     * @param raw исходное строковое значение кода инструмента
+     * @return нормализованное значение кода инструмента
+     */
+    private static String normalize(String raw) {
+        Objects.requireNonNull(raw, "instrumentCode must not be null");
+
+        String normalized = raw.strip();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("instrumentCode must not be blank");
+        }
+
+        normalized = normalized.toUpperCase(Locale.ROOT);
+
+        if (normalized.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("instrumentCode length must be <= " + MAX_LENGTH);
+        }
+
+        if (!VALIDATION_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    "instrumentCode must match pattern [A-Z0-9_]+: '" + normalized + "'"
+            );
+        }
+
+        return normalized;
+    }
+}


### PR DESCRIPTION
### Motivation
- Унифицировать формат кода инструмента аналогично `ProviderCode` и `CurrencyCode`.
- Требуется допускать цифры, латинские буквы и символ `_` и хранить код в верхнем регистре.

### Description
- Добавлен объект-значение `InstrumentCode` в `domain/src/main/java/com/alligator/market/domain/instrument/code/InstrumentCode.java`.
- Реализована нормализация входной строки: `strip()` -> `toUpperCase(Locale.ROOT)` и проверка на пустую строку.
- Введена валидация по шаблону `PATTERN = "^[A-Z0-9_]+$"` и ограничение длины `MAX_LENGTH = 50`.
- Добавлена фабрика `of(String)` для создания экземпляров значения.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69511c9c755c832d99f611a74dc92738)