### PR TITLE
Использовать `FxSpotEntityMapper` для преобразования в домен

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityAssembler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityAssembler.java
@@ -1,7 +1,6 @@
 package com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa;
 
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.persistence.jpa.CurrencyEntity;
-import com.alligator.market.backend.instrument.type.forex.currency.catalog.persistence.jpa.CurrencyEntityMapper;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 
 import java.util.Objects;
@@ -56,23 +55,4 @@ public final class FxSpotEntityAssembler {
         e.setDefaultQuoteFractionDigits(m.defaultQuoteFractionDigits());
     }
 
-    /**
-     * Преобразует JPA-сущность в доменную модель.
-     */
-    public static FxSpot toDomain(FxSpotEntity e) {
-        Objects.requireNonNull(e, "entity must not be null");
-
-        // Поле defaultQuoteFractionDigits не является идентичностью сущности, поэтому может быть null.
-        // Однако по бизнес логике доменная модель не предполагает возможность null => нужна null проверка.
-        int digits = Objects.requireNonNull(e.getDefaultQuoteFractionDigits(),
-                "defaultQuoteFractionDigits must not be null");
-
-        // Собираем и возвращаем доменную модель
-        return new FxSpot(
-                CurrencyEntityMapper.toDomain(e.getBaseCurrency()),
-                CurrencyEntityMapper.toDomain(e.getQuoteCurrency()),
-                e.getTenor(),
-                digits
-        );
-    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.instrument.type.forex.currency.catalog.persi
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.persistence.jpa.CurrencyJpaRepository;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntity;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntityAssembler;
+import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotEntityMapper;
 import com.alligator.market.backend.instrument.type.forex.spot.catalog.persistence.jpa.FxSpotJpaRepository;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.forex.currency.exception.CurrencyNotFoundException;
@@ -53,7 +54,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         // Пробуем сохранить созданную сущность и маппим наиболее вероятные ошибки
         try {
             FxSpotEntity saved = jpaRepository.saveAndFlush(entity);
-            return FxSpotEntityAssembler.toDomain(saved); // Успех
+            return FxSpotEntityMapper.toDomain(saved); // Успех
         } catch (DataIntegrityViolationException ex) {
             if (DbErrors.isViolationOf(ex, UQ_INSTRUMENT_CODE)) {
                 throw new FxSpotAlreadyExistsException(fxSpot.instrumentCode()); // <-- Бизнес‑ошибка: дубликат
@@ -82,7 +83,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         // Пробуем сохранить обновленную сущность и маппим наиболее вероятные ошибки
         try {
             FxSpotEntity saved = jpaRepository.saveAndFlush(e);
-            return FxSpotEntityAssembler.toDomain(saved); // <-- Успех
+            return FxSpotEntityMapper.toDomain(saved); // <-- Успех
         } catch (DataIntegrityViolationException ex) {
             // Любые ошибки целостности данных (уникальности/ограничения на уровне БД)
             // Для update бизнес-уникальность не меняется, поэтому маппим в техническую ошибку обновления
@@ -122,7 +123,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
         String codeValue = instrumentCode.value();
 
         return jpaRepository.findByCode(codeValue)
-                .map(FxSpotEntityAssembler::toDomain);
+                .map(FxSpotEntityMapper::toDomain);
     }
 
     @Override
@@ -130,7 +131,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
         return jpaRepository.findAll(Sort.by(Sort.Order.asc("code")))
                 .stream()
-                .map(FxSpotEntityAssembler::toDomain)
+                .map(FxSpotEntityMapper::toDomain)
                 .toList();
     }
 


### PR DESCRIPTION
### Motivation
- Перенести ответственность за преобразование JPA-сущности в доменную модель в отдельный маппер для лучшего разделения ответственностей. 
- Избежать дублирования логики преобразования и стандартизировать контракт маппинга через `FxSpotEntityMapper`. 
- Оставить `FxSpotEntityAssembler` только за созданием и обновлением JPA-сущности.

### Description
- Удалён метод `toDomain` из `FxSpotEntityAssembler`, в классе оставлены только `newEntity` и `apply` для сборки/обновления сущности. 
- Во `FxSpotRepositoryAdapter` все вызовы `FxSpotEntityAssembler::toDomain` заменены на `FxSpotEntityMapper::toDomain` и добавлен импорт `FxSpotEntityMapper`. 
- Удалён неиспользуемый импорт `CurrencyEntityMapper` из `FxSpotEntityAssembler`. 
- Изменения затронули файлы `backend/src/main/java/.../FxSpotEntityAssembler.java` и `backend/src/main/java/.../FxSpotRepositoryAdapter.java`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e46536b24832da893a4cd6648e6a0)