### PR TITLE
Добавить InstrumentSymbol и применить в доменной модели

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentBaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentBaseEntity.java
@@ -2,6 +2,8 @@ package com.alligator.market.backend.instrument.base.persistence.jpa;
 
 import com.alligator.market.backend.common.persistence.jpa.entity.BaseEntity;
 import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+import com.alligator.market.domain.instrument.symbol.InstrumentSymbol;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -24,7 +26,7 @@ import java.util.Objects;
  *     инструментов поля хранятся в родительской (базовой) таблице, а специфичные – в таблицах наследников.</li>
  *     <li>{@link NoArgsConstructor} с {@code PROTECTED}: конструктор без аргументов нужен только для ORM;
  *     вручную создаются только сущности-наследники, которые вызывают метод однократной инициализации
- *     полей родительской сущности {@link InstrumentBaseEntity#initIdentity(String, String, InstrumentType)}.</li>
+ *     полей родительской сущности {@link InstrumentBaseEntity#initIdentity(InstrumentCode, InstrumentSymbol, InstrumentType)}.</li>
  * </ul>
  */
 @Entity
@@ -108,8 +110,8 @@ public abstract class InstrumentBaseEntity extends BaseEntity {
     // Пока не появились иные инструменты кроме FX_SPOT, давим предупреждение типа "SameParameterValue"
     @SuppressWarnings("SameParameterValue")
     protected final void initIdentity(
-            String code,
-            String symbol,
+            InstrumentCode instrumentCode,
+            InstrumentSymbol instrumentSymbol,
             InstrumentType type
     ) {
         // Защита от повторной инициализации
@@ -118,18 +120,12 @@ public abstract class InstrumentBaseEntity extends BaseEntity {
         }
 
         // Базовые проверки аргументов
-        Objects.requireNonNull(code, "code must not be null");
-        Objects.requireNonNull(symbol, "symbol must not be null");
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        Objects.requireNonNull(instrumentSymbol, "instrumentSymbol must not be null");
         Objects.requireNonNull(type, "type must not be null");
 
-        // Нормализуем и проверяем строковые переменные
-        final String nCode = code.strip();
-        final String nSymbol = symbol.strip();
-        if (nCode.isEmpty()) throw new IllegalArgumentException("code must not be blank");
-        if (nSymbol.isEmpty()) throw new IllegalArgumentException("symbol must not be blank");
-
-        this.code = nCode;
-        this.symbol = nSymbol;
+        this.code = instrumentCode.value();
+        this.symbol = instrumentSymbol.value();
         this.type = type;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.persiste
 import com.alligator.market.backend.instrument.base.persistence.jpa.InstrumentBaseEntity;
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.domain.instrument.code.InstrumentCode;
+import com.alligator.market.domain.instrument.symbol.InstrumentSymbol;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.currency.code.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.codec.FxSpotCodec;
@@ -162,10 +163,10 @@ public class FxSpotEntity extends InstrumentBaseEntity {
             throw new IllegalArgumentException("base and quote currencies must be different");
         }
 
-        final String symbol = FxSpotCodec.fxSpotSymbol(baseCode, quoteCode, tenor);
+        final InstrumentSymbol symbol = FxSpotCodec.fxSpotSymbol(baseCode, quoteCode, tenor);
         final InstrumentCode code = FxSpotCodec.fxSpotCode(baseCode, quoteCode, tenor);
 
         // Инициализируем родительскую сущность
-        initIdentity(code.value(), symbol, InstrumentType.FX_SPOT);
+        initIdentity(code, symbol, InstrumentType.FX_SPOT);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
@@ -25,7 +25,7 @@ public class FxSpotDtoMapper {
 
         return new FxSpotResponseDto(
                 fxSpot.instrumentCode().value(),
-                fxSpot.instrumentSymbol(),
+                fxSpot.instrumentSymbol().value(),
                 fxSpot.base().code().value(),
                 fxSpot.quote().code().value(),
                 fxSpot.defaultQuoteFractionDigits(),

--- a/domain/src/main/java/com/alligator/market/domain/instrument/contract/Instrument.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/contract/Instrument.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.instrument.contract;
 
 import com.alligator.market.domain.instrument.code.InstrumentCode;
+import com.alligator.market.domain.instrument.symbol.InstrumentSymbol;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 
 /**
@@ -19,7 +20,7 @@ public interface Instrument {
     /**
      * Символ инструмента: для отображения в UI (более дружелюбен чем код инструмента).
      */
-    String instrumentSymbol();
+    InstrumentSymbol instrumentSymbol();
 
     /**
      * Тип финансового инструмента.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/symbol/InstrumentSymbol.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/symbol/InstrumentSymbol.java
@@ -1,0 +1,70 @@
+package com.alligator.market.domain.instrument.symbol;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Объект-значение уникального символа инструмента.
+ *
+ * <p>Причина создания: символ инструмента используется многократно в разных слоях приложения,
+ * поэтому важно гарантировать единый формат символа без многократных единообразных проверок.</p>
+ *
+ * @param value строковое значение символа инструмента
+ */
+public record InstrumentSymbol(
+        String value
+) {
+
+    /* Шаблон допустимых символов для символа инструмента. */
+    public static final String PATTERN = "^[A-Z0-9_]+$";
+
+    /* Максимальная длина символа инструмента. */
+    private static final int MAX_LENGTH = 50;
+
+    /* Шаблон для валидации символа инструмента. */
+    private static final Pattern VALIDATION_PATTERN = Pattern.compile(PATTERN);
+
+    /**
+     * Конструктор.
+     */
+    public InstrumentSymbol {
+        value = normalize(value);
+    }
+
+    /**
+     * Фабрика для создания объекта из строкового символа.
+     */
+    public static InstrumentSymbol of(String raw) {
+        return new InstrumentSymbol(raw);
+    }
+
+    /**
+     * Метод проверки и нормализации входящего значения символа инструмента.
+     *
+     * @param raw исходное строковое значение символа инструмента
+     * @return нормализованное значение символа инструмента
+     */
+    private static String normalize(String raw) {
+        Objects.requireNonNull(raw, "instrumentSymbol must not be null");
+
+        String normalized = raw.strip();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("instrumentSymbol must not be blank");
+        }
+
+        normalized = normalized.toUpperCase(Locale.ROOT);
+
+        if (normalized.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("instrumentSymbol length must be <= " + MAX_LENGTH);
+        }
+
+        if (!VALIDATION_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    "instrumentSymbol must match pattern [A-Z0-9_]+: '" + normalized + "'"
+            );
+        }
+
+        return normalized;
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/codec/FxSpotCodec.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.instrument.type.forex.spot.codec;
 
 import com.alligator.market.domain.instrument.code.InstrumentCode;
+import com.alligator.market.domain.instrument.symbol.InstrumentSymbol;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.currency.code.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpotTenor;
@@ -33,12 +34,12 @@ public final class FxSpotCodec {
     /**
      * Формирует строковый символ инструмента из кодов валют и тенора даты валютирования.
      */
-    public static String fxSpotSymbol(CurrencyCode baseCode, CurrencyCode quoteCode, FxSpotTenor tenor) {
+    public static InstrumentSymbol fxSpotSymbol(CurrencyCode baseCode, CurrencyCode quoteCode, FxSpotTenor tenor) {
         Objects.requireNonNull(baseCode, "baseCode must not be null");
         Objects.requireNonNull(quoteCode, "quoteCode must not be null");
         Objects.requireNonNull(tenor, "tenor must not be null");
 
-        return baseCode.value() + quoteCode.value() + SEP + tenor.value();
+        return InstrumentSymbol.of(baseCode.value() + quoteCode.value() + SEP + tenor.value());
     }
 
     /**
@@ -49,7 +50,7 @@ public final class FxSpotCodec {
         Objects.requireNonNull(quoteCode, "quoteCode must not be null");
         Objects.requireNonNull(tenor, "tenor must not be null");
 
-        return InstrumentCode.of(TYPE_PREFIX + fxSpotSymbol(baseCode, quoteCode, tenor));
+        return InstrumentCode.of(TYPE_PREFIX + fxSpotSymbol(baseCode, quoteCode, tenor).value());
     }
 
     /**

--- a/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/type/forex/spot/model/FxSpot.java
@@ -2,6 +2,7 @@ package com.alligator.market.domain.instrument.type.forex.spot.model;
 
 import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.contract.Instrument;
+import com.alligator.market.domain.instrument.symbol.InstrumentSymbol;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.spot.codec.FxSpotCodec;
@@ -52,7 +53,7 @@ public record FxSpot(
     }
 
     @Override
-    public String instrumentSymbol() {
+    public InstrumentSymbol instrumentSymbol() {
         return FxSpotCodec.fxSpotSymbol(base.code(), quote.code(), tenor);
     }
 


### PR DESCRIPTION
### Motivation

- Упростить и централизовать валидацию/нормализацию отображаемого символа инструмента и исключить дублирование логики по проекту.
- Обеспечить единый тип для символа инструмента в доменном контракте и в рамках JPA-сущностей, чтобы строго разделять внутренний `InstrumentCode` и пользовательский `symbol`.

### Description

- Добавлен value-object `InstrumentSymbol` в `domain` с нормализацией и валидацией через `InstrumentSymbol.of(...)` и строгим шаблоном/ограничением длины в файле `domain/src/main/java/.../InstrumentSymbol.java`.
- Изменён контракт `Instrument` так, что метод `instrumentSymbol()` возвращает `InstrumentSymbol` вместо `String` (`domain/.../Instrument.java`).
- Обновлены FX-спот объекты: `FxSpot` теперь возвращает `InstrumentSymbol`, а `FxSpotCodec.fxSpotSymbol(...)` формирует и возвращает `InstrumentSymbol`, при этом `fxSpotCode(...)` использует `fxSpotSymbol(...).value()` для построения `InstrumentCode` (`domain/.../FxSpot.java`, `domain/.../FxSpotCodec.java`).
- Приведена в соответствие персистентная инициализация: `InstrumentBaseEntity.initIdentity(...)` принимает `InstrumentCode` и `InstrumentSymbol` и сохраняет их строки в поля БД, а `FxSpotEntity` передаёт `InstrumentSymbol` при инициализации; также обновлён маппер ответа `FxSpotDtoMapper` для использования `instrumentSymbol().value()` (`backend/.../InstrumentBaseEntity.java`, `backend/.../FxSpotEntity.java`, `backend/.../FxSpotDtoMapper.java`).

### Testing

- Автоматические тесты не запускались в рамках этого изменения (тестирование не выполнялось).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977dd90b63c832d925dc9e6853b1cdb)