### PR TITLE
Увеличить длину instrument.code и instrument.symbol до 50 в миграции Flyway

### DIFF
--- a/backend/src/main/resources/db/migration/V2__increase_instrument_code_symbol_length.sql
+++ b/backend/src/main/resources/db/migration/V2__increase_instrument_code_symbol_length.sql
@@ -1,0 +1,5 @@
+ALTER TABLE instrument
+    ALTER COLUMN code TYPE VARCHAR(50);
+
+ALTER TABLE instrument
+    ALTER COLUMN symbol TYPE VARCHAR(50);


### PR DESCRIPTION
### Motivation
- Поля `InstrumentBaseEntity.code` и `InstrumentBaseEntity.symbol` были расширены до длины 50, поэтому требуется обновить схему БД, чтобы избежать несоответствия при валидации Flyway.

### Description
- Добавлена миграция Flyway `backend/src/main/resources/db/migration/V2__increase_instrument_code_symbol_length.sql`, выполняющая `ALTER TABLE instrument ALTER COLUMN code TYPE VARCHAR(50)` и `ALTER TABLE instrument ALTER COLUMN symbol TYPE VARCHAR(50)`.

### Testing
- Автоматические тесты не запускались; было добавлено только SQL-миграция и проверена её корректность в репозитории.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979359b5764832d997fe15ddb0da311)