### PR TITLE
Рефакторинг: унификация логирования через `@Slf4j`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/config/time/TimeZoneConfig.java
@@ -1,9 +1,8 @@
 package com.alligator.market.backend.config.time;
 
 import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cfg.AvailableSettings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -19,9 +18,8 @@ import java.util.TimeZone;
  * <p>Настраивает временную зону для системы, Jackson и Hibernate.</p>
  */
 @Configuration
+@Slf4j
 public class TimeZoneConfig {
-
-    private static final Logger log = LoggerFactory.getLogger(TimeZoneConfig.class);
 
     private static final ZoneId UTC = ZoneOffset.UTC;
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
@@ -13,9 +13,8 @@ import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentH
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -33,6 +32,7 @@ import java.util.Set;
 /**
  * Обработчик инструментов FX_SPOT для провайдера MOEX ISS {@link MoexIssAdapter}.
  */
+@Slf4j
 public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapter, FxSpot> {
 
     /* Уникальный код обработчика: UPPERCASE, формат [A-Z0-9_]+. */
@@ -43,9 +43,6 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
 
     /* Web-клиент. */
     private final WebClient webClient;
-
-    /* Для логирования. */
-    private static final Logger log = LoggerFactory.getLogger(MoexIssFxSpotHandler.class);
 
     /* Формат даты/времени поля SYSTIME в ответе MOEX ISS. */
     private static final DateTimeFormatter MOEX_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotHandler.java
@@ -8,13 +8,12 @@ import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
+import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -29,6 +28,7 @@ import java.util.Set;
 /**
  * Обработчик инструментов FX_SPOT для провайдера рыночных данных ProFinance (парсинг с сайта).
  */
+@Slf4j
 public class ProFinanceFxSpotHandler extends AbstractInstrumentHandler<ProFinanceAdapter, FxSpot> {
 
     /* Уникальный код обработчика: UPPERCASE, формат [A-Z0-9_]+. */
@@ -39,9 +39,6 @@ public class ProFinanceFxSpotHandler extends AbstractInstrumentHandler<ProFinanc
 
     /* Web-клиент. */
     private final WebClient webClient;
-
-    /* Для логирования. */
-    private static final Logger log = LoggerFactory.getLogger(ProFinanceFxSpotHandler.class);
 
     //=================================================================================================================
     // КОНСТРУКТОР

--- a/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamSmokeRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamSmokeRunner.java
@@ -5,8 +5,7 @@ import com.alligator.market.domain.instrument.type.forex.currency.model.Currency
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotTenor;
 import jakarta.annotation.PreDestroy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -21,9 +20,8 @@ import java.time.Duration;
  */
 @Component
 @ConditionalOnProperty(name = "quotes.smoke.enabled", havingValue = "true")
+@Slf4j
 public class QuoteStreamSmokeRunner {
-
-    private static final Logger log = LoggerFactory.getLogger(QuoteStreamSmokeRunner.class);
 
     /* Оркестратор построения потока котировок. */
     private final QuoteStreamingOrchestrator orchestrator;


### PR DESCRIPTION
### Motivation

- Обеспечить единообразный подход к внедрению логера во всех классах согласно лучшим практикам.
- Упростить и стандартизировать код, убрав ручные поля `Logger`/`LoggerFactory` и их дублирование.
- Повысить читаемость и подготовить проект к единому контракту по логированию.

### Description

- Заменены декларации логера на `lombok.extern.slf4j.Slf4j` и добавлена аннотация `@Slf4j` в `MoexIssFxSpotHandler`, `ProFinanceFxSpotHandler`, `QuoteStreamSmokeRunner` и `TimeZoneConfig`.
- Удалены явные поля `private static final Logger ... = LoggerFactory.getLogger(...)` в перечисленных классах.
- Добавлен импорт `lombok.extern.slf4j.Slf4j` и аннотация `@Slf4j` над классами, при этом использование `log` в существующем коде сохранено без изменений.
- Изменения оформлены коммитом с сообщением `refactor: standardize logging injection`.

### Testing

- Автоматические тесты не запускались в ходе этого изменения.
- Проверка сборки/CI не выполнялась локально для этого PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d24f7c20832db879f977abb7c1fd)