### PR TITLE
Remove ProviderSettings from MarketDataProvider contract

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/common/SpringMarketDataProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/common/SpringMarketDataProvider.java
@@ -7,7 +7,6 @@ import com.alligator.market.domain.provider.contract.MarketDataProvider;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
-import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
@@ -35,10 +34,9 @@ public abstract class SpringMarketDataProvider<P extends MarketDataProvider>
             ProviderCode providerCode,
             ProviderPassport passport,
             ProviderPolicy policy,
-            ProviderSettings settings,
             Set<? extends AbstractInstrumentHandler<P, ? extends Instrument>> handlers
     ) {
-        super(providerCode, passport, policy, settings, handlers);
+        super(providerCode, passport, policy, handlers);
     }
 
     /**

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
@@ -8,7 +8,6 @@ import com.alligator.market.domain.provider.contract.passport.AccessMethod;
 import com.alligator.market.domain.provider.contract.passport.DeliveryMode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
-import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -25,7 +24,7 @@ import java.util.Set;
 /**
  * Адаптер провайдера рыночных данных MOEX ISS.
  *
- * <p>Адаптер является Spring-компонентом {@link Component}, который инкапсулирует паспорт, политику, настройки и
+ * <p>Адаптер является Spring-компонентом {@link Component}, который инкапсулирует паспорт, политику и
  * обработчики провайдера.</p>
  */
 @Component("MOEX_ISS")
@@ -48,9 +47,6 @@ public class MoexIssAdapter extends SpringMarketDataProvider<MoexIssAdapter> {
     /* Политика провайдера. */
     private static final ProviderPolicy POLICY = ProviderPolicy.ofSeconds(1); // <-- интервал запросов 1 сек
 
-    /* Настройки провайдера. */
-    private static final ProviderSettings SETTINGS = ProviderSettings.empty(); // <-- заглушка до востребования
-
     /**
      * Конструктор адаптера MOEX ISS.
      *
@@ -69,7 +65,6 @@ public class MoexIssAdapter extends SpringMarketDataProvider<MoexIssAdapter> {
                 PROVIDER_CODE,
                 PASSPORT,
                 POLICY,
-                SETTINGS,
                 Set.of(new MoexIssFxSpotHandler(props, webClient))
         );
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/ProFinanceAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/ProFinanceAdapter.java
@@ -8,7 +8,6 @@ import com.alligator.market.domain.provider.contract.passport.AccessMethod;
 import com.alligator.market.domain.provider.contract.passport.DeliveryMode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
-import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -38,9 +37,6 @@ public class ProFinanceAdapter extends SpringMarketDataProvider<ProFinanceAdapte
     /* Политика провайдера: иммутабельные параметры, которые использует бизнес-логика. */
     private static final ProviderPolicy POLICY = ProviderPolicy.ofSeconds(10);
 
-    /* Настройки провайдера: параметры, которые разрешено менять из frontend. */
-    private static final ProviderSettings SETTINGS = ProviderSettings.empty(); // <-- Заглушка до востребования
-
     /**
      * Конструктор.
      */
@@ -53,7 +49,6 @@ public class ProFinanceAdapter extends SpringMarketDataProvider<ProFinanceAdapte
                 PROVIDER_CODE,
                 PASSPORT,
                 POLICY,
-                SETTINGS,
                 Set.of(new ProFinanceFxSpotHandler(webClient, props))
         );
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/TwelveFreeAdapterV2.java
@@ -8,7 +8,6 @@ import com.alligator.market.domain.provider.contract.passport.AccessMethod;
 import com.alligator.market.domain.provider.contract.passport.DeliveryMode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
-import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -39,9 +38,6 @@ public class TwelveFreeAdapterV2 extends SpringMarketDataProvider<TwelveFreeAdap
     /* Политика провайдера: иммутабельные параметры, которые использует бизнес-логика. */
     private static final ProviderPolicy POLICY = ProviderPolicy.ofSeconds(60);
 
-    /* Настройки провайдера: параметры, которые разрешено менять из frontend. */
-    private static final ProviderSettings SETTINGS = ProviderSettings.empty(); // <-- Заглушка до востребования
-
     /**
      * Конструктор.
      *
@@ -57,7 +53,6 @@ public class TwelveFreeAdapterV2 extends SpringMarketDataProvider<TwelveFreeAdap
                 PROVIDER_CODE,
                 PASSPORT,
                 POLICY,
-                SETTINGS,
                 Set.of(new TwelveFreeFxSpotHandler(webClient, props))
         );
     }

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/AbstractMarketDataProvider.java
@@ -7,13 +7,11 @@ import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.contract.handler.InstrumentHandler;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
-import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import com.alligator.market.domain.provider.exception.HandlerNotFoundException;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import org.reactivestreams.Publisher;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Абстрактная реализация провайдера рыночных данных {@link MarketDataProvider}.
@@ -29,9 +27,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
 
     /* Политика провайдера. */
     protected final ProviderPolicy policy;
-
-    /* Настройки провайдера. */
-    private final AtomicReference<ProviderSettings> settingsRef;
 
     /* Карта "код инструмента --> обработчик". После инициализации становится неизменяемой. */
     private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentMapByCode;
@@ -49,7 +44,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      * @param providerCode код провайдера
      * @param passport     паспорт провайдера
      * @param policy       политика провайдера
-     * @param settings     настройки провайдера
      * @throws NullPointerException     если переданы null-аргументы
      * @throws IllegalArgumentException если передан blank код провайдера или пустой набор обработчиков
      * @throws IllegalStateException    если обнаружены дубликаты обработчиков по коду или пересечения кодов инструментов
@@ -58,13 +52,11 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
             ProviderCode providerCode,
             ProviderPassport passport,
             ProviderPolicy policy,
-            ProviderSettings settings,
             Set<? extends AbstractInstrumentHandler<P, ? extends Instrument>> handlers // Набор обработчиков
     ) {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(passport, "passport must not be null");
         Objects.requireNonNull(policy, "policy must not be null");
-        Objects.requireNonNull(settings, "settings must not be null");
         Objects.requireNonNull(handlers, "handlers must not be null");
 
         if (handlers.isEmpty()) {
@@ -74,7 +66,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         this.providerCode = providerCode;
         this.passport = passport;
         this.policy = policy;
-        this.settingsRef = new AtomicReference<>(settings);
 
         // 1) Проверяем уникальность handlers по коду
         Set<String> handlerCodes = new HashSet<>();
@@ -130,11 +121,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         return policy;
     }
 
-    @Override
-    public ProviderSettings settings() {
-        return settingsRef.get();
-    }
-
     /**
      * Шаблонная реализация котировки: находит обработчик по коду инструмента и делегирует ему вызов.
      *
@@ -162,20 +148,6 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
      * F-bounded полиморфизм: возвращает текущий экземпляр провайдера в его конкретном дженерик-типе {@code P}.
      */
     protected abstract P self();
-
-    /**
-     * Атомарно заменяет настройки провайдера.
-     *
-     * <p>Метод защищённый и финальный, предназначен для использования наследниками.</p>
-     *
-     * @param newSettings новые настройки
-     * @throws NullPointerException если {@code newSettings} равен {@code null}
-     */
-    @SuppressWarnings("unused")
-    protected final void replaceSettings(ProviderSettings newSettings) {
-        Objects.requireNonNull(newSettings, "newSettings must not be null");
-        settingsRef.set(newSettings);
-    }
 
     /**
      * Возвращает обработчик по коду инструмента.

--- a/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/contract/MarketDataProvider.java
@@ -4,7 +4,6 @@ import com.alligator.market.domain.instrument.contract.Instrument;
 import com.alligator.market.domain.provider.code.ProviderCode;
 import com.alligator.market.domain.provider.contract.passport.ProviderPassport;
 import com.alligator.market.domain.provider.contract.policy.ProviderPolicy;
-import com.alligator.market.domain.provider.contract.settings.ProviderSettings;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import org.reactivestreams.Publisher;
 
@@ -29,12 +28,6 @@ public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
      * Политика провайдера.
      */
     ProviderPolicy policy();
-
-    /**
-     * Настройки провайдера.
-     */
-    @SuppressWarnings("unused")
-    ProviderSettings settings(); // <-- Точка роста, без реализации (заглушка)
 
     /**
      * Унифицированная операция получения котировок для финансового инструмента.


### PR DESCRIPTION
### Motivation

- Удалить из публичного контракта `MarketDataProvider` устаревшую заглушку `settings()` и упростить модель провайдера, поскольку настройки пока не используются и усложняют API.
- Сделать изменение безболезненным для наследников, сохранив их работу и конструкторную семантику провайдеров.

### Description

- Удалён метод `settings()` из интерфейса `MarketDataProvider` и соответствующий импорт `ProviderSettings`.
- Упрощён `AbstractMarketDataProvider`: удалён `settingsRef`, параметр конструктора `ProviderSettings settings` и методы работы с настройками (`settings()` и `replaceSettings`).
- Обновлён `SpringMarketDataProvider` для вызова нового конструктора `super(providerCode, passport, policy, handlers)` без `ProviderSettings`.
- Исправлены конкретные адаптеры (`MoexIssAdapter`, `ProFinanceAdapter`, `TwelveFreeAdapterV2`) — удалён статический `SETTINGS` и передача настроек в `super`.

### Testing

- Автоматические тесты не запускались (нет выполненных CI/unit тестов в рамках этого изменения).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765b0209c8832dbd6ed9ff3ba1ec89)