### PR TITLE
Реализация сервиса каталога паспортов провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogServiceImpl.java
@@ -1,14 +1,33 @@
 package com.alligator.market.backend.provider.catalog.passport.service;
 
+import com.alligator.market.backend.provider.catalog.passport.persistence.jpa.PassportEntityMapper;
+import com.alligator.market.backend.provider.catalog.passport.persistence.jpa.PassportJpaRepository;
+import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * Реализация сервиса {@link PassportCatalogService}.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PassportCatalogServiceImpl implements PassportCatalogService {
 
+    /* JPA-репозиторий паспортов провайдеров. */
+    private final PassportJpaRepository passportJpaRepository;
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProviderPassport> findAll() {
+        List<ProviderPassport> result = passportJpaRepository.findAll().stream()
+                .map(PassportEntityMapper::toDomain)
+                .toList();
+        log.debug("Found {} provider passports", result.size());
+        return result;
+    }
 }


### PR DESCRIPTION
### Motivation
- Нужна реализация `PassportCatalogService` для возврата списка паспортов провайдеров из хранилища через JPA.
- Обеспечить чтение справочника в режиме только чтения с минимальной логикой в приложении и возможностью трассировки через логирование.

### Description
- Добавлен `PassportCatalogServiceImpl`, который инжектит `PassportJpaRepository` и реализует метод `findAll()` получения паспортов.
- Результаты маппятся из JPA-сущностей в доменную модель через `PassportEntityMapper::toDomain` и возвращаются как `List<ProviderPassport>`.
- Метод помечен как `@Transactional(readOnly = true)` и добавлено логирование через `@Slf4j` с сообщением о количестве найденных паспортов.

### Testing
- Автоматические тесты не запускались (не запускалось ни `mvn test`, ни другие CI-локальные проверки).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696955c3d2d8832daa258c2bf35d35a7)