### PR TITLE
Add currency code pattern checks

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Checks;
 import org.hibernate.annotations.NaturalId;
 
 import java.util.Objects;
@@ -28,10 +29,16 @@ import java.util.Objects;
  * </ul>
  */
 @Entity
-@Check(
-        name = "chk_currency_fraction_digits",
-        constraints = "fraction_digits BETWEEN 0 AND 10"
-)
+@Checks({
+        @Check(
+                name = "chk_currency_code_pattern",
+                constraints = "code ~ '^[A-Z]{3}$'"
+        ),
+        @Check(
+                name = "chk_currency_fraction_digits",
+                constraints = "fraction_digits BETWEEN 0 AND 10"
+        )
+})
 @Table(
         name = "currency",
         uniqueConstraints = {

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE currency (
     updated_via VARCHAR(255) NOT NULL,
     CONSTRAINT uq_currency_code UNIQUE (code),
     CONSTRAINT uq_currency_name UNIQUE (name),
+    CONSTRAINT chk_currency_code_pattern CHECK (code ~ '^[A-Z]{3}$'),
     CONSTRAINT chk_currency_fraction_digits CHECK (fraction_digits BETWEEN 0 AND 10)
 );
 


### PR DESCRIPTION
### Motivation
- Enforce the currency code format at the database level to prevent invalid codes (three uppercase letters).
- Make the same constraint visible on the JPA entity for documentation and runtime ORM awareness.
- Keep consistency between the DB schema and the domain model `CurrencyCode` pattern.

### Description
- Add `CONSTRAINT chk_currency_code_pattern CHECK (code ~ '^[A-Z]{3}$')` to `V1__init_schema.sql` to validate stored currency codes.
- Add `@Checks` to `CurrencyEntity.java` with an `@Check` named `chk_currency_code_pattern` using the same regex and keep the existing `chk_currency_fraction_digits` check.
- Add the `org.hibernate.annotations.Checks` import and replace the single `@Check` usage with the aggregated `@Checks` annotation.
- Commit updated files: `backend/src/main/resources/db/migration/V1__init_schema.sql` and `backend/src/main/java/.../CurrencyEntity.java`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696574455820832db072ca6b0cf7dd43)