### PR TITLE
Добавить ProviderPassportEntityMapper

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderPassportEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/ProviderPassportEntityMapper.java
@@ -1,0 +1,35 @@
+package com.alligator.market.backend.provider.catalog.passport.persistence.jpa;
+
+import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
+
+import java.util.Objects;
+
+/**
+ * Маппер: JPA-сущность → доменная модель.
+ *
+ * <p>Только чтение, так как таблица provider_passport является статичным справочником.</p>
+ */
+public final class ProviderPassportEntityMapper {
+
+    /**
+     * Приватный конструктор (запрещает создание экземпляров).
+     */
+    private ProviderPassportEntityMapper() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * JPA-сущность --> доменная модель.
+     */
+    public static ProviderPassport toDomain(ProviderPassportEntity e) {
+        Objects.requireNonNull(e, "entity must not be null");
+
+        // Собираем и возвращаем доменную модель паспорта провайдера
+        return new ProviderPassport(
+                e.getDisplayName(),
+                e.getDeliveryMode(),
+                e.getAccessMethod(),
+                e.isBulkSubscription()
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Необходимо единообразное преобразование `ProviderPassportEntity` → `ProviderPassport`, аналогично `CurrencyEntityMapper`, при этом таблица `provider_passport` является статичным справочником только для чтения.

### Description
- Добавлен класс `ProviderPassportEntityMapper` в `backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/persistence/jpa/` с методом `toDomain(ProviderPassportEntity)`, который преобразует поля `displayName`, `deliveryMode`, `accessMethod` и `bulkSubscription` в доменную модель `ProviderPassport`.

### Testing
- Автоматические тесты не запускались (не требовалось).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696904f6ff80832d9433d896bc0f043a)