### PR TITLE
AbstractProviderContextScanner: возвращать паспорта провайдеров вместо снимков

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/AbstractProviderContextScanner.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/AbstractProviderContextScanner.java
@@ -3,10 +3,8 @@ package com.alligator.market.domain.provider.reconciliation.scanner;
 import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
-import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.exception.ProviderCodeDuplicateException;
 import com.alligator.market.domain.provider.exception.ProviderDisplayNameDuplicateException;
-import com.alligator.market.domain.provider.reconciliation.dto.ProviderSnapshot;
 
 import java.util.*;
 
@@ -21,21 +19,20 @@ public abstract non-sealed class AbstractProviderContextScanner implements Provi
     protected abstract Iterable<MarketDataProvider> providers();
 
     /**
-     * Возвращает карту снимков провайдеров {@link ProviderSnapshot}, индексированную по коду.
+     * Возвращает карту паспортов провайдеров {@link ProviderPassport}, индексированную по коду.
      * Содержит проверки на дублирование по коду провайдера и отображаемому имени.
      */
     @Override
-    public final Map<ProviderCode, ProviderSnapshot> providerSnapshots() {
-        Map<ProviderCode, ProviderSnapshot> snapshots = new LinkedHashMap<>();
+    public final Map<ProviderCode, ProviderPassport> providerPassports() {
+        Map<ProviderCode, ProviderPassport> passports = new LinkedHashMap<>();
         Set<String> displayNamesLower = new HashSet<>();
 
         for (MarketDataProvider provider : providers()) {
             ProviderCode code = provider.providerCode();
             ProviderPassport passport = provider.passport();
-            ProviderPolicy policy = provider.policy();
 
             // Проверка дублей по коду
-            ProviderSnapshot prev = snapshots.put(code, new ProviderSnapshot(code, passport, policy));
+            ProviderPassport prev = passports.put(code, passport);
             if (prev != null) {
                 throw new ProviderCodeDuplicateException(code);
             }
@@ -46,6 +43,6 @@ public abstract non-sealed class AbstractProviderContextScanner implements Provi
                 throw new ProviderDisplayNameDuplicateException(passport.displayName());
             }
         }
-        return snapshots;
+        return passports;
     }
 }


### PR DESCRIPTION
### Motivation
- Уйти от использования `ProviderSnapshot` при сканировании контекста приложения и извлекать только паспорта `ProviderPassport`.
- Упростить каркас сканера, убрав логику, связанную с формированием «снимков» и обработкой `ProviderPolicy`.
- Снизить связность между сканером контекста и DTO `ProviderSnapshot` для последующей поэтапной миграции.

### Description
- Метод `providerSnapshots()` заменён на `providerPassports()` и теперь возвращает `Map<ProviderCode, ProviderPassport>` вместо карты снимков.
- Логика сборки карты теперь складывает только `ProviderPassport` и выполняет проверки дубликатов по коду и по отображаемому имени (без учёта регистра).
- Удалена зависимость от `ProviderPolicy` и от `ProviderSnapshot` в классе `AbstractProviderContextScanner`.
- Изменён файл `domain/src/main/java/com/alligator/market/domain/provider/reconciliation/scanner/AbstractProviderContextScanner.java`.

### Testing
- Автоматические тесты не запускались (не запрошено).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654a2440e4832daadc751ed2a06293)