### PR TITLE
Разделить перегруженные `toDomain` в CurrencyDtoMapper

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/CurrencyController.java
@@ -36,7 +36,7 @@ public class CurrencyController {
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody @Valid CurrencyDto dto) {
 
-        Currency created = service.create(CurrencyDtoMapper.toDomain(dto));
+        Currency created = service.create(CurrencyDtoMapper.toDomainCreate(dto));
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{code}")
@@ -53,7 +53,7 @@ public class CurrencyController {
             @PathVariable @Pattern(regexp = "^[A-Z]{3}$") String code,
             @RequestBody @Valid CurrencyUpdateDto dto) {
 
-        service.update(CurrencyDtoMapper.toDomain(code, dto));
+        service.update(CurrencyDtoMapper.toDomainUpdate(code, dto));
         return ResponseEntityFactory.noContent();
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/currency/catalog/web/dto/mapper/CurrencyDtoMapper.java
@@ -22,7 +22,7 @@ public final class CurrencyDtoMapper {
     /**
      * Общий DTO --> модель.
      */
-    public static Currency toDomain(CurrencyDto dto) {
+    public static Currency toDomainCreate(CurrencyDto dto) {
         Objects.requireNonNull(dto, "dto must not be null");
 
         return new Currency(
@@ -50,7 +50,7 @@ public final class CurrencyDtoMapper {
     /**
      * Код валюты + DTO обновления --> модель.
      */
-    public static Currency toDomain(String code, CurrencyUpdateDto dto) {
+    public static Currency toDomainUpdate(String code, CurrencyUpdateDto dto) {
         Objects.requireNonNull(code, "code must not be null");
         Objects.requireNonNull(dto, "dto must not be null");
 


### PR DESCRIPTION
### Motivation
- Убрать перегрузку методов `toDomain` для явного разделения сценариев создания и обновления сущности.
- Сделать вызовы маппера более читаемыми и однозначными в коде контроллера.

### Description
- Переименованы методы в `CurrencyDtoMapper`: `toDomain(CurrencyDto)` -> `toDomainCreate` и `toDomain(String, CurrencyUpdateDto)` -> `toDomainUpdate`.
- Обновлены вызовы в `CurrencyController` на `CurrencyDtoMapper.toDomainCreate(dto)` и `CurrencyDtoMapper.toDomainUpdate(code, dto)`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969496e81dc832da874bbd9281d412e)