### PR TITLE
Миграция: переименование market_data_provider → provider_passport и удаление min_update_interval_seconds

### DIFF
--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -52,14 +52,13 @@ CREATE TABLE fx_spot (
 CREATE INDEX idx_fx_spot_base ON fx_spot (base_currency);
 CREATE INDEX idx_fx_spot_quote ON fx_spot (quote_currency);
 
-CREATE TABLE market_data_provider (
+CREATE TABLE provider_passport (
     id BIGSERIAL PRIMARY KEY,
     provider_code VARCHAR(50) NOT NULL,
     display_name VARCHAR(50) NOT NULL,
     delivery_mode VARCHAR(10) NOT NULL,
     access_method VARCHAR(20) NOT NULL,
     bulk_subscription BOOLEAN NOT NULL,
-    min_update_interval_seconds BIGINT NOT NULL,
     version BIGINT NOT NULL,
     created_timestamp TIMESTAMPTZ NOT NULL,
     created_by VARCHAR(255) NOT NULL,
@@ -68,7 +67,6 @@ CREATE TABLE market_data_provider (
     updated_by VARCHAR(255) NOT NULL,
     updated_via VARCHAR(255) NOT NULL,
     CONSTRAINT uq_provider_code UNIQUE (provider_code),
-    CONSTRAINT chk_provider_min_update_interval CHECK (min_update_interval_seconds >= 1),
     CONSTRAINT chk_provider_code_pattern CHECK (provider_code ~ '^[A-Z0-9_.-]+$'),
     CONSTRAINT chk_provider_delivery_mode_allowed CHECK (delivery_mode IN ('PULL', 'PUSH')),
     CONSTRAINT chk_provider_access_method_allowed CHECK (access_method IN ('API_POLL', 'WEBSOCKET', 'FIX_PROTOCOL'))


### PR DESCRIPTION
### Motivation
- Привести схему начальной миграции в соответствие с JPA-сущностью `ProviderPassportEntity` (имя таблицы и набор полей). 
- Удалить неиспользуемое поле `min_update_interval_seconds`, которое отсутствует в `ProviderPassportEntity`.
- Обеспечить соответствие ограничений в БД проверкам, заданным в сущности (паттерн кода провайдера и перечисления режимов/методов доступа).

### Description
- В `backend/src/main/resources/db/migration/V1__init_schema.sql` таблица `market_data_provider` переименована в `provider_passport`.
- Удалён столбец `min_update_interval_seconds` и связанная проверка `chk_provider_min_update_interval` из определения таблицы.
- Сохранены уникальное ограничение `uq_provider_code` и проверки `chk_provider_code_pattern`, `chk_provider_delivery_mode_allowed` и `chk_provider_access_method_allowed`.
- Изменения минимальны и ограничены файлом миграции `V1__init_schema.sql`.

### Testing
- Автоматические тесты не запускались для этого изменения.
- Внесённые правки покрыты ручной проверкой содержимого файла миграции (структура и ограничения).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696580bc71a8832da7c940df46cc317d)