### PR TITLE
Убрать неиспользуемый набор кодов инструментов из MarketDataProvider

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -37,8 +37,7 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     /* Карта "код инструмента --> обработчик". После инициализации становится неизменяемой. */
     private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentMapByCode;
 
-    /* Коллекции для кодов и типов инструментов. После инициализации становятся неизменяемыми. */
-    private final Set<InstrumentCode> instrumentCodes;
+    /* Коллекция для типов инструментов. После инициализации становится неизменяемой. */
     private final Set<InstrumentType> instrumentTypes;
 
     //=================================================================================================================
@@ -94,7 +93,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         // 2) Собираем карту "код инструмента --> обработчик" и агрегируем наборы кодов/типов
         Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> mapByCode =
                 new LinkedHashMap<>(); // <-- Карта
-        Set<InstrumentCode> allCodes = new LinkedHashSet<>(); // <-- Набор всех кодов инструментов
         Set<InstrumentType> types = EnumSet.noneOf(InstrumentType.class); // <-- Набор всех типов инструментов
         for (AbstractInstrumentHandler<P, ? extends Instrument> h : handlers) {
             types.add(h.instrumentType()); // <-- Один тип на обработчик
@@ -106,13 +104,11 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
                             "' is already bound to handler '" + prev.handlerCode() +
                             "' in provider '" + providerCode.value() + "'");
                 }
-                allCodes.add(code);
             }
         }
 
         // 3) Фиксируем структуру неизменяемых коллекций
         this.instrumentMapByCode = Collections.unmodifiableMap(mapByCode);
-        this.instrumentCodes = Collections.unmodifiableSet(allCodes);
         this.instrumentTypes = Collections.unmodifiableSet(types);
 
         // 4) Прикрепляем обработчики к провайдеру
@@ -144,11 +140,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     @Override
     public ProviderSettings settings() {
         return settingsRef.get();
-    }
-
-    @Override
-    public Set<InstrumentCode> instrumentsCodes() {
-        return instrumentCodes;
     }
 
     @Override

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -1,6 +1,5 @@
 package com.alligator.market.domain.provider.contract;
 
-import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.code.ProviderCode;
@@ -39,12 +38,6 @@ public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
      */
     @SuppressWarnings("unused")
     ProviderSettings settings(); // <-- Точка роста, без реализации (заглушка)
-
-    /**
-     * Иммутабельный набор кодов поддерживаемых инструментов.
-     */
-    @SuppressWarnings("unused")
-    Set<InstrumentCode> instrumentsCodes();
 
     /**
      * Иммутабельный набор типов поддерживаемых инструментов.


### PR DESCRIPTION
### Motivation
- Упростить контракт `MarketDataProvider` удалив метод, который нигде не используется, и убрать избыточное хранение кодов инструментов в абстрактной реализации.

### Description
- Удалён метод `Set<InstrumentCode> instrumentsCodes()` из интерфейса `MarketDataProvider` (файл `domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java`).
- Убрано поле `instrumentCodes` и сбор множества кодов инструментов из конструктора в `AbstractMarketDataProvider`, а также сопутствующие операции агрегации (файл `domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java`).
- Упрощена инициализация: теперь сохраняется только карта `instrumentMapByCode` и множество типов `instrumentTypes` без дополнительного хранения списка всех кодов.
- Обновлены импорты и удалены неиспользуемые элементы, связанные с удалённым контрактом.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976471ac530832d92747a43eea1494c)