### PR TITLE
Применить InstrumentCode в доменном слое

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/contract/Instrument.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/contract/Instrument.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.instrument.contract;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 
 /**
@@ -10,7 +11,7 @@ public interface Instrument {
     /**
      * Внутренний код инструмента (уникален в контексте приложения).
      */
-    String instrumentCode();
+    InstrumentCode instrumentCode();
 
     /**
      * Символ инструмента для отображения в UI.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.instrument.type.forex.spot.codec;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
@@ -53,15 +54,15 @@ public final class FxSpotCodec {
     /**
      * Формирует внутренний код инструмента из доменных моделей кодов валют и даты валютирования.
      */
-    public static String fxSpotCode(CurrencyCode baseCode, CurrencyCode quoteCode, FxSpotValueDate valueDate) {
+    public static InstrumentCode fxSpotCode(CurrencyCode baseCode, CurrencyCode quoteCode, FxSpotValueDate valueDate) {
         // Добавляем префикс к символу
-        return TYPE_PREFIX + fxSpotSymbol(baseCode, quoteCode, valueDate);
+        return InstrumentCode.of(TYPE_PREFIX + fxSpotSymbol(baseCode, quoteCode, valueDate));
     }
 
     /**
      * Перегрузка: Формирует внутренний код инструмента из доменных моделей валют и даты валютирования.
      */
-    public static String fxSpotCode(Currency baseCurrency, Currency quoteCurrency, FxSpotValueDate valueDate) {
+    public static InstrumentCode fxSpotCode(Currency baseCurrency, Currency quoteCurrency, FxSpotValueDate valueDate) {
         Objects.requireNonNull(baseCurrency, "baseCurrency must not be null");
         Objects.requireNonNull(quoteCurrency, "quoteCurrency must not be null");
         Objects.requireNonNull(valueDate, "valueDate must not be null");
@@ -73,19 +74,28 @@ public final class FxSpotCodec {
      */
     public static FxSpotCodeParts parseFxSpotCode(String instrumentCode) {
         Objects.requireNonNull(instrumentCode, "Instrument code must not be null");
+        return parseFxSpotCode(InstrumentCode.of(instrumentCode));
+    }
 
-        if (!instrumentCode.startsWith(TYPE_PREFIX)) {
+    /**
+     * Разбирает код инструмента формата {@code FX_SPOT_<AAA><BBB>_<FxSpotValueDate>} на составные компоненты.
+     */
+    public static FxSpotCodeParts parseFxSpotCode(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        String codeValue = instrumentCode.value();
+
+        if (!codeValue.startsWith(TYPE_PREFIX)) {
             throw new IllegalArgumentException("Instrument code must start with " + TYPE_PREFIX);
         }
 
         final int start = TYPE_PREFIX.length();
-        final int sep = instrumentCode.indexOf(SEP, start);
+        final int sep = codeValue.indexOf(SEP, start);
         if (sep < 0) {
             throw new IllegalArgumentException("Instrument code must contain separator '_' after prefix "
                     + TYPE_PREFIX);
         }
 
-        final String pair = instrumentCode.substring(start, sep);
+        final String pair = codeValue.substring(start, sep);
         if (pair.length() != CURRENCY_PAIR_LENGTH) {
             throw new IllegalArgumentException("Currency pair must contain " + CURRENCY_PAIR_LENGTH + " characters");
         }
@@ -94,7 +104,7 @@ public final class FxSpotCodec {
         final String baseRaw = pair.substring(0, CURRENCY_CODE_LENGTH);
         final String quoteRaw = pair.substring(CURRENCY_CODE_LENGTH);
 
-        final String valueDateRaw = instrumentCode.substring(sep + 1);
+        final String valueDateRaw = codeValue.substring(sep + 1);
         if (valueDateRaw.isEmpty()) {
             throw new IllegalArgumentException("Value date code must not be empty");
         }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotAlreadyExistsException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotAlreadyExistsException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+
 import java.util.Objects;
 
 /**
@@ -7,7 +9,17 @@ import java.util.Objects;
  */
 public final class FxSpotAlreadyExistsException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    public FxSpotAlreadyExistsException(InstrumentCode instrumentCode) {
+        super(msg(instrumentCode));
+        this.instrumentCode = instrumentCode;
+    }
 
     /**
      * Создает исключение.
@@ -15,8 +27,7 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
      * @param instrumentCode код инструмента
      */
     public FxSpotAlreadyExistsException(String instrumentCode) {
-        super(msg(instrumentCode));
-        this.instrumentCode = instrumentCode;
+        this(InstrumentCode.of(instrumentCode));
     }
 
     /**
@@ -26,9 +37,19 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
      * @param cause          причина ошибки
      */
     @SuppressWarnings("unused")
-    public FxSpotAlreadyExistsException(String instrumentCode, Throwable cause) {
+    public FxSpotAlreadyExistsException(InstrumentCode instrumentCode, Throwable cause) {
         super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause          причина ошибки
+     */
+    public FxSpotAlreadyExistsException(String instrumentCode, Throwable cause) {
+        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**
@@ -37,9 +58,9 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
      * @param instrumentCode код инструмента
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode) {
-        String code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        return "FX_SPOT instrument already exists (code=" + code + ")";
+    private static String msg(InstrumentCode instrumentCode) {
+        InstrumentCode code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "FX_SPOT instrument already exists (code=" + code.value() + ")";
     }
 
     /**
@@ -48,7 +69,7 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotCreateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotCreateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+
 import java.util.Objects;
 
 /**
@@ -7,7 +9,18 @@ import java.util.Objects;
  */
 public final class FxSpotCreateException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    @SuppressWarnings("unused")
+    public FxSpotCreateException(InstrumentCode instrumentCode) {
+        super(msg(instrumentCode));
+        this.instrumentCode = instrumentCode;
+    }
 
     /**
      * Создает исключение.
@@ -16,7 +29,17 @@ public final class FxSpotCreateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotCreateException(String instrumentCode) {
-        super(msg(instrumentCode));
+        this(InstrumentCode.of(instrumentCode));
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause          причина ошибки
+     */
+    public FxSpotCreateException(InstrumentCode instrumentCode, Throwable cause) {
+        super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
     }
 
@@ -27,8 +50,7 @@ public final class FxSpotCreateException extends RuntimeException {
      * @param cause          причина ошибки
      */
     public FxSpotCreateException(String instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**
@@ -37,9 +59,9 @@ public final class FxSpotCreateException extends RuntimeException {
      * @param instrumentCode код инструмента
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode) {
-        String code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        return "Failed to create FX_SPOT instrument (code=" + code + ")";
+    private static String msg(InstrumentCode instrumentCode) {
+        InstrumentCode code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "Failed to create FX_SPOT instrument (code=" + code.value() + ")";
     }
 
     /**
@@ -48,7 +70,7 @@ public final class FxSpotCreateException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+
 import java.util.Objects;
 
 /**
@@ -7,7 +9,18 @@ import java.util.Objects;
  */
 public final class FxSpotDeleteException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    @SuppressWarnings("unused")
+    public FxSpotDeleteException(InstrumentCode instrumentCode) {
+        super(msg(instrumentCode));
+        this.instrumentCode = instrumentCode;
+    }
 
     /**
      * Создает исключение.
@@ -16,7 +29,17 @@ public final class FxSpotDeleteException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotDeleteException(String instrumentCode) {
-        super(msg(instrumentCode));
+        this(InstrumentCode.of(instrumentCode));
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause          причина ошибки
+     */
+    public FxSpotDeleteException(InstrumentCode instrumentCode, Throwable cause) {
+        super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
     }
 
@@ -27,8 +50,7 @@ public final class FxSpotDeleteException extends RuntimeException {
      * @param cause          причина ошибки
      */
     public FxSpotDeleteException(String instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**
@@ -37,9 +59,9 @@ public final class FxSpotDeleteException extends RuntimeException {
      * @param instrumentCode код инструмента
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode) {
-        String code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        return "Failed to delete FX_SPOT instrument (code=" + code + ")";
+    private static String msg(InstrumentCode instrumentCode) {
+        InstrumentCode code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "Failed to delete FX_SPOT instrument (code=" + code.value() + ")";
     }
 
     /**
@@ -48,7 +70,7 @@ public final class FxSpotDeleteException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+
 import java.util.Objects;
 
 /**
@@ -7,7 +9,17 @@ import java.util.Objects;
  */
 public final class FxSpotNotFoundException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    public FxSpotNotFoundException(InstrumentCode instrumentCode) {
+        super(msg(instrumentCode));
+        this.instrumentCode = instrumentCode;
+    }
 
     /**
      * Создает исключение.
@@ -15,8 +27,7 @@ public final class FxSpotNotFoundException extends RuntimeException {
      * @param instrumentCode код инструмента
      */
     public FxSpotNotFoundException(String instrumentCode) {
-        super(msg(instrumentCode));
-        this.instrumentCode = instrumentCode;
+        this(InstrumentCode.of(instrumentCode));
     }
 
     /**
@@ -26,9 +37,19 @@ public final class FxSpotNotFoundException extends RuntimeException {
      * @param cause          причина ошибки
      */
     @SuppressWarnings("unused")
-    public FxSpotNotFoundException(String instrumentCode, Throwable cause) {
+    public FxSpotNotFoundException(InstrumentCode instrumentCode, Throwable cause) {
         super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause          причина ошибки
+     */
+    public FxSpotNotFoundException(String instrumentCode, Throwable cause) {
+        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**
@@ -37,9 +58,9 @@ public final class FxSpotNotFoundException extends RuntimeException {
      * @param instrumentCode код инструмента
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode) {
-        String c = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        return "FX_SPOT instrument not found (code=" + c + ")";
+    private static String msg(InstrumentCode instrumentCode) {
+        InstrumentCode c = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "FX_SPOT instrument not found (code=" + c.value() + ")";
     }
 
     /**
@@ -48,7 +69,7 @@ public final class FxSpotNotFoundException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+
 import java.util.Objects;
 
 /**
@@ -7,7 +9,18 @@ import java.util.Objects;
  */
 public final class FxSpotUpdateException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
+
+    /**
+     * Создает исключение.
+     *
+     * @param instrumentCode код инструмента
+     */
+    @SuppressWarnings("unused")
+    public FxSpotUpdateException(InstrumentCode instrumentCode) {
+        super(msg(instrumentCode));
+        this.instrumentCode = instrumentCode;
+    }
 
     /**
      * Создает исключение.
@@ -16,7 +29,17 @@ public final class FxSpotUpdateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotUpdateException(String instrumentCode) {
-        super(msg(instrumentCode));
+        this(InstrumentCode.of(instrumentCode));
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param instrumentCode код инструмента
+     * @param cause          причина ошибки
+     */
+    public FxSpotUpdateException(InstrumentCode instrumentCode, Throwable cause) {
+        super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
     }
 
@@ -27,8 +50,7 @@ public final class FxSpotUpdateException extends RuntimeException {
      * @param cause          причина ошибки
      */
     public FxSpotUpdateException(String instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**
@@ -37,9 +59,9 @@ public final class FxSpotUpdateException extends RuntimeException {
      * @param instrumentCode код инструмента
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode) {
-        String code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        return "Failed to update FX_SPOT instrument (code=" + code + ")";
+    private static String msg(InstrumentCode instrumentCode) {
+        InstrumentCode code = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return "Failed to update FX_SPOT instrument (code=" + code.value() + ")";
     }
 
     /**
@@ -48,7 +70,7 @@ public final class FxSpotUpdateException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.instrument.type.forex.spot.model;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.currency.model.Currency;
@@ -47,7 +48,7 @@ public record FxSpot(
      * Внутренний код инструмента (уникален в контексте приложения).
      */
     @Override
-    public String instrumentCode() {
+    public InstrumentCode instrumentCode() {
         return FxSpotCodec.fxSpotCode(base, quote, valueDate);
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
@@ -1,9 +1,11 @@
 package com.alligator.market.domain.instrument.type.forex.spot.repository;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -27,9 +29,25 @@ public interface FxSpotRepository {
     void deleteByCode(String instrumentCode);
 
     /**
+     * Удалить инструмент по коду.
+     */
+    default void deleteByCode(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        deleteByCode(instrumentCode.value());
+    }
+
+    /**
      * Найти инструмент по коду.
      */
     Optional<FxSpot> findByCode(String instrumentCode);
+
+    /**
+     * Найти инструмент по коду.
+     */
+    default Optional<FxSpot> findByCode(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        return findByCode(instrumentCode.value());
+    }
 
     /**
      * Вернуть все инструменты.

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.contract;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.code.ProviderCode;
@@ -34,10 +35,10 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     private final AtomicReference<ProviderSettings> settingsRef;
 
     /* Карта "код инструмента --> обработчик". После инициализации становится неизменяемой. */
-    private final Map<String, InstrumentHandler<P, ? extends Instrument>> instrumentMapByCode;
+    private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentMapByCode;
 
     /* Коллекции для кодов и типов инструментов. После инициализации становятся неизменяемыми. */
-    private final Set<String> instrumentCodes;
+    private final Set<InstrumentCode> instrumentCodes;
     private final Set<InstrumentType> instrumentTypes;
 
     //=================================================================================================================
@@ -91,23 +92,21 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         }
 
         // 2) Собираем карту "код инструмента --> обработчик" и агрегируем наборы кодов/типов
-        Map<String, InstrumentHandler<P, ? extends Instrument>> mapByCode =
+        Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> mapByCode =
                 new LinkedHashMap<>(); // <-- Карта
-        Set<String> allCodes = new LinkedHashSet<>(); // <-- Набор всех кодов инструментов
+        Set<InstrumentCode> allCodes = new LinkedHashSet<>(); // <-- Набор всех кодов инструментов
         Set<InstrumentType> types = EnumSet.noneOf(InstrumentType.class); // <-- Набор всех типов инструментов
         for (AbstractInstrumentHandler<P, ? extends Instrument> h : handlers) {
             types.add(h.instrumentType()); // <-- Один тип на обработчик
-            for (String code : h.supportedInstrumentCodes()) {
-                // Коды в обработчике уже нормализованы, но повторно нормализуем для надёжности
-                String upper = code.toUpperCase(Locale.ROOT);
-                InstrumentHandler<P, ? extends Instrument> prev = mapByCode.putIfAbsent(upper, h);
+            for (InstrumentCode code : h.supportedInstrumentCodes()) {
+                InstrumentHandler<P, ? extends Instrument> prev = mapByCode.putIfAbsent(code, h);
                 if (prev != null && prev != h) {
                     // Запрещаем связывать один и тот же код с разными обработчиками
-                    throw new IllegalStateException("Instrument code '" + upper +
+                    throw new IllegalStateException("Instrument code '" + code.value() +
                             "' is already bound to handler '" + prev.handlerCode() +
                             "' in provider '" + providerCode.value() + "'");
                 }
-                allCodes.add(upper);
+                allCodes.add(code);
             }
         }
 
@@ -163,7 +162,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      * Иммутабельный набор кодов поддерживаемых провайдером инструментов.
      */
     @Override
-    public Set<String> instrumentsCodes() {
+    public Set<InstrumentCode> instrumentsCodes() {
         return instrumentCodes;
     }
 
@@ -221,12 +220,11 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      */
     @SuppressWarnings("unchecked")
     private <I extends Instrument> InstrumentHandler<P, I> handlerOf(I instrument) {
-        String raw = instrument.instrumentCode();
-        if (raw == null || raw.isBlank()) {
+        InstrumentCode code = instrument.instrumentCode();
+        if (code == null) {
             return null;
         }
-        String codeUpper = instrument.instrumentCode().toUpperCase(Locale.ROOT);
-        InstrumentHandler<P, ? extends Instrument> h = instrumentMapByCode.get(codeUpper);
+        InstrumentHandler<P, ? extends Instrument> h = instrumentMapByCode.get(code);
         return (InstrumentHandler<P, I>) h;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.contract;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.code.ProviderCode;
@@ -41,7 +42,7 @@ public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
      * Иммутабельный набор кодов поддерживаемых инструментов.
      */
     @SuppressWarnings("unused")
-    Set<String> instrumentsCodes(); // <-- TODO: нужен ли?
+    Set<InstrumentCode> instrumentsCodes(); // <-- TODO: нужен ли?
 
     /**
      * Иммутабельный набор типов поддерживаемых инструментов.

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/handler/AbstractInstrumentHandler.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.contract.handler;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
@@ -28,8 +29,8 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
     /* Декларируемый тип поддерживаемых инструментов. */
     private final InstrumentType instrumentType;
 
-    /* Нормализованные и неизменяемые коды поддерживаемых инструментов: UPPERCASE, формат [A-Z0-9_]+. */
-    private final Set<String> normSupportedInstrumentCodes;
+    /* Нормализованные и неизменяемые коды поддерживаемых инструментов. */
+    private final Set<InstrumentCode> normSupportedInstrumentCodes;
 
     /* Ссылка на провайдера (присваивается один раз, видимость между потоками гарантируется volatile). */
     private volatile P provider;
@@ -46,7 +47,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
      * @param handlerCode              код обработчика; нормализуется в UPPERCASE; формат [A-Z0-9_]+
      * @param instrumentClass          класс поддерживаемых инструментов
      * @param instrumentType           тип поддерживаемых инструментов
-     * @param supportedInstrumentCodes набор кодов инструментов; нормализуются в UPPERCASE; формат [A-Z0-9_]+; без дублей
+     * @param supportedInstrumentCodes набор кодов инструментов; нормализуются через {@link InstrumentCode}; без дублей
      * @throws NullPointerException     если любой параметр равен null
      * @throws IllegalArgumentException если код пустой/с пробелами/не соответствует формату; набор пуст; содержит null/blank/дубликаты
      */
@@ -54,7 +55,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
             String handlerCode,
             Class<I> instrumentClass,
             InstrumentType instrumentType,
-            Set<String> supportedInstrumentCodes
+            Set<InstrumentCode> supportedInstrumentCodes
     ) {
         Objects.requireNonNull(handlerCode, "handlerCode must not be null");
         Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
@@ -106,7 +107,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
      * Неизменяемый набор поддерживаемых кодов инструментов: UPPERCASE, формат [A-Z0-9_]+.
      */
     @Override
-    public final Set<String> supportedInstrumentCodes() {
+    public final Set<InstrumentCode> supportedInstrumentCodes() {
         return normSupportedInstrumentCodes;
     }
 
@@ -144,7 +145,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
      * @throws IllegalStateException           если провайдер не прикреплён
      * @throws InstrumentWrongClassException   если класс инструмента не соответствует {@link #instrumentClass()}
      * @throws InstrumentWrongTypeException    если тип инструмента не соответствует {@link #instrumentType()}
-     * @throws IllegalArgumentException        если код инструмента {@code null} или пустой
+     * @throws IllegalArgumentException        если код инструмента {@code null}
      * @throws InstrumentNotSupportedException если код инструмента не входит в поддерживаемый набор
      */
     @Override
@@ -178,12 +179,11 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
         }
 
         // 4) Проверяем, что код инструмента поддерживается обработчиком
-        final String rawCode = instrument.instrumentCode();
-        if (rawCode == null || rawCode.isBlank()) {
-            throw new IllegalArgumentException("instrumentCode must not be null or blank");
+        final InstrumentCode instrumentCode = instrument.instrumentCode();
+        if (instrumentCode == null) {
+            throw new IllegalArgumentException("instrumentCode must not be null");
         }
-        final String normCode = rawCode.trim().toUpperCase(java.util.Locale.ROOT); // <-- Нормализуем код
-        if (!normSupportedInstrumentCodes.contains(normCode)) {
+        if (!normSupportedInstrumentCodes.contains(instrumentCode)) {
             throw new InstrumentNotSupportedException( // <-- Не поддерживается
                     instrument.instrumentCode(),
                     normHandlerCode);
@@ -224,22 +224,17 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
      *
      * @throws IllegalArgumentException если в наборе есть null/blank/неверный формат/дубликаты
      */
-    private static Set<String> getNormalizedCodes(Set<String> supportedInstrumentCodes) {
-        final Set<String> codes = new LinkedHashSet<>();
-        for (String code : supportedInstrumentCodes) {
-            // Набор не должен содержать null или пустые коды инструментов
-            if (code == null || code.isBlank()) {
-                throw new IllegalArgumentException("supportedInstrumentCodes must not contain null/blank");
+    private static Set<InstrumentCode> getNormalizedCodes(Set<InstrumentCode> supportedInstrumentCodes) {
+        final Set<InstrumentCode> codes = new LinkedHashSet<>();
+        for (InstrumentCode code : supportedInstrumentCodes) {
+            // Набор не должен содержать null коды инструментов
+            if (code == null) {
+                throw new IllegalArgumentException("supportedInstrumentCodes must not contain null");
             }
-            final String norm = code.trim().toUpperCase(java.util.Locale.ROOT);
-            // Разрешены только латинские заглавные, цифры и подчёркивание
-            if (!norm.chars().allMatch(ch ->
-                    (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_')) {
-                throw new IllegalArgumentException("Instrument code must match [A-Z0-9_]+: '" + norm + "'");
-            }
-            if (!codes.add(norm)) {
+            if (!codes.add(code)) {
                 // Набор не должен содержать дублирующиеся коды инструментов
-                throw new IllegalArgumentException("Duplicate instrumentCode '" + norm + "' in supportedInstrumentCodes");
+                throw new IllegalArgumentException(
+                        "Duplicate instrumentCode '" + code.value() + "' in supportedInstrumentCodes");
             }
         }
         return java.util.Collections.unmodifiableSet(codes); // <-- Фиксируем неизменяемость

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/handler/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/handler/InstrumentHandler.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.contract.handler;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
@@ -35,7 +36,7 @@ public sealed interface InstrumentHandler<P extends MarketDataProvider, I extend
     /**
      * Неизменяемый набор поддерживаемых кодов инструментов.
      */
-    Set<String> supportedInstrumentCodes();
+    Set<InstrumentCode> supportedInstrumentCodes();
 
     /**
      * Однократное прикрепление обработчика к провайдеру.

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.provider.code.ProviderCode;
 
 import java.util.Objects;
@@ -9,7 +10,7 @@ import java.util.Objects;
  */
 public final class HandlerNotFoundException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
     private final ProviderCode providerCode;
 
     /**
@@ -18,7 +19,7 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @param instrumentCode код инструмента
      * @param providerCode   код провайдера
      */
-    public HandlerNotFoundException(String instrumentCode, ProviderCode providerCode) {
+    public HandlerNotFoundException(InstrumentCode instrumentCode, ProviderCode providerCode) {
         super(msg(instrumentCode, providerCode));
         this.instrumentCode = instrumentCode;
         this.providerCode = providerCode;
@@ -32,7 +33,7 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @param cause          причина ошибки
      */
     @SuppressWarnings("unused")
-    public HandlerNotFoundException(String instrumentCode, ProviderCode providerCode, Throwable cause) {
+    public HandlerNotFoundException(InstrumentCode instrumentCode, ProviderCode providerCode, Throwable cause) {
         super(msg(instrumentCode, providerCode), cause);
         this.instrumentCode = instrumentCode;
         this.providerCode = providerCode;
@@ -45,10 +46,10 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @param providerCode   код провайдера
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode, ProviderCode providerCode) {
-        String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+    private static String msg(InstrumentCode instrumentCode, ProviderCode providerCode) {
+        InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         ProviderCode pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
-        return "Handler not found (instrumentCode=" + ic + ", providerCode=" + pc.value() + ")";
+        return "Handler not found (instrumentCode=" + ic.value() + ", providerCode=" + pc.value() + ")";
     }
 
     /**
@@ -57,7 +58,7 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+
 import java.util.Objects;
 
 /**
@@ -7,7 +9,7 @@ import java.util.Objects;
  */
 public final class InstrumentNotSupportedException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
     private final String handlerCode;
 
     /**
@@ -17,7 +19,7 @@ public final class InstrumentNotSupportedException extends RuntimeException {
      * @param handlerCode    код обработчика, который не поддерживает {@code instrumentCode}
      */
     @SuppressWarnings("unused")
-    public InstrumentNotSupportedException(String instrumentCode, String handlerCode) {
+    public InstrumentNotSupportedException(InstrumentCode instrumentCode, String handlerCode) {
         super(msg(instrumentCode, handlerCode));
         this.instrumentCode = instrumentCode;
         this.handlerCode = handlerCode;
@@ -31,7 +33,7 @@ public final class InstrumentNotSupportedException extends RuntimeException {
      * @param cause          причина ошибки
      */
     @SuppressWarnings("unused")
-    public InstrumentNotSupportedException(String instrumentCode, String handlerCode, Throwable cause) {
+    public InstrumentNotSupportedException(InstrumentCode instrumentCode, String handlerCode, Throwable cause) {
         super(msg(instrumentCode, handlerCode), cause);
         this.instrumentCode = instrumentCode;
         this.handlerCode = handlerCode;
@@ -44,10 +46,10 @@ public final class InstrumentNotSupportedException extends RuntimeException {
      * @param handlerCode    код обработчика, который не поддерживает {@code instrumentCode}
      * @return текст сообщения
      */
-    private static String msg(String instrumentCode, String handlerCode) {
-        String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+    private static String msg(InstrumentCode instrumentCode, String handlerCode) {
+        InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
-        return "Instrument not supported (instrumentCode=" + ic + ", handlerCode=" + hc + ")";
+        return "Instrument not supported (instrumentCode=" + ic.value() + ", handlerCode=" + hc + ")";
     }
 
     /**
@@ -56,7 +58,7 @@ public final class InstrumentNotSupportedException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+
 import java.util.Objects;
 
 /**
@@ -7,7 +9,7 @@ import java.util.Objects;
  */
 public final class InstrumentWrongClassException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
     private final Class<?> instrumentClass;
     private final String handlerCode;
     private final Class<?> expectedClass;
@@ -21,7 +23,7 @@ public final class InstrumentWrongClassException extends RuntimeException {
      * @param expectedClass   ожидаемый класс инструмента
      */
     public InstrumentWrongClassException(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             Class<?> instrumentClass,
             String handlerCode,
             Class<?> expectedClass
@@ -44,7 +46,7 @@ public final class InstrumentWrongClassException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public InstrumentWrongClassException(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             Class<?> instrumentClass,
             String handlerCode,
             Class<?> expectedClass,
@@ -67,16 +69,16 @@ public final class InstrumentWrongClassException extends RuntimeException {
      * @return текст сообщения
      */
     private static String msg(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             Class<?> instrumentClass,
             String handlerCode,
             Class<?> expectedClass
     ) {
-        String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         Class<?> actual = Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
         String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
         Class<?> expected = Objects.requireNonNull(expectedClass, "expectedClass must not be null");
-        return "Instrument class mismatch (instrumentCode=" + ic + ", actualClass=" + actual.getName()
+        return "Instrument class mismatch (instrumentCode=" + ic.value() + ", actualClass=" + actual.getName()
                 + ", handlerCode=" + hc + ", expectedClass=" + expected.getName() + ")";
     }
 
@@ -86,7 +88,7 @@ public final class InstrumentWrongClassException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongTypeException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongTypeException.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 
 import java.util.Objects;
@@ -9,7 +10,7 @@ import java.util.Objects;
  */
 public final class InstrumentWrongTypeException extends RuntimeException {
 
-    private final String instrumentCode;
+    private final InstrumentCode instrumentCode;
     private final InstrumentType instrumentType;
     private final String handlerCode;
     private final InstrumentType expectedType;
@@ -23,7 +24,7 @@ public final class InstrumentWrongTypeException extends RuntimeException {
      * @param expectedType   ожидаемый тип инструмента
      */
     public InstrumentWrongTypeException(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             InstrumentType instrumentType,
             String handlerCode,
             InstrumentType expectedType
@@ -46,7 +47,7 @@ public final class InstrumentWrongTypeException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public InstrumentWrongTypeException(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             InstrumentType instrumentType,
             String handlerCode,
             InstrumentType expectedType,
@@ -69,16 +70,16 @@ public final class InstrumentWrongTypeException extends RuntimeException {
      * @return текст сообщения
      */
     private static String msg(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             InstrumentType instrumentType,
             String handlerCode,
             InstrumentType expectedType
     ) {
-        String ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         InstrumentType actual = Objects.requireNonNull(instrumentType, "instrumentType must not be null");
         String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
         InstrumentType expected = Objects.requireNonNull(expectedType, "expectedType must not be null");
-        return "Instrument type mismatch (instrumentCode=" + ic + ", actualType=" + actual.name()
+        return "Instrument type mismatch (instrumentCode=" + ic.value() + ", actualType=" + actual.name()
                 + ", handlerCode=" + hc + ", expectedType=" + expected.name() + ")";
     }
 
@@ -88,7 +89,7 @@ public final class InstrumentWrongTypeException extends RuntimeException {
      * @return код инструмента
      */
     @SuppressWarnings("unused")
-    public String getInstrumentCode() {
+    public InstrumentCode getInstrumentCode() {
         return instrumentCode;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
@@ -1,5 +1,6 @@
 package com.alligator.market.domain.quote.tick.model;
 
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
@@ -23,7 +24,7 @@ import java.util.Objects;
  * @param providerCode      технический код провайдера, предоставившего котировку (соответствует {@link MarketDataProvider#providerCode()})
  */
 public record QuoteTick(
-        String instrumentCode,
+        InstrumentCode instrumentCode,
         BigDecimal last,
         BigDecimal bid,
         BigDecimal ask,
@@ -32,10 +33,34 @@ public record QuoteTick(
         ProviderCode providerCode
 ) {
     /**
+     * Конструктор для строкового кода инструмента.
+     */
+    @SuppressWarnings("unused")
+    public QuoteTick(
+            String instrumentCode,
+            BigDecimal last,
+            BigDecimal bid,
+            BigDecimal ask,
+            Instant exchangeTimestamp,
+            Instant receivedTimestamp,
+            ProviderCode providerCode
+    ) {
+        this(
+                InstrumentCode.of(instrumentCode),
+                last,
+                bid,
+                ask,
+                exchangeTimestamp,
+                receivedTimestamp,
+                providerCode
+        );
+    }
+
+    /**
      * Фабрика тика по последней сделке (LAST): Поля "bid"/"ask" {@code null}.
      */
     public static QuoteTick lastTrade(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             BigDecimal last,
             Instant exchangeTimestamp,
             Instant receivedTimestamp,
@@ -59,10 +84,29 @@ public record QuoteTick(
     }
 
     /**
+     * Перегрузка фабрики тика по последней сделке (LAST) для строкового кода.
+     */
+    public static QuoteTick lastTrade(
+            String instrumentCode,
+            BigDecimal last,
+            Instant exchangeTimestamp,
+            Instant receivedTimestamp,
+            ProviderCode providerCode
+    ) {
+        return lastTrade(
+                InstrumentCode.of(instrumentCode),
+                last,
+                exchangeTimestamp,
+                receivedTimestamp,
+                providerCode
+        );
+    }
+
+    /**
      * Фабрика тика для котировки "bid"/"ask": поле "last" {@code null}.
      */
     public static QuoteTick bidAsk(
-            String instrumentCode,
+            InstrumentCode instrumentCode,
             BigDecimal bid,
             BigDecimal ask,
             Instant exchangeTimestamp,
@@ -79,6 +123,27 @@ public record QuoteTick(
         return new QuoteTick(
                 instrumentCode,
                 null,
+                bid,
+                ask,
+                exchangeTimestamp,
+                receivedTimestamp,
+                providerCode
+        );
+    }
+
+    /**
+     * Перегрузка фабрики тика для котировки "bid"/"ask" для строкового кода.
+     */
+    public static QuoteTick bidAsk(
+            String instrumentCode,
+            BigDecimal bid,
+            BigDecimal ask,
+            Instant exchangeTimestamp,
+            Instant receivedTimestamp,
+            ProviderCode providerCode
+    ) {
+        return bidAsk(
+                InstrumentCode.of(instrumentCode),
                 bid,
                 ask,
                 exchangeTimestamp,


### PR DESCRIPTION
### Motivation
- Упорядочить и централизовать представление внутреннего кода инструмента через объект-значение `InstrumentCode` для избавления от локальной нормализации и дублирования; 
- Обеспечить единый тип для наборов поддерживаемых кодов в обработчиках и провайдерах для упрощения логики сопоставления; 
- Актуализировать связанные утилиты и исключения (в частности для FX_SPOT) под новый контракт кода инструмента; 
- Подготовить основу для дальнейшего использования `InstrumentCode` в `InstrumentHandler`/`AbstractInstrumentHandler` и `AbstractMarketDataProvider`.

### Description
- Заменён тип возвращаемого и используемого кода инструмента на `InstrumentCode` в контракте `Instrument` и в модели `FxSpot`, а также в `QuoteTick` и других доменных API; 
- `FxSpotCodec.fxSpotCode(...)` теперь возвращает `InstrumentCode` и добавлена перегрузка `parseFxSpotCode(InstrumentCode)` с адаптером от строки; 
- `AbstractInstrumentHandler` и `InstrumentHandler` используют `Set<InstrumentCode>` для `supportedInstrumentCodes`, убрана ручная нормализация строк в наборах и изменён алгоритм проверки поддержки; 
- `AbstractMarketDataProvider` хранит карту и наборы по `InstrumentCode` и ищет обработчик по `InstrumentCode` вместо строк; 
- Доменные исключения и FX_SPOT-исключения обновлены для хранения `InstrumentCode` и формирования сообщений через `instrumentCode.value()`, при этом добавлены удобные перегрузки конструкторов/адаптеры где требуется совместимость со строковыми кодами; 
- `FxSpotRepository` и `QuoteTick` получили удобные default/перегрузки для приёма `InstrumentCode` или строкового кода.

### Testing
- Автоматизированные тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69513f84cf0c832dad38a3ce81488ba1)