### PR TITLE
Flyway: дефолты и исправления ограничений для currency и fx_spot

### DIFF
--- a/backend/src/main/resources/db/migration/V2__create_currency_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_currency_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE currency (
     code VARCHAR(3) NOT NULL,
     name VARCHAR(50) NOT NULL,
     country VARCHAR(100) NOT NULL,
-    fraction_digits INTEGER NOT NULL,
+    fraction_digits INTEGER NOT NULL DEFAULT 2,
     version BIGINT NOT NULL,
     created_timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
     created_by VARCHAR(255) NOT NULL,
@@ -13,5 +13,5 @@ CREATE TABLE currency (
     updated_via VARCHAR(255) NOT NULL,
     CONSTRAINT uq_currency_code UNIQUE (code),
     CONSTRAINT uq_currency_name UNIQUE (name),
-    CONSTRAINT chk_currency_fraction_digits CHECK (fraction_digits BETWEEN 0 AND 10)
+    CONSTRAINT ck_currency_fraction_digits CHECK (fraction_digits BETWEEN 0 AND 10)
 );

--- a/backend/src/main/resources/db/migration/V3__create_fx_spot_table.sql
+++ b/backend/src/main/resources/db/migration/V3__create_fx_spot_table.sql
@@ -3,16 +3,14 @@ CREATE TABLE fx_spot (
     base_currency VARCHAR(3) NOT NULL,
     quote_currency VARCHAR(3) NOT NULL,
     tenor VARCHAR(4) NOT NULL,
-    quote_fraction_digits INTEGER NOT NULL,
+    quote_fraction_digits INTEGER NOT NULL DEFAULT 4,
     CONSTRAINT fk_fx_spot_instrument FOREIGN KEY (id) REFERENCES instrument (id) ON DELETE CASCADE,
     CONSTRAINT fk_fx_spot_base FOREIGN KEY (base_currency) REFERENCES currency (code),
     CONSTRAINT fk_fx_spot_quote FOREIGN KEY (quote_currency) REFERENCES currency (code),
     CONSTRAINT uq_fx_spot_pair_tenor UNIQUE (base_currency, quote_currency, tenor),
-    CONSTRAINT chk_fx_spot_integrity CHECK (
-        base_currency <> quote_currency
-        AND quote_fraction_digits BETWEEN 0 AND 10
-        AND tenor IN ('TOD', 'TOM', 'SPOT')
-    )
+    CONSTRAINT chk_fx_spot_base_quote_diff CHECK (base_currency <> quote_currency),
+    CONSTRAINT chk_fx_spot_digits_range CHECK (quote_fraction_digits BETWEEN 0 AND 10),
+    CONSTRAINT chk_fx_spot_tenor_allowed CHECK (tenor IN ('TOD', 'TOM', 'SPOT'))
 );
 
 CREATE INDEX idx_fx_spot_base ON fx_spot (base_currency);


### PR DESCRIPTION
### Motivation
- Привести SQL-миграции в соответствие с JPA-сущностями `CurrencyEntity` и `FxSpotEntity` и заданными именами ограничений.
- Задать значения по умолчанию для полей, которые имеют дефолты в коде сущностей, чтобы согласовать поведение БД и приложения.

### Description
- В `V2__create_currency_table.sql` добавлено `DEFAULT 2` для `fraction_digits` и исправлено имя чек-ограничения на `ck_currency_fraction_digits`.
- В `V3__create_fx_spot_table.sql` добавлено `DEFAULT 4` для `quote_fraction_digits` и разнесены составные проверки на три отдельных чек-ограничения с именами `chk_fx_spot_base_quote_diff`, `chk_fx_spot_digits_range` и `chk_fx_spot_tenor_allowed`.
- Сохранены существующие уникальные и внешние ключи, а также индексы `idx_fx_spot_base` и `idx_fx_spot_quote`.

### Testing
- Автоматические миграционные или интеграционные тесты не запускались в процессе этого изменения.
- Локальные проверки синтаксиса файлов выполнены в ходе редактирования (файлы сохранены без конфликтов).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962afe2c614832dac1b6de26d29131e)