### PR TITLE
Переименовать колонку fx_spot: `value_date` → `tenor`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -28,13 +28,13 @@ import java.util.Objects;
         // CHECK: при DDL-генерации создаётся Hibernate; иначе – «живая» спецификация для миграций.
         constraints = "(base_currency <> quote_currency) " +
                 "AND (quote_fraction_digits BETWEEN 0 AND 10) " +
-                "AND (value_date IN ('TOD','TOM','SPOT'))"
+                "AND (tenor IN ('TOD','TOM','SPOT'))"
 )
 @Table(
         name = "fx_spot",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_fx_spot_pair_value_date",
-                        columnNames = {"base_currency", "quote_currency", "value_date"})
+                @UniqueConstraint(name = "uq_fx_spot_pair_tenor",
+                        columnNames = {"base_currency", "quote_currency", "tenor"})
         },
         indexes = {
                 @Index(name = "idx_fx_spot_base", columnList = "base_currency"),
@@ -82,7 +82,7 @@ public class FxSpotEntity extends InstrumentBaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     @Column(
-            name = "value_date", length = 4,
+            name = "tenor", length = 4,
             nullable = false,
             updatable = false
     )

--- a/backend/src/main/resources/db/migration/V3__create_fx_spot_table.sql
+++ b/backend/src/main/resources/db/migration/V3__create_fx_spot_table.sql
@@ -2,16 +2,16 @@ CREATE TABLE fx_spot (
     id BIGINT PRIMARY KEY,
     base_currency VARCHAR(3) NOT NULL,
     quote_currency VARCHAR(3) NOT NULL,
-    value_date VARCHAR(4) NOT NULL,
+    tenor VARCHAR(4) NOT NULL,
     quote_fraction_digits INTEGER NOT NULL,
     CONSTRAINT fk_fx_spot_instrument FOREIGN KEY (id) REFERENCES instrument (id) ON DELETE CASCADE,
     CONSTRAINT fk_fx_spot_base FOREIGN KEY (base_currency) REFERENCES currency (code),
     CONSTRAINT fk_fx_spot_quote FOREIGN KEY (quote_currency) REFERENCES currency (code),
-    CONSTRAINT uq_fx_spot_pair_value_date UNIQUE (base_currency, quote_currency, value_date),
+    CONSTRAINT uq_fx_spot_pair_tenor UNIQUE (base_currency, quote_currency, tenor),
     CONSTRAINT chk_fx_spot_integrity CHECK (
         base_currency <> quote_currency
         AND quote_fraction_digits BETWEEN 0 AND 10
-        AND value_date IN ('TOD', 'TOM', 'SPOT')
+        AND tenor IN ('TOD', 'TOM', 'SPOT')
     )
 );
 


### PR DESCRIPTION
### Motivation
- В доменной модели параметр `valueDate` был переименован в `tenor`, требуется синхронизировать базу и JPA-сущность.
- Избежать рассинхронизации имён колонок и ограничений между миграциями и ORM.
- Обеспечить корректную генерацию DDL и работу `FxSpotEntity` вместе с перечислением `FxSpotTenor`.

### Description
- В `backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java` заменил `@Column(name = "value_date")` на `@Column(name = "tenor")` и обновил `@Check` и `@UniqueConstraint` с `value_date` → `tenor`.
- В миграции `backend/src/main/resources/db/migration/V3__create_fx_spot_table.sql` переименовал колонку `value_date` в `tenor`, обновил уникальное ограничение `uq_fx_spot_pair_value_date` → `uq_fx_spot_pair_tenor` и условие `value_date IN (...)` → `tenor IN (...)`.
- Сохранены формат и длина поля (`VARCHAR(4)`) и использование перечисления `FxSpotTenor` для значений тенора.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e758f5d4832d99ad39a6daaa077c)