### PR TITLE
Перевод instrumentCode на InstrumentCode в домене и backend

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -64,9 +64,9 @@ public class FxSpotEntityMapper {
         Objects.requireNonNull(e, "entity must not be null");
 
         // Модель и сущность должны соответствовать одному и тому же инструменту
-        if (!e.getCode().equals(m.instrumentCode())) {
+        if (!e.getCode().equals(m.instrumentCode().value())) {
             throw new IllegalStateException("Instrument code mismatch: " + e.getCode() + " vs " +
-                    m.instrumentCode());
+                    m.instrumentCode().value());
         }
 
         // Копируем в изменяемые поля JPA-сущности поля из доменной модели

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
@@ -6,6 +6,7 @@ import com.alligator.market.backend.instrument.type.forex.currency.catalog.persi
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntity;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntityMapper;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotJpaRepository;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.forex.currency.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.*;
@@ -72,7 +73,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         Objects.requireNonNull(fxSpot, "fxSpot model must not be null");
 
         // Ищем JPA-сущность инструмента FX_SPOT к обновлению
-        FxSpotEntity e = jpaRepository.findByCode(fxSpot.instrumentCode())
+        FxSpotEntity e = jpaRepository.findByCode(fxSpot.instrumentCode().value())
                 .orElseThrow(() -> new FxSpotNotFoundException(fxSpot.instrumentCode()));
 
         // Заполняем изменяемые поля из переданной модели
@@ -96,11 +97,13 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
-    public void deleteByCode(String instrumentCode) {
+    public void deleteByCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        // Строковое значение кода инструмента для запроса в БД
+        String codeValue = instrumentCode.value();
 
         // Ищем JPA-сущность по коду инструмента иначе бросаем ошибку
-        FxSpotEntity e = jpaRepository.findByCode(instrumentCode)
+        FxSpotEntity e = jpaRepository.findByCode(codeValue)
                 .orElseThrow(() -> new FxSpotNotFoundException(instrumentCode));
 
         // Пробуем удалить запись (ловим наиболее вероятные ошибки и пробрасываем их выше)
@@ -113,10 +116,12 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
-    public Optional<FxSpot> findByCode(String instrumentCode) {
+    public Optional<FxSpot> findByCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        // Строковое значение кода инструмента для запроса в БД
+        String codeValue = instrumentCode.value();
 
-        return jpaRepository.findByCode(instrumentCode)
+        return jpaRepository.findByCode(codeValue)
                 .map(FxSpotEntityMapper::toDomain);
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotAssembler.java
@@ -38,17 +38,14 @@ public class FxSpotAssembler {
     }
 
     /**
-     * Доменная модель существующего инструмента FX_SPOT из DTO обновления и строкового кода инструмента.
+     * Доменная модель существующего инструмента FX_SPOT из DTO обновления и кода инструмента.
      */
-    public FxSpot toDomainByCode(String instrumentCode, FxSpotUpdateDto dto) {
+    public FxSpot toDomainByCode(InstrumentCode instrumentCode, FxSpotUpdateDto dto) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         Objects.requireNonNull(dto, "dto must not be null");
 
-        // Парсим строковый код инструмента в объект-значение
-        InstrumentCode code = InstrumentCode.of(instrumentCode);
-
         // Разбираем код инструмента на составные компоненты, необходимые для создания доменной модели
-        FxSpotCodec.FxSpotCodeParts parts = FxSpotCodec.parseFxSpotCode(code);
+        FxSpotCodec.FxSpotCodeParts parts = FxSpotCodec.parseFxSpotCode(instrumentCode);
 
         // Фиксируем коды базовой и котируемой валют
         CurrencyCode baseCode = parts.baseCode();

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCase.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ public interface FxSpotUseCase {
     /**
      * Удалить инструмент по коду.
      */
-    void delete(String instrumentCode);
+    void delete(InstrumentCode instrumentCode);
 
     /**
      * Вернуть все инструменты.

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/service/FxSpotUseCaseImpl.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.service;
 import com.alligator.market.domain.instrument.type.forex.spot.exception.FxSpotNotFoundException;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.repository.FxSpotRepository;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
         // Без пред‑проверок на уникальность (устраняем TOCTOU) — уникальные ключи распознаёт адаптер
         FxSpot created = fxSpotRepository.create(fxSpot);
-        log.info("FX_SPOT instrument {} created", created.instrumentCode());
+        log.info("FX_SPOT instrument {} created", created.instrumentCode().value());
         return created;
     }
 
@@ -43,7 +44,7 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
 
         // Если изменений нет — возвращаем текущее состояние без записи в БД
         if (current.equals(fxSpot)) {
-            log.debug("FX_SPOT instrument {} update skipped: nothing to change", fxSpot.instrumentCode());
+            log.debug("FX_SPOT instrument {} update skipped: nothing to change", fxSpot.instrumentCode().value());
             return;
         }
 
@@ -51,18 +52,18 @@ public class FxSpotUseCaseImpl implements FxSpotUseCase {
         // Бизнес-идентичность (instrumentCode) при update не меняется,
         // в случае сбоев адаптер бросит FxSpotUpdateException.
         FxSpot updated = fxSpotRepository.update(fxSpot);
-        log.info("FX_SPOT instrument {} updated", updated.instrumentCode());
+        log.info("FX_SPOT instrument {} updated", updated.instrumentCode().value());
     }
 
     @Override
     @Transactional
-    public void delete(String instrumentCode) {
+    public void delete(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         // Отсутствие инструмента определит адаптер (FxSpotNotFoundException).
         // Прочие БД-сбои — FxSpotDeleteException.
         fxSpotRepository.deleteByCode(instrumentCode);
-        log.info("FX_SPOT instrument {} deleted", instrumentCode);
+        log.info("FX_SPOT instrument {} deleted", instrumentCode.value());
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/FxSpotController.java
@@ -8,6 +8,7 @@ import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.i
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.in.FxSpotUpdateDto;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.mapper.FxSpotDtoMapper;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.web.dto.out.FxSpotResponseDto;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,9 +40,9 @@ public class FxSpotController {
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{instrumentCode}")
-                .buildAndExpand(created.instrumentCode())
+                .buildAndExpand(created.instrumentCode().value())
                 .toUri();
-        return ResponseEntityFactory.created(location, created.instrumentCode());
+        return ResponseEntityFactory.created(location, created.instrumentCode().value());
     }
 
     /**
@@ -51,7 +52,9 @@ public class FxSpotController {
     public ResponseEntity<Void> update(@PathVariable String instrumentCode,
                                        @RequestBody @Valid FxSpotUpdateDto dto) {
 
-        service.update(assembler.toDomainByCode(instrumentCode, dto));
+        // Парсим строковый код инструмента в объект-значение
+        InstrumentCode code = InstrumentCode.of(instrumentCode);
+        service.update(assembler.toDomainByCode(code, dto));
         return ResponseEntityFactory.noContent();
     }
 
@@ -61,7 +64,9 @@ public class FxSpotController {
     @DeleteMapping("/{instrumentCode}")
     public ResponseEntity<Void> delete(@PathVariable String instrumentCode) {
 
-        service.delete(instrumentCode);
+        // Парсим строковый код инструмента в объект-значение
+        InstrumentCode code = InstrumentCode.of(instrumentCode);
+        service.delete(code);
         return ResponseEntityFactory.noContent();
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
@@ -24,7 +24,7 @@ public class FxSpotDtoMapper {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         return new FxSpotResponseDto(
-                fxSpot.instrumentCode(),
+                fxSpot.instrumentCode().value(),
                 fxSpot.instrumentSymbol(),
                 fxSpot.base().code().value(),
                 fxSpot.quote().code().value(),

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.config.time.TimeZoneConfig;
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssAdapter;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProps;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssWebConfig;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.provider.code.ProviderCode;
@@ -38,7 +39,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
     private static final String HANDLER_CODE = "MOEX_ISS_FX_SPOT_HANDLER";
 
     /* Поддерживаемые коды инструментов FX_SPOT. */
-    private static final Set<String> SUPPORTED_CODES = MoexIssFxSpotInstruments.SUPPORTED_DOMAIN_CODES;
+    private static final Set<InstrumentCode> SUPPORTED_CODES = MoexIssFxSpotInstruments.SUPPORTED_DOMAIN_CODES;
 
     /* Web-клиент. */
     private final WebClient webClient;
@@ -98,7 +99,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
                 .onErrorResume(ex -> {
                     log.warn(
                             "Failed to fetch FX_SPOT quote from MOEX ISS: instrumentCode={}, reason={}",
-                            instrument.instrumentCode(),
+                            instrument.instrumentCode().value(),
                             ex.getMessage(),
                             ex
                     );
@@ -122,13 +123,13 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
      *   <li>4) Строим доменную модель {@link QuoteTick}.</li>
      * </ul></p>
      *
-     * <p>Примечание: пункты 3) и 4) вынесены в отдельный метод {@link #mapMarketdataToQuoteTick(String, JsonNode)}.</p>
+     * <p>Примечание: пункты 3) и 4) вынесены в отдельный метод {@link #mapMarketdataToQuoteTick(InstrumentCode, JsonNode)}.</p>
      */
     private Mono<QuoteTick> fetchQuoteOnce(FxSpot instrument) {
         // Примечание: проверка выполняется в AbstractInstrumentHandler, поэтому здесь не требуется
 
         // 1) Доменный код инструмента --> SECID MOEX ISS
-        String domainCode = instrument.instrumentCode();
+        InstrumentCode domainCode = instrument.instrumentCode();
         String secid = MoexIssFxSpotInstruments.moexSecidOf(domainCode);
 
         // 2) Запрос к MOEX ISS для получения таблицы marketdata для полученного secid
@@ -151,7 +152,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
                 .bodyToMono(JsonNode.class) // <-- Парсим JSON в дерево JsonNode
                 .doOnSubscribe(sub -> log.debug(
                         "Requesting FX_SPOT quote from MOEX ISS: instrumentCode={}, secid={}",
-                        domainCode, secid))
+                        domainCode.value(), secid))
                 .map(body -> {
                     // 3) Строгая проверка структуры JSON + извлечение SYSTIME/LAST
                     // 4) Построение доменной модели QuoteTick
@@ -167,7 +168,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
      * <p>Примечание: в итоговом {@link QuoteTick} конвертируем временную зону для поля {@link QuoteTick#exchangeTimestamp()}
      * в UTC, согласно конфигурации времени в приложении {@link TimeZoneConfig}.</p>
      */
-    private QuoteTick mapMarketdataToQuoteTick(String instrumentCode, JsonNode root) {
+    private QuoteTick mapMarketdataToQuoteTick(InstrumentCode instrumentCode, JsonNode root) {
         /*
          * Ожидаемый JSON-ответ (упрощённо):
          *
@@ -213,7 +214,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
         // 4) Проверяем, что в массиве "data" ровно одна строка (одна строка в "marketdata" для этого инструмента)
         if (data.size() != 1) {
             throw new IllegalStateException(
-                    "Array 'data' must contain exactly one row for instrument " + instrumentCode +
+                    "Array 'data' must contain exactly one row for instrument " + instrumentCode.value() +
                             ", but was: " + data.size()
             );
         }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotInstruments.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotInstruments.java
@@ -4,6 +4,7 @@ import com.alligator.market.domain.instrument.type.forex.currency.model.Currency
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotTenor;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.*;
 
@@ -24,16 +25,16 @@ public class MoexIssFxSpotInstruments {
     private static final FxSpot CNY_RUB = new FxSpot(CNY, RUB, FxSpotTenor.TOM, 4);
 
     /* Карта соответствий: доменный код ↔ SECID. */
-    private static final Map<String, String> DOMAIN_CODE_TO_SECID;
+    private static final Map<InstrumentCode, String> DOMAIN_CODE_TO_SECID;
 
     /**
      * Набор кодов поддерживаемых доменных инструментов.
      */
-    public static final Set<String> SUPPORTED_DOMAIN_CODES;
+    public static final Set<InstrumentCode> SUPPORTED_DOMAIN_CODES;
 
     static {
         // Строим карту соответствий доменных кодов и SECID
-        Map<String, String> map = new LinkedHashMap<>();
+        Map<InstrumentCode, String> map = new LinkedHashMap<>();
 
         map.put(USD_RUB.instrumentCode(), "USD000UTSTOM");
         map.put(CNY_RUB.instrumentCode(), "CNYRUB_TOM");
@@ -54,14 +55,14 @@ public class MoexIssFxSpotInstruments {
      *       что {@code instrumentCode} принадлежит {@link #SUPPORTED_DOMAIN_CODES}.</li>
      * </ul>
      */
-    public static String moexSecidOf(String instrumentCode) {
+    public static String moexSecidOf(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         // Ищем значение из карты соответствий
         String secid = DOMAIN_CODE_TO_SECID.get(instrumentCode);
         if (secid == null) {
             throw new IllegalStateException(
-                    "Missing MOEX ISS SECID mapping for supported instrumentCode: " + instrumentCode
+                    "Missing MOEX ISS SECID mapping for supported instrumentCode: " + instrumentCode.value()
             );
         }
         return secid;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotCatalog.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotCatalog.java
@@ -4,6 +4,7 @@ import com.alligator.market.domain.instrument.type.forex.currency.model.Currency
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotTenor;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Set;
 
@@ -22,7 +23,7 @@ public class ProFinanceFxSpotCatalog {
     /**
      * Набор поддерживаемых кодов инструментов.
      */
-    public static final Set<String> SUPPORTED_CODES = Set.of(EUR_USD.instrumentCode());
+    public static final Set<InstrumentCode> SUPPORTED_CODES = Set.of(EUR_USD.instrumentCode());
 
     /**
      * Скрываем конструктор.

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.provider.adapter.profinance.ProFinanceAdapte
 import com.alligator.market.backend.provider.adapter.profinance.config.ProFinanceAdapterProps;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
@@ -34,7 +35,7 @@ public class ProFinanceFxSpotHandler extends AbstractInstrumentHandler<ProFinanc
     private static final String HANDLER_CODE = "PROFINANCE_FX_SPOT_HANDLER";
 
     /* Поддерживаемые коды инструментов FX_SPOT. */
-    private static final Set<String> SUPPORTED_CODES = ProFinanceFxSpotCatalog.SUPPORTED_CODES;
+    private static final Set<InstrumentCode> SUPPORTED_CODES = ProFinanceFxSpotCatalog.SUPPORTED_CODES;
 
     /* Web-клиент. */
     private final WebClient webClient;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotCatalog.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotCatalog.java
@@ -4,6 +4,7 @@ import com.alligator.market.domain.instrument.type.forex.currency.model.Currency
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotTenor;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Set;
 
@@ -22,7 +23,7 @@ public final class TwelveFreeFxSpotCatalog {
     /**
      * Набор поддерживаемых кодов инструментов.
      */
-    public static final Set<String> SUPPORTED_CODES = Set.of(EUR_USD.instrumentCode());
+    public static final Set<InstrumentCode> SUPPORTED_CODES = Set.of(EUR_USD.instrumentCode());
 
     /**
      * Скрываем конструктор.

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.adapter.twelve.free.handler.forex.
 
 import com.alligator.market.backend.provider.adapter.twelve.free.TwelveFreeAdapterV2;
 import com.alligator.market.backend.provider.adapter.twelve.free.config.TwelveFreeConnectionProps;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
@@ -24,7 +25,7 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
     private static final String HANDLER_CODE = "TWELVE_FREE_FX_SPOT_HANDLER";
 
     /* Поддерживаемые коды инструментов FX_SPOT. */
-    private static final Set<String> SUPPORTED_CODES = TwelveFreeFxSpotCatalog.SUPPORTED_CODES;
+    private static final Set<InstrumentCode> SUPPORTED_CODES = TwelveFreeFxSpotCatalog.SUPPORTED_CODES;
 
     /* Web-клиент. */
     private final WebClient webClient;
@@ -71,7 +72,7 @@ public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFre
     /**
      * Преобразование JSON ответа провайдера в доменную модель котировки.
      */
-    private QuoteTick responseJsonToQuoteTick(JsonNode json, String instrumentCode) {
+    private QuoteTick responseJsonToQuoteTick(JsonNode json, InstrumentCode instrumentCode) {
         JsonNode priceNode = json.get("price");
         if (priceNode == null) {
             throw new IllegalArgumentException("Invalid provider response: " + json);

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotAlreadyExistsException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotAlreadyExistsException.java
@@ -22,15 +22,6 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
     }
 
     /**
-     * Создает исключение.
-     *
-     * @param instrumentCode код инструмента
-     */
-    public FxSpotAlreadyExistsException(String instrumentCode) {
-        this(InstrumentCode.of(instrumentCode));
-    }
-
-    /**
      * Создает исключение с причиной.
      *
      * @param instrumentCode код инструмента
@@ -40,16 +31,6 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
     public FxSpotAlreadyExistsException(InstrumentCode instrumentCode, Throwable cause) {
         super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
-    }
-
-    /**
-     * Создает исключение с причиной.
-     *
-     * @param instrumentCode код инструмента
-     * @param cause          причина ошибки
-     */
-    public FxSpotAlreadyExistsException(String instrumentCode, Throwable cause) {
-        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotCreateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotCreateException.java
@@ -23,16 +23,6 @@ public final class FxSpotCreateException extends RuntimeException {
     }
 
     /**
-     * Создает исключение.
-     *
-     * @param instrumentCode код инструмента
-     */
-    @SuppressWarnings("unused")
-    public FxSpotCreateException(String instrumentCode) {
-        this(InstrumentCode.of(instrumentCode));
-    }
-
-    /**
      * Создает исключение с причиной.
      *
      * @param instrumentCode код инструмента
@@ -41,16 +31,6 @@ public final class FxSpotCreateException extends RuntimeException {
     public FxSpotCreateException(InstrumentCode instrumentCode, Throwable cause) {
         super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
-    }
-
-    /**
-     * Создает исключение с причиной.
-     *
-     * @param instrumentCode код инструмента
-     * @param cause          причина ошибки
-     */
-    public FxSpotCreateException(String instrumentCode, Throwable cause) {
-        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
@@ -23,16 +23,6 @@ public final class FxSpotDeleteException extends RuntimeException {
     }
 
     /**
-     * Создает исключение.
-     *
-     * @param instrumentCode код инструмента
-     */
-    @SuppressWarnings("unused")
-    public FxSpotDeleteException(String instrumentCode) {
-        this(InstrumentCode.of(instrumentCode));
-    }
-
-    /**
      * Создает исключение с причиной.
      *
      * @param instrumentCode код инструмента
@@ -41,16 +31,6 @@ public final class FxSpotDeleteException extends RuntimeException {
     public FxSpotDeleteException(InstrumentCode instrumentCode, Throwable cause) {
         super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
-    }
-
-    /**
-     * Создает исключение с причиной.
-     *
-     * @param instrumentCode код инструмента
-     * @param cause          причина ошибки
-     */
-    public FxSpotDeleteException(String instrumentCode, Throwable cause) {
-        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
@@ -22,15 +22,6 @@ public final class FxSpotNotFoundException extends RuntimeException {
     }
 
     /**
-     * Создает исключение.
-     *
-     * @param instrumentCode код инструмента
-     */
-    public FxSpotNotFoundException(String instrumentCode) {
-        this(InstrumentCode.of(instrumentCode));
-    }
-
-    /**
      * Создает исключение с причиной.
      *
      * @param instrumentCode код инструмента
@@ -40,16 +31,6 @@ public final class FxSpotNotFoundException extends RuntimeException {
     public FxSpotNotFoundException(InstrumentCode instrumentCode, Throwable cause) {
         super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
-    }
-
-    /**
-     * Создает исключение с причиной.
-     *
-     * @param instrumentCode код инструмента
-     * @param cause          причина ошибки
-     */
-    public FxSpotNotFoundException(String instrumentCode, Throwable cause) {
-        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
@@ -23,16 +23,6 @@ public final class FxSpotUpdateException extends RuntimeException {
     }
 
     /**
-     * Создает исключение.
-     *
-     * @param instrumentCode код инструмента
-     */
-    @SuppressWarnings("unused")
-    public FxSpotUpdateException(String instrumentCode) {
-        this(InstrumentCode.of(instrumentCode));
-    }
-
-    /**
      * Создает исключение с причиной.
      *
      * @param instrumentCode код инструмента
@@ -41,16 +31,6 @@ public final class FxSpotUpdateException extends RuntimeException {
     public FxSpotUpdateException(InstrumentCode instrumentCode, Throwable cause) {
         super(msg(instrumentCode), cause);
         this.instrumentCode = instrumentCode;
-    }
-
-    /**
-     * Создает исключение с причиной.
-     *
-     * @param instrumentCode код инструмента
-     * @param cause          причина ошибки
-     */
-    public FxSpotUpdateException(String instrumentCode, Throwable cause) {
-        this(InstrumentCode.of(instrumentCode), cause);
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/repository/FxSpotRepository.java
@@ -5,7 +5,6 @@ import com.alligator.market.domain.instrument.type.forex.currency.model.Currency
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -26,28 +25,12 @@ public interface FxSpotRepository {
     /**
      * Удалить инструмент по коду.
      */
-    void deleteByCode(String instrumentCode);
-
-    /**
-     * Удалить инструмент по коду.
-     */
-    default void deleteByCode(InstrumentCode instrumentCode) {
-        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        deleteByCode(instrumentCode.value());
-    }
+    void deleteByCode(InstrumentCode instrumentCode);
 
     /**
      * Найти инструмент по коду.
      */
-    Optional<FxSpot> findByCode(String instrumentCode);
-
-    /**
-     * Найти инструмент по коду.
-     */
-    default Optional<FxSpot> findByCode(InstrumentCode instrumentCode) {
-        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        return findByCode(instrumentCode.value());
-    }
+    Optional<FxSpot> findByCode(InstrumentCode instrumentCode);
 
     /**
      * Вернуть все инструменты.

--- a/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
@@ -33,30 +33,6 @@ public record QuoteTick(
         ProviderCode providerCode
 ) {
     /**
-     * Конструктор для строкового кода инструмента.
-     */
-    @SuppressWarnings("unused")
-    public QuoteTick(
-            String instrumentCode,
-            BigDecimal last,
-            BigDecimal bid,
-            BigDecimal ask,
-            Instant exchangeTimestamp,
-            Instant receivedTimestamp,
-            ProviderCode providerCode
-    ) {
-        this(
-                InstrumentCode.of(instrumentCode),
-                last,
-                bid,
-                ask,
-                exchangeTimestamp,
-                receivedTimestamp,
-                providerCode
-        );
-    }
-
-    /**
      * Фабрика тика по последней сделке (LAST): Поля "bid"/"ask" {@code null}.
      */
     public static QuoteTick lastTrade(
@@ -77,25 +53,6 @@ public record QuoteTick(
                 last,
                 null,
                 null,
-                exchangeTimestamp,
-                receivedTimestamp,
-                providerCode
-        );
-    }
-
-    /**
-     * Перегрузка фабрики тика по последней сделке (LAST) для строкового кода.
-     */
-    public static QuoteTick lastTrade(
-            String instrumentCode,
-            BigDecimal last,
-            Instant exchangeTimestamp,
-            Instant receivedTimestamp,
-            ProviderCode providerCode
-    ) {
-        return lastTrade(
-                InstrumentCode.of(instrumentCode),
-                last,
                 exchangeTimestamp,
                 receivedTimestamp,
                 providerCode
@@ -131,24 +88,4 @@ public record QuoteTick(
         );
     }
 
-    /**
-     * Перегрузка фабрики тика для котировки "bid"/"ask" для строкового кода.
-     */
-    public static QuoteTick bidAsk(
-            String instrumentCode,
-            BigDecimal bid,
-            BigDecimal ask,
-            Instant exchangeTimestamp,
-            Instant receivedTimestamp,
-            ProviderCode providerCode
-    ) {
-        return bidAsk(
-                InstrumentCode.of(instrumentCode),
-                bid,
-                ask,
-                exchangeTimestamp,
-                receivedTimestamp,
-                providerCode
-        );
-    }
 }


### PR DESCRIPTION
### Motivation
- Упростить и унифицировать работу с кодом инструмента, сделав `InstrumentCode` единственным источником истины вместо строковых перегрузок.
- Исключить дублирование и неоднозначности при передаче кода инструмента между слоями (domain ↔ backend ↔ DB/DTO).
- Обеспечить ясные границы: в домене работать с `InstrumentCode`, а на границах (логирование/DB/HTTP) использовать `InstrumentCode.value()`.

### Description
- Убраны строковые перегрузки из `QuoteTick` и из исключений FX_SPOT, оставив конструкторы/поля только с `InstrumentCode` и удалены устаревшие string-конструкторы.
- Порт репозитория `FxSpotRepository` теперь использует `InstrumentCode` в сигнатурах `deleteByCode` и `findByCode`, а адаптер `FxSpotRepositoryAdapter` преобразует `InstrumentCode.value()` для запросов к JPA.
- Обновлены backend-каталоги и обработчики: `MoexIssFxSpotInstruments`, `ProFinanceFxSpotCatalog`, `TwelveFreeFxSpotCatalog`, а также обработчики (`MoexIssFxSpotHandler`, `ProFinanceFxSpotHandler`, `TwelveFreeFxSpotHandler`) работают с `InstrumentCode` и используют `.value()` на границах.
- Обновлены контроллер/assembler/mapper/use-case/entity-mapper/логирование, где необходимо явно парсить строковый путь в `InstrumentCode` (`InstrumentCode.of(...)`) и при обращении к внешним системам/БД использовать `instrumentCode().value()`.

### Testing
- Автоматические тесты на изменённом коде не запускались в рамках этого PR.
- В локальном коммите изменено 20 файлов (примерно 58 insertions, 221 deletions) и внесены правки, совместимые с существующей архитектурой типов.
- Рекомендуется запустить `mvn -DskipTests=false test` и сборку сервиса после слияния для проверки компиляции и регрессий.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951bb3be57c832db64f08db73acfa35)