### PR TITLE
Хранить Duration в секундах в JPA-конвертере

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/persistence/jpa/converter/DurationToMillisConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/persistence/jpa/converter/DurationToMillisConverter.java
@@ -5,9 +5,9 @@ import jakarta.persistence.Converter;
 import java.time.Duration;
 
 /**
- * JPA-конвертер {@link java.time.Duration} ↔ {@link Long} (миллисекунды) для хранения в БД.
+ * JPA-конвертер {@link java.time.Duration} ↔ {@link Long} (секунды) для хранения в БД.
  *
- * <p>Точность — до миллисекунды: наносекунды отбрасываются (используется {@link Duration#toMillis()}),
+ * <p>Точность — до секунды: наносекунды отбрасываются (используется {@link Duration#toSeconds()}),
  * {@code null} ↔ {@code null}.</p>
  */
 @Converter
@@ -16,11 +16,11 @@ public class DurationToMillisConverter
 
     @Override
     public Long convertToDatabaseColumn(java.time.Duration attribute) {
-        return attribute == null ? null : attribute.toMillis();
+        return attribute == null ? null : attribute.toSeconds();
     }
 
     @Override
     public java.time.Duration convertToEntityAttribute(Long dbData) {
-        return dbData == null ? null : java.time.Duration.ofMillis(dbData);
+        return dbData == null ? null : java.time.Duration.ofSeconds(dbData);
     }
 }


### PR DESCRIPTION
### Motivation
- Бизнес-логика оперирует `minUpdateInterval` в секундах (см. `ProviderPolicy` и поле `minUpdateIntervalSeconds`).
- Существующий конвертер сохранял миллисекунды, что приводило к несоответствию представления в БД и доменной логике.
- Нужно привести конвертер к секундам, чтобы хранение и использование значений было согласованно.
- Изменение упрощает чтение/запись интервалов и устраняет потенциальные ошибки при расчётах периодичности запросов.

### Description
- Обновлён `DurationToMillisConverter` для сохранения значений в секундах с использованием `Duration#toSeconds()` и восстановления через `Duration#ofSeconds()`.
- Исправлена JavaDoc конвертера, теперь документирует хранение в секундах и точность до секунды.
- Конвертер продолжает применяться в JPA (`ProviderPolicyEmbeddable`) и JDBC-адаптере (`ProviderSyncDaoPostgresAdapter`) для колонки `min_update_interval_seconds`.
- Логика согласована с фабрикой `ProviderPolicy.ofSeconds(...)` и полями DTO/DB, обозначающими секунды.

### Testing
- Автоматические тесты не запускались в рамках этого изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f0f205b8832d8e596fcb1154a2eb)