### PR TITLE
Use InstrumentCode / InstrumentSymbol value objects in InstrumentBaseEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentBaseEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentBaseEntity.java
@@ -6,7 +6,6 @@ import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.symbol.InstrumentSymbol;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -61,14 +60,15 @@ public abstract class InstrumentBaseEntity extends BaseEntity {
      * запрет на переназначение через сеттер {@code @Setter(AccessLevel.NONE)}.</p>
      */
     @Setter(AccessLevel.NONE)
-    @NotBlank
+    @NotNull
     @NaturalId()
+    @Convert(converter = InstrumentCodeConverter.class)
     @Column(
-            name = "code", length = 32,
+            name = "code", length = 50,
             nullable = false,
             updatable = false
     )
-    private String code;
+    private InstrumentCode code;
 
     /**
      * Символ инструмента для отображения в UI.
@@ -77,13 +77,14 @@ public abstract class InstrumentBaseEntity extends BaseEntity {
      * запрет на переназначение через сеттер {@code @Setter(AccessLevel.NONE)}.</p>
      */
     @Setter(AccessLevel.NONE)
-    @NotBlank
+    @NotNull
+    @Convert(converter = InstrumentSymbolConverter.class)
     @Column(
-            name = "symbol", length = 32,
+            name = "symbol", length = 50,
             nullable = false,
             updatable = false
     )
-    private String symbol;
+    private InstrumentSymbol symbol;
 
     /**
      * Тип финансового инструмента.
@@ -124,8 +125,8 @@ public abstract class InstrumentBaseEntity extends BaseEntity {
         Objects.requireNonNull(instrumentSymbol, "instrumentSymbol must not be null");
         Objects.requireNonNull(type, "type must not be null");
 
-        this.code = instrumentCode.value();
-        this.symbol = instrumentSymbol.value();
+        this.code = instrumentCode;
+        this.symbol = instrumentSymbol;
         this.type = type;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentCodeConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentCodeConverter.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.base.persistence.jpa;
+
+import com.alligator.market.domain.instrument.code.InstrumentCode;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Конвертер для хранения {@link InstrumentCode} в виде строкового значения в БД.
+ */
+@Converter(autoApply = true)
+public class InstrumentCodeConverter implements AttributeConverter<InstrumentCode, String> {
+
+    /**
+     * Преобразует доменную модель в значение для БД.
+     */
+    @Override
+    public String convertToDatabaseColumn(InstrumentCode attribute) {
+        return attribute != null ? attribute.value() : null;
+    }
+
+    /**
+     * Преобразует значение из БД в доменную модель.
+     */
+    @Override
+    public InstrumentCode convertToEntityAttribute(String dbData) {
+        return dbData != null ? InstrumentCode.of(dbData) : null;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentSymbolConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa/InstrumentSymbolConverter.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.base.persistence.jpa;
+
+import com.alligator.market.domain.instrument.symbol.InstrumentSymbol;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Конвертер для хранения {@link InstrumentSymbol} в виде строкового значения в БД.
+ */
+@Converter(autoApply = true)
+public class InstrumentSymbolConverter implements AttributeConverter<InstrumentSymbol, String> {
+
+    /**
+     * Преобразует доменную модель в значение для БД.
+     */
+    @Override
+    public String convertToDatabaseColumn(InstrumentSymbol attribute) {
+        return attribute != null ? attribute.value() : null;
+    }
+
+    /**
+     * Преобразует значение из БД в доменную модель.
+     */
+    @Override
+    public InstrumentSymbol convertToEntityAttribute(String dbData) {
+        return dbData != null ? InstrumentSymbol.of(dbData) : null;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/type/forex/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.instrument.type.forex.spot.catalog.persiste
 
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.type.forex.currency.catalog.persistence.jpa.CurrencyEntityMapper;
+import com.alligator.market.domain.instrument.code.InstrumentCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 
 import java.util.Objects;
@@ -49,11 +50,11 @@ public final class FxSpotEntityMapper {
         Objects.requireNonNull(e, "entity must not be null");
 
         // Guard check: предотвращаем "тихое" обновление не той сущности.
-        String entityCode = e.getCode();
-        String modelCode = m.instrumentCode().value();
+        InstrumentCode entityCode = e.getCode();
+        InstrumentCode modelCode = m.instrumentCode();
         if (!Objects.equals(entityCode, modelCode)) {
-            throw new IllegalStateException("Instrument code mismatch: entityCode=" + entityCode
-                    + ", modelCode=" + modelCode);
+            throw new IllegalStateException("Instrument code mismatch: entityCode=" + entityCode.value()
+                    + ", modelCode=" + modelCode.value());
         }
 
         // Копируем изменяемые поля из доменной модели в JPA-сущность


### PR DESCRIPTION
### Motivation

- Привести JPA-сущность инструмента к использованию доменных value-объектов `InstrumentCode` и `InstrumentSymbol` вместо сырой строки для обеспечения единообразия валидации и форматирования.
- Обеспечить поведение, аналогичное уже существному `ProviderCode` + конвертеру, чтобы избегать дублирования логики преобразования между БД и доменной моделью.
- Увеличить длину колонок, чтобы соответствовать ограничениям доменных value-объектов (`MAX_LENGTH = 50`).

### Description

- В `InstrumentBaseEntity` поля `code` и `symbol` заменены с `String` на `InstrumentCode` и `InstrumentSymbol`, добавлены `@Convert` и выставлен `length = 50` для колонок; инициализация через `initIdentity` теперь присваивает value-объекты напрямую вместо `value()` строк.
- Добавлены простые JPA-конвертеры `InstrumentCodeConverter` и `InstrumentSymbolConverter` в пакет `backend/src/main/java/com/alligator/market/backend/instrument/base/persistence/jpa` по аналогии с `ProviderCodeConverter`.
- Обновлён `FxSpotEntityMapper` для сравнения и проверки `InstrumentCode` как value-объектов и корректного вывода в сообщении об ошибке (использует `value()` в сообщении).

Изменённые файлы: `InstrumentBaseEntity.java`, `InstrumentCodeConverter.java`, `InstrumentSymbolConverter.java`, `FxSpotEntityMapper.java`.

### Testing

- Автоматизированные тесты не запускались в рамках этого PR (не запрошено).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69792f1fcfb0832d8046f9852d0e14b9)