### PR TITLE
Маппер ProviderPassport → ProviderPassportResponseDto и корректировка полей DTO

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/mapper/ProviderPassportDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/mapper/ProviderPassportDtoMapper.java
@@ -1,9 +1,33 @@
 package com.alligator.market.backend.provider.catalog.passport.web.dto.mapper;
 
+import com.alligator.market.backend.provider.catalog.passport.web.dto.out.ProviderPassportResponseDto;
+import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
+
+import java.util.Objects;
+
 /**
  * Маппер DTO паспорта провайдера и доменной модели провайдера.
  */
 public final class ProviderPassportDtoMapper {
 
+    /**
+     * Приватный конструктор (запрещает создание экземпляров).
+     */
+    private ProviderPassportDtoMapper() {
+        throw new UnsupportedOperationException("Utility class");
+    }
 
+    /**
+     * Преобразует доменную модель {@link ProviderPassport} в DTO ответа {@link ProviderPassportResponseDto}.
+     */
+    public static ProviderPassportResponseDto toDto(ProviderPassport passport) {
+        Objects.requireNonNull(passport, "passport must not be null");
+
+        return new ProviderPassportResponseDto(
+                passport.displayName(),
+                passport.deliveryMode().name(),
+                passport.accessMethod().name(),
+                passport.bulkSubscription()
+        );
+    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/out/ProviderPassportResponseDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/out/ProviderPassportResponseDto.java
@@ -4,7 +4,6 @@ package com.alligator.market.backend.provider.catalog.passport.web.dto.out;
  * DTO для передачи паспорта провайдера (out).
  */
 public record ProviderPassportResponseDto(
-        String providerCode,
         String displayName,
         String deliveryMode,
         String accessMethod,


### PR DESCRIPTION
### Motivation
- Упростить и согласовать DTO ответа с доменной моделью `ProviderPassport` для чтения паспортов провайдеров через REST.
- Исключить из ответа поле технического кода `providerCode`, поскольку таблица паспортов используется как read-only и код не требуется в этом DTO.

### Description
- Удалено поле `providerCode` из `ProviderPassportResponseDto` и оставлены только поля, соответствующие доменной модели: `displayName`, `deliveryMode`, `accessMethod`, `bulkSubscription`.
- Добавлен класс-утилита `ProviderPassportDtoMapper` с приватным конструктором и статическим методом `toDto(ProviderPassport)` для преобразования доменной модели в `ProviderPassportResponseDto`.
- В `toDto` добавлена проверка `Objects.requireNonNull(passport, "passport must not be null")` и маппинг перечислений через `deliveryMode().name()` и `accessMethod().name()`.
- Изменения затрагивают файлы: `backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/out/ProviderPassportResponseDto.java` и `backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/mapper/ProviderPassportDtoMapper.java`.

### Testing
- Автоматические тесты не запускались в рамках этого изменения.
- Локальных автоматизированных проверок не выполнялось; ручная компиляция не запрашивалась.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690c117f08832dbf4f7859dcdb7a33)