### PR TITLE
Использовать `ProviderCode` в `ProviderPassportEntity` и добавить JPA-конвертер

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderCodeConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderCodeConverter.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.provider.catalog.passport.persistence.jpa;
+
+import com.alligator.market.domain.provider.code.ProviderCode;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Конвертер для хранения {@link ProviderCode} в виде строкового значения в БД.
+ */
+@Converter(autoApply = true)
+public class ProviderCodeConverter implements AttributeConverter<ProviderCode, String> {
+
+    /**
+     * Преобразует доменную модель в значение для БД.
+     */
+    @Override
+    public String convertToDatabaseColumn(ProviderCode attribute) {
+        return attribute != null ? attribute.value() : null;
+    }
+
+    /**
+     * Преобразует значение из БД в доменную модель.
+     */
+    @Override
+    public ProviderCode convertToEntityAttribute(String dbData) {
+        return dbData != null ? ProviderCode.of(dbData) : null;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderPassportEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderPassportEntity.java
@@ -7,10 +7,7 @@ import com.alligator.market.domain.provider.contract.passport.DeliveryMode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.reconciliation.ProviderSynchronizer;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -80,16 +77,15 @@ public class ProviderPassportEntity extends BaseEntity {
     /**
      * Технический код провайдера (натуральный ключ).
      */
-    @NotBlank
-    @Size(max = 50)
-    @Pattern(regexp = ProviderCode.PATTERN)
+    @NotNull
+    @Convert(converter = ProviderCodeConverter.class)
     @NaturalId()
     @Column(
             name = "provider_code", length = 50,
             nullable = false,
             updatable = false
     )
-    private String providerCode;
+    private ProviderCode providerCode;
 
     /**
      * Имя провайдера (user friendly).

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderPassportJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderPassportJpaRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 
+import com.alligator.market.domain.provider.code.ProviderCode;
+
 import java.util.List;
 
 /**
@@ -17,5 +19,5 @@ public interface ProviderPassportJpaRepository extends JpaRepository<ProviderPas
      */
     @Query("select p.providerCode from ProviderPassportEntity p")
     @QueryHints(@QueryHint(name = org.hibernate.jpa.HibernateHints.HINT_READ_ONLY, value = "true"))
-    List<String> findAllCodes();
+    List<ProviderCode> findAllCodes();
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/repository/ProviderPassportRepositoryJpaAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/repository/ProviderPassportRepositoryJpaAdapter.java
@@ -28,8 +28,6 @@ public class ProviderPassportRepositoryJpaAdapter implements ProviderPassportRep
 
     @Override
     public List<ProviderCode> findAllCodes() {
-        return jpa.findAllCodes().stream()
-                .map(ProviderCode::of)
-                .toList(); // <-- Читаем дешёвую проекцию, без загрузки сущностей
+        return jpa.findAllCodes(); // <-- Читаем дешёвую проекцию, без загрузки сущностей
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/ProviderCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/ProviderCatalogService.java
@@ -2,7 +2,6 @@ package com.alligator.market.backend.provider.catalog.passport.service;
 
 import com.alligator.market.backend.provider.catalog.passport.persistence.jpa.ProviderPassportEntity;
 import com.alligator.market.backend.provider.catalog.passport.persistence.jpa.ProviderPassportJpaRepository;
-import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +50,7 @@ public class ProviderCatalogService implements ProviderCatalogUseCase {
         ProviderPolicy policy = new ProviderPolicy(minUpdateInterval);
 
         return new ProviderCatalogItem(
-                ProviderCode.of(entity.getProviderCode()),
+                entity.getProviderCode(),
                 passport,
                 policy
         );


### PR DESCRIPTION
### Motivation

- Сделать поле `providerCode` в `ProviderPassportEntity` типизированным `ProviderCode` для единообразия с `CurrencyEntity` и повышения type-safety.
- Убрать ручные преобразования строк в `ProviderCode` в репозиториях и сервисах, чтобы минимизировать дублирование логики конверсии.
- Позволить Hibernate хранить объект-значение через единый JPA-конвертер и сохранить читаемую проекцию в репозитории.
- Упростить маппинг каталога провайдеров за счёт возвращения уже типизированного кода провайдера из проекции.

### Description

- Поменял тип поля `providerCode` в `ProviderPassportEntity` с `String` на `ProviderCode` и добавил `@Convert(converter = ProviderCodeConverter.class)`.
- Добавил `ProviderCodeConverter` (`AttributeConverter<ProviderCode,String>`) с `@Converter(autoApply = true)` для преобразования между сущностью и БД.
- Обновил проекцию в `ProviderPassportJpaRepository` — `findAllCodes()` теперь возвращает `List<ProviderCode>` вместо `List<String>`.
- Упростил адаптер репозитория и mapping в `ProviderCatalogService`, используя `entity.getProviderCode()` напрямую вместо `ProviderCode.of(...)`.

### Testing

- Автоматизированные тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657efd5b14832da303a6564754a437)