### PR TITLE
Синхронизировать проверку кода валюты с `CurrencyCode.PATTERN`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 @Checks({
         @Check(
                 name = "chk_currency_code_pattern",
-                constraints = "code ~ '^[A-Z]{3}$'"
+                constraints = "code ~ '" + CurrencyCode.PATTERN + "'"
         ),
         @Check(
                 name = "chk_currency_fraction_digits",

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE currency (
     updated_via VARCHAR(255) NOT NULL,
     CONSTRAINT uq_currency_code UNIQUE (code),
     CONSTRAINT uq_currency_name UNIQUE (name),
+    -- Должно соответствовать CurrencyCode.PATTERN.
     CONSTRAINT chk_currency_code_pattern CHECK (code ~ '^[A-Z]{3}$'),
     CONSTRAINT chk_currency_fraction_digits CHECK (fraction_digits BETWEEN 0 AND 10)
 );


### PR DESCRIPTION
### Motivation

- В коде уже использовался единый источник правды для формата кода провайдера через `ProviderCode.PATTERN`, а проверка кода валюты была захардкожена как литерал, что может привести к рассинхронизации.
- Нужно обеспечить одинаковый подход для валидации форматов (единственный источник правды для регулярного выражения).

### Description

- В `CurrencyEntity` заменил литеральный SQL-check `code ~ '^[A-Z]{3}$'` на ссылку на доменный константный шаблон `CurrencyCode.PATTERN` (`constraints = "code ~ '" + CurrencyCode.PATTERN + "'"`).
- В миграции `backend/src/main/resources/db/migration/V1__init_schema.sql` добавил комментарий рядом с констрейнтом, указывающий, что правило должно соответствовать `CurrencyCode.PATTERN`.
- Изменённые файлы: `backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/persistence/jpa/CurrencyEntity.java` и `backend/src/main/resources/db/migration/V1__init_schema.sql`.

### Testing

- Автоматические тесты не запускались.
- Изменения ограничены выравниванием аннотаций и комментариев в миграции и не вносят логики, требующей дополнительных модульных тестов на данном этапе.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657e699790832d839198db2c3c7238)