### PR TITLE
Удалить неиспользуемый метод instrumentsTypes() из MarketDataProvider

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -2,7 +2,6 @@ package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
-import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
@@ -36,9 +35,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
 
     /* Карта "код инструмента --> обработчик". После инициализации становится неизменяемой. */
     private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentMapByCode;
-
-    /* Коллекция для типов инструментов. После инициализации становится неизменяемой. */
-    private final Set<InstrumentType> instrumentTypes;
 
     //=================================================================================================================
     // КОНСТРУКТОР
@@ -90,12 +86,10 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
             }
         }
 
-        // 2) Собираем карту "код инструмента --> обработчик" и агрегируем наборы кодов/типов
+        // 2) Собираем карту "код инструмента --> обработчик" и агрегируем наборы кодов
         Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> mapByCode =
                 new LinkedHashMap<>(); // <-- Карта
-        Set<InstrumentType> types = EnumSet.noneOf(InstrumentType.class); // <-- Набор всех типов инструментов
         for (AbstractInstrumentHandler<P, ? extends Instrument> h : handlers) {
-            types.add(h.instrumentType()); // <-- Один тип на обработчик
             for (InstrumentCode code : h.supportedInstrumentCodes()) {
                 InstrumentHandler<P, ? extends Instrument> prev = mapByCode.putIfAbsent(code, h);
                 if (prev != null && prev != h) {
@@ -109,7 +103,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
 
         // 3) Фиксируем структуру неизменяемых коллекций
         this.instrumentMapByCode = Collections.unmodifiableMap(mapByCode);
-        this.instrumentTypes = Collections.unmodifiableSet(types);
 
         // 4) Прикрепляем обработчики к провайдеру
         Set<AbstractInstrumentHandler<P, ? extends Instrument>> uniqueHandlers =
@@ -140,11 +133,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     @Override
     public ProviderSettings settings() {
         return settingsRef.get();
-    }
-
-    @Override
-    public Set<InstrumentType> instrumentsTypes() {
-        return instrumentTypes;
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -1,15 +1,12 @@
 package com.alligator.market.domain.provider.contract;
 
 import com.alligator.market.domain.instrument.contract.Instrument;
-import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import org.reactivestreams.Publisher;
-
-import java.util.Set;
 
 /**
  * Провайдер рыночных данных.
@@ -38,12 +35,6 @@ public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
      */
     @SuppressWarnings("unused")
     ProviderSettings settings(); // <-- Точка роста, без реализации (заглушка)
-
-    /**
-     * Иммутабельный набор типов поддерживаемых инструментов.
-     */
-    @SuppressWarnings("unused")
-    Set<InstrumentType> instrumentsTypes();
 
     /**
      * Унифицированная операция получения котировок для финансового инструмента.


### PR DESCRIPTION
### Motivation
- Убрать избыточный и нигде не используемый контрактный метод `instrumentsTypes()` из интерфейса провайдера рыночных данных для упрощения API и уменьшения технического долга.
- Упростить реализацию `AbstractMarketDataProvider`, удалив сбор и хранение множеств типов инструментов, которые не использовались в кодовой базе.

### Description
- Удалён метод `Set<InstrumentType> instrumentsTypes()` и соответствующий импорт из `MarketDataProvider`.
- Удалены поле `instrumentTypes`, его инициализация и агрегация типов в конструкторе `AbstractMarketDataProvider` вместе с ненужным импортом `InstrumentType`.
- Обновлён конструктор `AbstractMarketDataProvider` для фокусировки только на сборе карты `instrumentMapByCode` и прикреплении обработчиков, без сбора типов инструментов.
- Изменения не затрагивают поведение операции `quote(...)` и логики поиска/делегирования обработчиков.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764a68f8e0832d8b8406a2d8a33367)