### PR TITLE
Убрать исключение null в `ApiResponse`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/http/ApiResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/http/ApiResponse.java
@@ -1,15 +1,11 @@
 package com.alligator.market.backend.common.web.http;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.time.Instant;
 
 /**
  * Унифицированный конверт REST-ответов.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL) // <-- Не включать в JSON свойства со значением null (общее правило)
 public record ApiResponse<T>(
-        @JsonInclude(JsonInclude.Include.ALWAYS) // <-- Для поля ниже исключение — всегда включаем в JSON, даже если null
         T data,
         boolean success,
         String errorCode,

--- a/frontend/src/app/shared/api/api-response.model.ts
+++ b/frontend/src/app/shared/api/api-response.model.ts
@@ -2,7 +2,7 @@
 export interface ApiResponse<T> {
   data: T | null;
   success: boolean;
-  errorCode?: string;
+  errorCode: string | null;
   message: string;
   timestamp: string;
 }


### PR DESCRIPTION
### Motivation
- Упростить сериализацию ответов API и позволить полям с `null` явно присутствовать в JSON без специальных исключений.
- Синхронизировать контракт backend-а и frontend-а, чтобы не было рассинхронизации по полю `errorCode`.

### Description
- Удалена аннотация `@JsonInclude(JsonInclude.Include.NON_NULL)` из `backend/src/main/java/com/alligator/market/backend/common/web/http/ApiResponse.java` и исключение `@JsonInclude(JsonInclude.Include.ALWAYS)` для поля `data`.
- Обновлён frontend контракт в `frontend/src/app/shared/api/api-response.model.ts`, где `errorCode` стал `string | null` вместо опционального поля.
- Контроллеры и фабрика ответов продолжают использовать `ApiResponse.ok(...)` и `ApiResponse.error(...)` без изменений логики.

### Testing
- Автоматические тесты не запускались.
- Изменения были отформатированы и собраны как коммиты проекта (без запусков CI в рамках этого PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f5ece644832d988f6c6e8d39c73b)