### PR TITLE
Приведение доменных исключений к `BaseDomainException`

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyAlreadyExistsException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyAlreadyExistsException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.currency.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка: валюта уже существует.
  */
-public final class CurrencyAlreadyExistsException extends RuntimeException {
+public final class CurrencyAlreadyExistsException extends BaseDomainException {
 
     private final CurrencyCode code;
 
@@ -17,8 +19,8 @@ public final class CurrencyAlreadyExistsException extends RuntimeException {
      * @param code код валюты
      */
     public CurrencyAlreadyExistsException(CurrencyCode code) {
-        super(msg(code));
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_ALREADY_EXISTS, msg(code));
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class CurrencyAlreadyExistsException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public CurrencyAlreadyExistsException(CurrencyCode code, Throwable cause) {
-        super(msg(code), cause);
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_ALREADY_EXISTS, msg(code), cause);
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyCreateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyCreateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.currency.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка создания валюты.
  */
-public final class CurrencyCreateException extends RuntimeException {
+public final class CurrencyCreateException extends BaseDomainException {
 
     private final CurrencyCode code;
 
@@ -18,8 +20,8 @@ public final class CurrencyCreateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public CurrencyCreateException(CurrencyCode code) {
-        super(msg(code));
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_CREATE_FAILED, msg(code));
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class CurrencyCreateException extends RuntimeException {
      * @param cause причина ошибки
      */
     public CurrencyCreateException(CurrencyCode code, Throwable cause) {
-        super(msg(code), cause);
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_CREATE_FAILED, msg(code), cause);
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyDeleteException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyDeleteException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.currency.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка удаления валюты.
  */
-public final class CurrencyDeleteException extends RuntimeException {
+public final class CurrencyDeleteException extends BaseDomainException {
 
     private final CurrencyCode code;
 
@@ -18,8 +20,8 @@ public final class CurrencyDeleteException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public CurrencyDeleteException(CurrencyCode code) {
-        super(msg(code));
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_DELETE_FAILED, msg(code));
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class CurrencyDeleteException extends RuntimeException {
      * @param cause причина ошибки
      */
     public CurrencyDeleteException(CurrencyCode code, Throwable cause) {
-        super(msg(code), cause);
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_DELETE_FAILED, msg(code), cause);
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyNameDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyNameDuplicateException.java
@@ -1,11 +1,14 @@
 package com.alligator.market.domain.instrument.type.forex.currency.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
+
 import java.util.Objects;
 
 /**
  * Ошибка: дубликат валюты по имени.
  */
-public final class CurrencyNameDuplicateException extends RuntimeException {
+public final class CurrencyNameDuplicateException extends BaseDomainException {
 
     private final String name;
 
@@ -15,8 +18,8 @@ public final class CurrencyNameDuplicateException extends RuntimeException {
      * @param name имя валюты
      */
     public CurrencyNameDuplicateException(String name) {
-        super(msg(name));
-        this.name = name;
+        super(DomainErrorCode.CURRENCY_NAME_DUPLICATE, msg(name));
+        this.name = Objects.requireNonNull(name, "name must not be null");
     }
 
     /**
@@ -27,8 +30,8 @@ public final class CurrencyNameDuplicateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public CurrencyNameDuplicateException(String name, Throwable cause) {
-        super(msg(name), cause);
-        this.name = name;
+        super(DomainErrorCode.CURRENCY_NAME_DUPLICATE, msg(name), cause);
+        this.name = Objects.requireNonNull(name, "name must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyNotFoundException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.currency.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка поиска валюты.
  */
-public final class CurrencyNotFoundException extends RuntimeException {
+public final class CurrencyNotFoundException extends BaseDomainException {
 
     private final CurrencyCode code;
 
@@ -17,8 +19,8 @@ public final class CurrencyNotFoundException extends RuntimeException {
      * @param code код валюты
      */
     public CurrencyNotFoundException(CurrencyCode code) {
-        super(msg(code));
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_NOT_FOUND, msg(code));
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class CurrencyNotFoundException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public CurrencyNotFoundException(CurrencyCode code, Throwable cause) {
-        super(msg(code), cause);
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_NOT_FOUND, msg(code), cause);
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyUpdateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyUpdateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.currency.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка обновления валюты.
  */
-public final class CurrencyUpdateException extends RuntimeException {
+public final class CurrencyUpdateException extends BaseDomainException {
 
     private final CurrencyCode code;
 
@@ -18,8 +20,8 @@ public final class CurrencyUpdateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public CurrencyUpdateException(CurrencyCode code) {
-        super(msg(code));
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_UPDATE_FAILED, msg(code));
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class CurrencyUpdateException extends RuntimeException {
      * @param cause причина ошибки
      */
     public CurrencyUpdateException(CurrencyCode code, Throwable cause) {
-        super(msg(code), cause);
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_UPDATE_FAILED, msg(code), cause);
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyUsedInFxSpotException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/currency/exception/CurrencyUsedInFxSpotException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.currency.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка: валюта используется в FX_SPOT инструменте.
  */
-public final class CurrencyUsedInFxSpotException extends RuntimeException {
+public final class CurrencyUsedInFxSpotException extends BaseDomainException {
 
     private final CurrencyCode code;
 
@@ -17,8 +19,8 @@ public final class CurrencyUsedInFxSpotException extends RuntimeException {
      * @param code код валюты
      */
     public CurrencyUsedInFxSpotException(CurrencyCode code) {
-        super(msg(code));
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_USED_IN_FX_SPOT, msg(code));
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class CurrencyUsedInFxSpotException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public CurrencyUsedInFxSpotException(CurrencyCode code, Throwable cause) {
-        super(msg(code), cause);
-        this.code = code;
+        super(DomainErrorCode.CURRENCY_USED_IN_FX_SPOT, msg(code), cause);
+        this.code = Objects.requireNonNull(code, "code must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotAlreadyExistsException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotAlreadyExistsException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка повторного создания инструмента FX_SPOT.
  */
-public final class FxSpotAlreadyExistsException extends RuntimeException {
+public final class FxSpotAlreadyExistsException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
 
@@ -17,8 +19,8 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
      * @param instrumentCode код инструмента
      */
     public FxSpotAlreadyExistsException(InstrumentCode instrumentCode) {
-        super(msg(instrumentCode));
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_ALREADY_EXISTS, msg(instrumentCode));
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class FxSpotAlreadyExistsException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotAlreadyExistsException(InstrumentCode instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_ALREADY_EXISTS, msg(instrumentCode), cause);
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotCreateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotCreateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка создания инструмента FX_SPOT.
  */
-public final class FxSpotCreateException extends RuntimeException {
+public final class FxSpotCreateException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
 
@@ -18,8 +20,8 @@ public final class FxSpotCreateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotCreateException(InstrumentCode instrumentCode) {
-        super(msg(instrumentCode));
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_CREATE_FAILED, msg(instrumentCode));
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class FxSpotCreateException extends RuntimeException {
      * @param cause          причина ошибки
      */
     public FxSpotCreateException(InstrumentCode instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_CREATE_FAILED, msg(instrumentCode), cause);
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotDeleteException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка удаления инструмента FX_SPOT.
  */
-public final class FxSpotDeleteException extends RuntimeException {
+public final class FxSpotDeleteException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
 
@@ -18,8 +20,8 @@ public final class FxSpotDeleteException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotDeleteException(InstrumentCode instrumentCode) {
-        super(msg(instrumentCode));
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_DELETE_FAILED, msg(instrumentCode));
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class FxSpotDeleteException extends RuntimeException {
      * @param cause          причина ошибки
      */
     public FxSpotDeleteException(InstrumentCode instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_DELETE_FAILED, msg(instrumentCode), cause);
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotNotFoundException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка поиска инструмента FX_SPOT.
  */
-public final class FxSpotNotFoundException extends RuntimeException {
+public final class FxSpotNotFoundException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
 
@@ -17,8 +19,8 @@ public final class FxSpotNotFoundException extends RuntimeException {
      * @param instrumentCode код инструмента
      */
     public FxSpotNotFoundException(InstrumentCode instrumentCode) {
-        super(msg(instrumentCode));
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_NOT_FOUND, msg(instrumentCode));
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class FxSpotNotFoundException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotNotFoundException(InstrumentCode instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_NOT_FOUND, msg(instrumentCode), cause);
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotSameCurrenciesException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotSameCurrenciesException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.type.forex.currency.model.CurrencyCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка: базовая и котируемая валюты совпадают.
  */
-public final class FxSpotSameCurrenciesException extends RuntimeException {
+public final class FxSpotSameCurrenciesException extends BaseDomainException {
 
     private final CurrencyCode base;
     private final CurrencyCode quote;
@@ -19,9 +21,9 @@ public final class FxSpotSameCurrenciesException extends RuntimeException {
      * @param quote код котируемой валюты
      */
     public FxSpotSameCurrenciesException(CurrencyCode base, CurrencyCode quote) {
-        super(msg(base, quote));
-        this.base = base;
-        this.quote = quote;
+        super(DomainErrorCode.FX_SPOT_SAME_CURRENCIES, msg(base, quote));
+        this.base = Objects.requireNonNull(base, "base must not be null");
+        this.quote = Objects.requireNonNull(quote, "quote must not be null");
     }
 
     /**
@@ -33,9 +35,9 @@ public final class FxSpotSameCurrenciesException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotSameCurrenciesException(CurrencyCode base, CurrencyCode quote, Throwable cause) {
-        super(msg(base, quote), cause);
-        this.base = base;
-        this.quote = quote;
+        super(DomainErrorCode.FX_SPOT_SAME_CURRENCIES, msg(base, quote), cause);
+        this.base = Objects.requireNonNull(base, "base must not be null");
+        this.quote = Objects.requireNonNull(quote, "quote must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/exception/FxSpotUpdateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Ошибка обновления инструмента FX_SPOT.
  */
-public final class FxSpotUpdateException extends RuntimeException {
+public final class FxSpotUpdateException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
 
@@ -18,8 +20,8 @@ public final class FxSpotUpdateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public FxSpotUpdateException(InstrumentCode instrumentCode) {
-        super(msg(instrumentCode));
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_UPDATE_FAILED, msg(instrumentCode));
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class FxSpotUpdateException extends RuntimeException {
      * @param cause          причина ошибки
      */
     public FxSpotUpdateException(InstrumentCode instrumentCode, Throwable cause) {
-        super(msg(instrumentCode), cause);
-        this.instrumentCode = instrumentCode;
+        super(DomainErrorCode.FX_SPOT_UPDATE_FAILED, msg(instrumentCode), cause);
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.provider.code.ProviderCode;
 
@@ -8,7 +10,7 @@ import java.util.Objects;
 /**
  * Обработчик для инструмента не найден.
  */
-public final class HandlerNotFoundException extends RuntimeException {
+public final class HandlerNotFoundException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
     private final ProviderCode providerCode;
@@ -20,9 +22,9 @@ public final class HandlerNotFoundException extends RuntimeException {
      * @param providerCode   код провайдера
      */
     public HandlerNotFoundException(InstrumentCode instrumentCode, ProviderCode providerCode) {
-        super(msg(instrumentCode, providerCode));
-        this.instrumentCode = instrumentCode;
-        this.providerCode = providerCode;
+        super(DomainErrorCode.HANDLER_NOT_FOUND, msg(instrumentCode, providerCode));
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.providerCode = Objects.requireNonNull(providerCode, "providerCode must not be null");
     }
 
     /**
@@ -34,9 +36,9 @@ public final class HandlerNotFoundException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public HandlerNotFoundException(InstrumentCode instrumentCode, ProviderCode providerCode, Throwable cause) {
-        super(msg(instrumentCode, providerCode), cause);
-        this.instrumentCode = instrumentCode;
-        this.providerCode = providerCode;
+        super(DomainErrorCode.HANDLER_NOT_FOUND, msg(instrumentCode, providerCode), cause);
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.providerCode = Objects.requireNonNull(providerCode, "providerCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Инструмент не поддерживается обработчиком.
  */
-public final class InstrumentNotSupportedException extends RuntimeException {
+public final class InstrumentNotSupportedException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
     private final String handlerCode;
@@ -20,9 +22,9 @@ public final class InstrumentNotSupportedException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public InstrumentNotSupportedException(InstrumentCode instrumentCode, String handlerCode) {
-        super(msg(instrumentCode, handlerCode));
-        this.instrumentCode = instrumentCode;
-        this.handlerCode = handlerCode;
+        super(DomainErrorCode.INSTRUMENT_NOT_SUPPORTED, msg(instrumentCode, handlerCode));
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
     }
 
     /**
@@ -34,9 +36,9 @@ public final class InstrumentNotSupportedException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public InstrumentNotSupportedException(InstrumentCode instrumentCode, String handlerCode, Throwable cause) {
-        super(msg(instrumentCode, handlerCode), cause);
-        this.instrumentCode = instrumentCode;
-        this.handlerCode = handlerCode;
+        super(DomainErrorCode.INSTRUMENT_NOT_SUPPORTED, msg(instrumentCode, handlerCode), cause);
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Класс инструмента не соответствует обработчику.
  */
-public final class InstrumentWrongClassException extends RuntimeException {
+public final class InstrumentWrongClassException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
     private final Class<?> instrumentClass;
@@ -28,11 +30,14 @@ public final class InstrumentWrongClassException extends RuntimeException {
             String handlerCode,
             Class<?> expectedClass
     ) {
-        super(msg(instrumentCode, instrumentClass, handlerCode, expectedClass));
-        this.instrumentCode = instrumentCode;
-        this.instrumentClass = instrumentClass;
-        this.handlerCode = handlerCode;
-        this.expectedClass = expectedClass;
+        super(
+                DomainErrorCode.INSTRUMENT_WRONG_CLASS,
+                msg(instrumentCode, instrumentClass, handlerCode, expectedClass)
+        );
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.instrumentClass = Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
+        this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        this.expectedClass = Objects.requireNonNull(expectedClass, "expectedClass must not be null");
     }
 
     /**
@@ -52,11 +57,15 @@ public final class InstrumentWrongClassException extends RuntimeException {
             Class<?> expectedClass,
             Throwable cause
     ) {
-        super(msg(instrumentCode, instrumentClass, handlerCode, expectedClass), cause);
-        this.instrumentCode = instrumentCode;
-        this.instrumentClass = instrumentClass;
-        this.handlerCode = handlerCode;
-        this.expectedClass = expectedClass;
+        super(
+                DomainErrorCode.INSTRUMENT_WRONG_CLASS,
+                msg(instrumentCode, instrumentClass, handlerCode, expectedClass),
+                cause
+        );
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.instrumentClass = Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
+        this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        this.expectedClass = Objects.requireNonNull(expectedClass, "expectedClass must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongTypeException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongTypeException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 
@@ -8,7 +10,7 @@ import java.util.Objects;
 /**
  * Тип инструмента не соответствует обработчику.
  */
-public final class InstrumentWrongTypeException extends RuntimeException {
+public final class InstrumentWrongTypeException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
     private final InstrumentType instrumentType;
@@ -29,11 +31,14 @@ public final class InstrumentWrongTypeException extends RuntimeException {
             String handlerCode,
             InstrumentType expectedType
     ) {
-        super(msg(instrumentCode, instrumentType, handlerCode, expectedType));
-        this.instrumentCode = instrumentCode;
-        this.instrumentType = instrumentType;
-        this.handlerCode = handlerCode;
-        this.expectedType = expectedType;
+        super(
+                DomainErrorCode.INSTRUMENT_WRONG_TYPE,
+                msg(instrumentCode, instrumentType, handlerCode, expectedType)
+        );
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.instrumentType = Objects.requireNonNull(instrumentType, "instrumentType must not be null");
+        this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        this.expectedType = Objects.requireNonNull(expectedType, "expectedType must not be null");
     }
 
     /**
@@ -53,11 +58,15 @@ public final class InstrumentWrongTypeException extends RuntimeException {
             InstrumentType expectedType,
             Throwable cause
     ) {
-        super(msg(instrumentCode, instrumentType, handlerCode, expectedType), cause);
-        this.instrumentCode = instrumentCode;
-        this.instrumentType = instrumentType;
-        this.handlerCode = handlerCode;
-        this.expectedType = expectedType;
+        super(
+                DomainErrorCode.INSTRUMENT_WRONG_TYPE,
+                msg(instrumentCode, instrumentType, handlerCode, expectedType),
+                cause
+        );
+        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        this.instrumentType = Objects.requireNonNull(instrumentType, "instrumentType must not be null");
+        this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        this.expectedType = Objects.requireNonNull(expectedType, "expectedType must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderCodeDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderCodeDuplicateException.java
@@ -1,5 +1,7 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.provider.code.ProviderCode;
 
 import java.util.Objects;
@@ -7,7 +9,7 @@ import java.util.Objects;
 /**
  * Дублирование кодов провайдеров.
  */
-public final class ProviderCodeDuplicateException extends RuntimeException {
+public final class ProviderCodeDuplicateException extends BaseDomainException {
 
     private final ProviderCode providerCode;
 
@@ -17,8 +19,8 @@ public final class ProviderCodeDuplicateException extends RuntimeException {
      * @param providerCode код провайдера
      */
     public ProviderCodeDuplicateException(ProviderCode providerCode) {
-        super(msg(providerCode));
-        this.providerCode = providerCode;
+        super(DomainErrorCode.PROVIDER_CODE_DUPLICATE, msg(providerCode));
+        this.providerCode = Objects.requireNonNull(providerCode, "providerCode must not be null");
     }
 
     /**
@@ -29,8 +31,8 @@ public final class ProviderCodeDuplicateException extends RuntimeException {
      */
     @SuppressWarnings("unused")
     public ProviderCodeDuplicateException(ProviderCode providerCode, Throwable cause) {
-        super(msg(providerCode), cause);
-        this.providerCode = providerCode;
+        super(DomainErrorCode.PROVIDER_CODE_DUPLICATE, msg(providerCode), cause);
+        this.providerCode = Objects.requireNonNull(providerCode, "providerCode must not be null");
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDisplayNameDuplicateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderDisplayNameDuplicateException.java
@@ -1,11 +1,14 @@
 package com.alligator.market.domain.provider.exception;
 
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
+
 import java.util.Objects;
 
 /**
  * Дублирование отображаемых имен провайдеров.
  */
-public final class ProviderDisplayNameDuplicateException extends RuntimeException {
+public final class ProviderDisplayNameDuplicateException extends BaseDomainException {
 
     private final String displayName;
 
@@ -15,8 +18,8 @@ public final class ProviderDisplayNameDuplicateException extends RuntimeExceptio
      * @param displayName отображаемое имя провайдера
      */
     public ProviderDisplayNameDuplicateException(String displayName) {
-        super(msg(displayName));
-        this.displayName = displayName;
+        super(DomainErrorCode.PROVIDER_DISPLAY_NAME_DUPLICATE, msg(displayName));
+        this.displayName = Objects.requireNonNull(displayName, "displayName must not be null");
     }
 
     /**
@@ -27,8 +30,8 @@ public final class ProviderDisplayNameDuplicateException extends RuntimeExceptio
      */
     @SuppressWarnings("unused")
     public ProviderDisplayNameDuplicateException(String displayName, Throwable cause) {
-        super(msg(displayName), cause);
-        this.displayName = displayName;
+        super(DomainErrorCode.PROVIDER_DISPLAY_NAME_DUPLICATE, msg(displayName), cause);
+        this.displayName = Objects.requireNonNull(displayName, "displayName must not be null");
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Упорядочить доменные исключения, сделав их расширениями `BaseDomainException` и связав с `DomainErrorCode`.
- Обеспечить единый контракт для обработки доменных ошибок по коду и типу ошибки.
- Уменьшить риск скрытых NPE за счёт явной проверки обязательных полей при создании исключений.

### Description
- Множество исключений в пакете `domain` (валюты, FX_SPOT, провайдеры) теперь наследуются от `BaseDomainException` и получают соответствующий `DomainErrorCode` при вызове суперкласса.
- Заменены вызовы `super(msg(...))` на `super(DomainErrorCode.XYZ, msg(...))` и добавлены проверки `Objects.requireNonNull` для полей контекста.
- Сохранены существующие информативные текстовые сообщения об ошибках; добавлена явная валидация входных значений в конструкторах.
- Изменения затронули ~19 файлов в пакете `domain` (исключения для currency, fx_spot и provider).

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ce4cbc3bc832d84748b65af953947)