### PR TITLE
Удалить колонку Min Update Interval (s) из списка провайдеров

### DIFF
--- a/frontend/src/app/features/provider_passport/models/provider-dto.model.ts
+++ b/frontend/src/app/features/provider_passport/models/provider-dto.model.ts
@@ -10,6 +10,4 @@ export interface ProviderDto {
   accessMethod: string;
   /* Признак поддержки массовой подписки. */
   bulkSubscription: boolean;
-  /* Минимальный интервал обновления данных в секундах. */
-  minUpdateIntervalSeconds: number;
 }

--- a/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.html
+++ b/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.html
@@ -29,13 +29,6 @@
           </td>
         </ng-container>
 
-        <ng-container matColumnDef="minUpdateIntervalSeconds">
-          <th mat-header-cell *matHeaderCellDef>Min Update Interval (s)</th>
-          <td mat-cell *matCellDef="let passport">
-            {{ passport.minUpdateIntervalSeconds }}
-          </td>
-        </ng-container>
-
         <tr mat-header-row *matHeaderRowDef="displayed"></tr>
         <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
         <tr class="mat-row" *matNoDataRow>

--- a/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
+++ b/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
@@ -19,8 +19,7 @@ export class PassportListComponent implements OnInit {
     'displayName',
     'deliveryMode',
     'accessMethod',
-    'bulkSubscription',
-    'minUpdateIntervalSeconds'
+    'bulkSubscription'
   ];
   /* Источник данных для таблицы. */
   dataSource = new MatTableDataSource<ProviderDto>([]);


### PR DESCRIPTION
### Motivation
- Удалить отображение и контракт поля `minUpdateIntervalSeconds`, потому что эта информация больше не передаётся в данных провайдеров.

### Description
- Удалено поле `minUpdateIntervalSeconds` из `ProviderDto` и убрана соответствующая колонка из `passport-list.component.html`, а также исключено из списка `displayed` в `passport-list.component.ts`.

### Testing
- Запущена dev-сборка с помощью `npm run start`, сборка прошла успешно и сделан скриншот страницы списка провайдеров (колонка отсутствует).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696963bbb4a0832dad5468cc9e6434f2)