### PR TITLE
Убрать `providerCode` из frontend и добавить строку-плейсхолдер для пустой таблицы

### DIFF
--- a/frontend/src/app/features/provider_passport/models/provider-dto.model.ts
+++ b/frontend/src/app/features/provider_passport/models/provider-dto.model.ts
@@ -2,8 +2,6 @@
  * DTO провайдера, соответствующее backend-контракту ProviderDto.
  */
 export interface ProviderDto {
-  /* Технический код провайдера. */
-  providerCode: string;
   /* Отображаемое имя провайдера (user friendly). */
   displayName: string;
   /* Режим доставки рыночных данных. */

--- a/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.html
+++ b/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.html
@@ -7,11 +7,6 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
-        <ng-container matColumnDef="providerCode">
-          <th mat-header-cell *matHeaderCellDef>Code</th>
-          <td mat-cell *matCellDef="let passport">{{ passport.providerCode }}</td>
-        </ng-container>
-
         <ng-container matColumnDef="displayName">
           <th mat-header-cell *matHeaderCellDef>Provider</th>
           <td mat-cell *matCellDef="let passport">{{ passport.displayName }}</td>
@@ -43,6 +38,9 @@
 
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>
         <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+        <tr class="mat-row" *matNoDataRow>
+          <td class="mat-cell" [attr.colspan]="displayed.length">No provider passports found.</td>
+        </tr>
       </table>
     </mat-card-content>
   </mat-card>

--- a/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
+++ b/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
@@ -16,7 +16,6 @@ export class PassportListComponent implements OnInit {
 
   /* Список колонок таблицы. */
   displayed: string[] = [
-    'providerCode',
     'displayName',
     'deliveryMode',
     'accessMethod',


### PR DESCRIPTION
### Motivation
- Убрать передачу/отображение технического кода провайдера во frontend, чтобы UI не оперировал backend-only полем и не раскрывал внутренний идентификатор.
- Улучшить UX таблицы, добавив явное сообщение при отсутствии записей.

### Description
- Удалено поле `providerCode` из интерфейса `ProviderDto` в `frontend/src/app/features/provider_passport/models/provider-dto.model.ts`.
- Убрана колонка с `providerCode` из шаблона таблицы в `passport-list.component.html` и соответствующая колонка удалена из массива `displayed` в `passport-list.component.ts`.
- Добавлена строка-плейсхолдер `*matNoDataRow` с текстом `No provider passports found.` в `passport-list.component.html` для отображения при пустой выборке.

### Testing
- Выполнена установка зависимостей с `npm install`, завершилась успешно.
- Запущен dev server через `ng serve` и сборка приложения прошла успешно (приложение собрано и доступно в режиме разработки).
- Попытка сделать скриншот страницы через Playwright потерпела неудачу из-за падения браузера в контейнере (SIGSEGV), поэтому визуальная проверка скриншотом не выполнена; автоматические тесты (`npm test`) не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695c78c798832db46bd1b8e692533f)