### PR TITLE
Добавить HandlerCode value object и перейти на него в обработчиках

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
@@ -7,6 +7,7 @@ import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssWebC
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.provider.model.passport.AccessMethod;
 import com.alligator.market.domain.provider.model.handler.model.AbstractInstrumentHandler;
@@ -36,7 +37,7 @@ import java.util.Set;
 public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapter, FxSpot> {
 
     /* Уникальный код обработчика: UPPERCASE, формат [A-Z0-9_]+. */
-    private static final String HANDLER_CODE = "MOEX_ISS_FX_SPOT_HANDLER";
+    private static final HandlerCode HANDLER_CODE = HandlerCode.of("MOEX_ISS_FX_SPOT_HANDLER");
 
     /* Поддерживаемые коды инструментов FX_SPOT. */
     private static final Set<InstrumentCode> SUPPORTED_CODES = MoexIssFxSpotInstruments.SUPPORTED_DOMAIN_CODES;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/profinance/handler/forex/spot/ProFinanceFxSpotHandler.java
@@ -6,6 +6,7 @@ import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.handler.model.AbstractInstrumentHandler;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 import com.alligator.market.domain.provider.model.policy.ProviderPolicy;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +33,7 @@ import java.util.Set;
 public class ProFinanceFxSpotHandler extends AbstractInstrumentHandler<ProFinanceAdapter, FxSpot> {
 
     /* Уникальный код обработчика: UPPERCASE, формат [A-Z0-9_]+. */
-    private static final String HANDLER_CODE = "PROFINANCE_FX_SPOT_HANDLER";
+    private static final HandlerCode HANDLER_CODE = HandlerCode.of("PROFINANCE_FX_SPOT_HANDLER");
 
     /* Поддерживаемые коды инструментов FX_SPOT. */
     private static final Set<InstrumentCode> SUPPORTED_CODES = ProFinanceFxSpotCatalog.SUPPORTED_CODES;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/twelve/free/handler/forex/spot/TwelveFreeFxSpotHandler.java
@@ -6,6 +6,7 @@ import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
 import com.alligator.market.domain.provider.model.handler.model.AbstractInstrumentHandler;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.reactivestreams.Publisher;
@@ -22,7 +23,7 @@ import java.util.Set;
 public class TwelveFreeFxSpotHandler extends AbstractInstrumentHandler<TwelveFreeAdapterV2, FxSpot> {
 
     /* Уникальный код обработчика: UPPERCASE, формат [A-Z0-9_]+. */
-    private static final String HANDLER_CODE = "TWELVE_FREE_FX_SPOT_HANDLER";
+    private static final HandlerCode HANDLER_CODE = HandlerCode.of("TWELVE_FREE_FX_SPOT_HANDLER");
 
     /* Поддерживаемые коды инструментов FX_SPOT. */
     private static final Set<InstrumentCode> SUPPORTED_CODES = TwelveFreeFxSpotCatalog.SUPPORTED_CODES;

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentNotSupportedException.java
@@ -3,6 +3,7 @@ package com.alligator.market.domain.provider.exception;
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 
 import java.util.Objects;
 
@@ -12,7 +13,7 @@ import java.util.Objects;
 public final class InstrumentNotSupportedException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
-    private final String handlerCode;
+    private final HandlerCode handlerCode;
 
     /**
      * Создает исключение.
@@ -21,7 +22,7 @@ public final class InstrumentNotSupportedException extends BaseDomainException {
      * @param handlerCode    код обработчика, который не поддерживает {@code instrumentCode}
      */
     @SuppressWarnings("unused")
-    public InstrumentNotSupportedException(InstrumentCode instrumentCode, String handlerCode) {
+    public InstrumentNotSupportedException(InstrumentCode instrumentCode, HandlerCode handlerCode) {
         super(DomainErrorCode.INSTRUMENT_NOT_SUPPORTED, msg(instrumentCode, handlerCode));
         this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
@@ -35,7 +36,7 @@ public final class InstrumentNotSupportedException extends BaseDomainException {
      * @param cause          причина ошибки
      */
     @SuppressWarnings("unused")
-    public InstrumentNotSupportedException(InstrumentCode instrumentCode, String handlerCode, Throwable cause) {
+    public InstrumentNotSupportedException(InstrumentCode instrumentCode, HandlerCode handlerCode, Throwable cause) {
         super(DomainErrorCode.INSTRUMENT_NOT_SUPPORTED, msg(instrumentCode, handlerCode), cause);
         this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         this.handlerCode = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
@@ -48,10 +49,10 @@ public final class InstrumentNotSupportedException extends BaseDomainException {
      * @param handlerCode    код обработчика, который не поддерживает {@code instrumentCode}
      * @return текст сообщения
      */
-    private static String msg(InstrumentCode instrumentCode, String handlerCode) {
+    private static String msg(InstrumentCode instrumentCode, HandlerCode handlerCode) {
         InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
-        return "Instrument not supported (instrumentCode=" + ic.value() + ", handlerCode=" + hc + ")";
+        HandlerCode hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        return "Instrument not supported (instrumentCode=" + ic.value() + ", handlerCode=" + hc.value() + ")";
     }
 
     /**
@@ -70,7 +71,7 @@ public final class InstrumentNotSupportedException extends BaseDomainException {
      * @return код обработчика
      */
     @SuppressWarnings("unused")
-    public String getHandlerCode() {
+    public HandlerCode getHandlerCode() {
         return handlerCode;
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongClassException.java
@@ -3,6 +3,7 @@ package com.alligator.market.domain.provider.exception;
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 
 import java.util.Objects;
 
@@ -13,7 +14,7 @@ public final class InstrumentWrongClassException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
     private final Class<?> instrumentClass;
-    private final String handlerCode;
+    private final HandlerCode handlerCode;
     private final Class<?> expectedClass;
 
     /**
@@ -27,7 +28,7 @@ public final class InstrumentWrongClassException extends BaseDomainException {
     public InstrumentWrongClassException(
             InstrumentCode instrumentCode,
             Class<?> instrumentClass,
-            String handlerCode,
+            HandlerCode handlerCode,
             Class<?> expectedClass
     ) {
         super(
@@ -53,7 +54,7 @@ public final class InstrumentWrongClassException extends BaseDomainException {
     public InstrumentWrongClassException(
             InstrumentCode instrumentCode,
             Class<?> instrumentClass,
-            String handlerCode,
+            HandlerCode handlerCode,
             Class<?> expectedClass,
             Throwable cause
     ) {
@@ -80,15 +81,15 @@ public final class InstrumentWrongClassException extends BaseDomainException {
     private static String msg(
             InstrumentCode instrumentCode,
             Class<?> instrumentClass,
-            String handlerCode,
+            HandlerCode handlerCode,
             Class<?> expectedClass
     ) {
         InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         Class<?> actual = Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
-        String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        HandlerCode hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
         Class<?> expected = Objects.requireNonNull(expectedClass, "expectedClass must not be null");
         return "Instrument class mismatch (instrumentCode=" + ic.value() + ", actualClass=" + actual.getName()
-                + ", handlerCode=" + hc + ", expectedClass=" + expected.getName() + ")";
+                + ", handlerCode=" + hc.value() + ", expectedClass=" + expected.getName() + ")";
     }
 
     /**
@@ -117,7 +118,7 @@ public final class InstrumentWrongClassException extends BaseDomainException {
      * @return код обработчика
      */
     @SuppressWarnings("unused")
-    public String getHandlerCode() {
+    public HandlerCode getHandlerCode() {
         return handlerCode;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongTypeException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/InstrumentWrongTypeException.java
@@ -4,6 +4,7 @@ import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 
 import java.util.Objects;
 
@@ -14,7 +15,7 @@ public final class InstrumentWrongTypeException extends BaseDomainException {
 
     private final InstrumentCode instrumentCode;
     private final InstrumentType instrumentType;
-    private final String handlerCode;
+    private final HandlerCode handlerCode;
     private final InstrumentType expectedType;
 
     /**
@@ -28,7 +29,7 @@ public final class InstrumentWrongTypeException extends BaseDomainException {
     public InstrumentWrongTypeException(
             InstrumentCode instrumentCode,
             InstrumentType instrumentType,
-            String handlerCode,
+            HandlerCode handlerCode,
             InstrumentType expectedType
     ) {
         super(
@@ -54,7 +55,7 @@ public final class InstrumentWrongTypeException extends BaseDomainException {
     public InstrumentWrongTypeException(
             InstrumentCode instrumentCode,
             InstrumentType instrumentType,
-            String handlerCode,
+            HandlerCode handlerCode,
             InstrumentType expectedType,
             Throwable cause
     ) {
@@ -81,15 +82,15 @@ public final class InstrumentWrongTypeException extends BaseDomainException {
     private static String msg(
             InstrumentCode instrumentCode,
             InstrumentType instrumentType,
-            String handlerCode,
+            HandlerCode handlerCode,
             InstrumentType expectedType
     ) {
         InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         InstrumentType actual = Objects.requireNonNull(instrumentType, "instrumentType must not be null");
-        String hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        HandlerCode hc = Objects.requireNonNull(handlerCode, "handlerCode must not be null");
         InstrumentType expected = Objects.requireNonNull(expectedType, "expectedType must not be null");
         return "Instrument type mismatch (instrumentCode=" + ic.value() + ", actualType=" + actual.name()
-                + ", handlerCode=" + hc + ", expectedType=" + expected.name() + ")";
+                + ", handlerCode=" + hc.value() + ", expectedType=" + expected.name() + ")";
     }
 
     /**
@@ -118,7 +119,7 @@ public final class InstrumentWrongTypeException extends BaseDomainException {
      * @return код обработчика
      */
     @SuppressWarnings("unused")
-    public String getHandlerCode() {
+    public HandlerCode getHandlerCode() {
         return handlerCode;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
@@ -8,6 +8,7 @@ import com.alligator.market.domain.provider.model.handler.model.InstrumentHandle
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
 import com.alligator.market.domain.provider.model.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.exception.HandlerNotFoundException;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import org.reactivestreams.Publisher;
 
@@ -137,15 +138,15 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
         Objects.requireNonNull(handlers, "handlers must not be null");
 
         Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> map = new LinkedHashMap<>();
-        Set<String> handlerCodes = new HashSet<>();
+        Set<HandlerCode> handlerCodes = new HashSet<>();
 
         for (AbstractInstrumentHandler<P, ? extends Instrument> h : handlers) {
             Objects.requireNonNull(h, "handler must not be null");
 
-            String handlerCode = Objects.requireNonNull(h.handlerCode(), "handlerCode must not be null");
+            HandlerCode handlerCode = Objects.requireNonNull(h.handlerCode(), "handlerCode must not be null");
             if (!handlerCodes.add(handlerCode)) {
                 throw new IllegalStateException("Provider '" + providerCode.value() +
-                        "' contains multiple handlers with the same code '" + handlerCode + "'");
+                        "' contains multiple handlers with the same code '" + handlerCode.value() + "'");
             }
 
             Set<InstrumentCode> codes = Objects.requireNonNull(h.supportedInstrumentCodes(),
@@ -158,8 +159,8 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
                 if (prev != null) {
                     throw new IllegalStateException("Provider '" + providerCode.value() +
                             "' contains instrument code '" + instrumentCode.value() +
-                            "' that is supported by multiple handlers ('" + prev.handlerCode() +
-                            "', '" + handlerCode + "')");
+                            "' that is supported by multiple handlers ('" + prev.handlerCode().value() +
+                            "', '" + handlerCode.value() + "')");
                 }
             }
         }

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/model/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/model/AbstractInstrumentHandler.java
@@ -7,6 +7,7 @@ import com.alligator.market.domain.provider.model.MarketDataProvider;
 import com.alligator.market.domain.provider.exception.InstrumentNotSupportedException;
 import com.alligator.market.domain.provider.exception.InstrumentWrongClassException;
 import com.alligator.market.domain.provider.exception.InstrumentWrongTypeException;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import org.reactivestreams.Publisher;
 
@@ -20,8 +21,8 @@ import java.util.Set;
 public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
         implements InstrumentHandler<P, I> {
 
-    /* Нормализованный код обработчика: UPPERCASE, формат [A-Z0-9_]+. */
-    private final String normHandlerCode;
+    /* Нормализованный код обработчика. */
+    private final HandlerCode handlerCode;
 
     /* Декларируемый класс поддерживаемых инструментов. */
     private final Class<I> instrumentClass;
@@ -44,7 +45,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
      *
      * <p>Проверяет инварианты, нормализует код обработчика, нормализует коды в наборе кодов инструментов.</p>
      *
-     * @param handlerCode              код обработчика; нормализуется в UPPERCASE; формат [A-Z0-9_]+
+     * @param handlerCode              код обработчика; валидируется через {@link HandlerCode}
      * @param instrumentClass          класс поддерживаемых инструментов
      * @param instrumentType           тип поддерживаемых инструментов
      * @param supportedInstrumentCodes набор кодов инструментов; нормализуются через {@link InstrumentCode}; без дублей
@@ -52,7 +53,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
      * @throws IllegalArgumentException если код пустой/с пробелами/не соответствует формату; набор пуст; содержит null/blank/дубликаты
      */
     protected AbstractInstrumentHandler(
-            String handlerCode,
+            HandlerCode handlerCode,
             Class<I> instrumentClass,
             InstrumentType instrumentType,
             Set<InstrumentCode> supportedInstrumentCodes
@@ -62,14 +63,11 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
         Objects.requireNonNull(instrumentType, "instrumentType must not be null");
         Objects.requireNonNull(supportedInstrumentCodes, "supportedInstrumentCodes must not be null");
 
-        if (handlerCode.isBlank()) {
-            throw new IllegalArgumentException("handlerCode must not be blank");
-        }
         if (supportedInstrumentCodes.isEmpty()) {
             throw new IllegalArgumentException("supportedInstrumentCodes must not be empty");
         }
 
-        this.normHandlerCode = normalizeHandlerCode(handlerCode);
+        this.handlerCode = handlerCode;
         this.instrumentClass = instrumentClass;
         this.instrumentType = instrumentType;
         this.normSupportedInstrumentCodes = getNormalizedCodes(supportedInstrumentCodes);
@@ -80,8 +78,8 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
     //=================================================================================================================
 
     @Override
-    public final String handlerCode() {
-        return normHandlerCode;
+    public final HandlerCode handlerCode() {
+        return handlerCode;
     }
 
     @Override
@@ -148,7 +146,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
             throw new InstrumentWrongClassException( // <-- Неверный класс
                     instrument.instrumentCode(),
                     instrument.getClass(),
-                    normHandlerCode,
+                    handlerCode,
                     instrumentClass
             );
         }
@@ -158,7 +156,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
             throw new InstrumentWrongTypeException( // <-- Неверный тип
                     instrument.instrumentCode(),
                     instrument.instrumentType(),
-                    normHandlerCode,
+                    handlerCode,
                     instrumentType
             );
         }
@@ -171,7 +169,7 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
         if (!normSupportedInstrumentCodes.contains(instrumentCode)) {
             throw new InstrumentNotSupportedException( // <-- Не поддерживается
                     instrument.instrumentCode(),
-                    normHandlerCode);
+                    handlerCode);
         }
         return doQuote(instrument);
     }
@@ -225,20 +223,4 @@ public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataP
         return java.util.Collections.unmodifiableSet(codes); // <-- Фиксируем неизменяемость
     }
 
-    /**
-     * Нормализует и валидирует код обработчика: trim --> UPPERCASE --> проверка формата [A-Z0-9_]+.
-     *
-     * @throws IllegalArgumentException если код обработчика не соответствует формату
-     */
-    private static String normalizeHandlerCode(String code) {
-        // Нормализуем код обработчика
-        final String normalized = code.trim().toUpperCase(java.util.Locale.ROOT);
-        // Разрешены только латинские заглавные, цифры и подчёркивание
-        if (!normalized.chars().allMatch(ch ->
-                (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_')) {
-            throw new IllegalArgumentException(
-                    "handlerCode must match pattern [A-Z0-9_]+: '" + normalized + "'");
-        }
-        return normalized;
-    }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/model/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/model/InstrumentHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.instrument.type.InstrumentType;
 import com.alligator.market.domain.provider.model.MarketDataProvider;
+import com.alligator.market.domain.provider.model.vo.HandlerCode;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import org.reactivestreams.Publisher;
 
@@ -20,7 +21,7 @@ public sealed interface InstrumentHandler<P extends MarketDataProvider, I extend
     /**
      * Код обработчика – уникальный идентификатор обработчика.
      */
-    String handlerCode();
+    HandlerCode handlerCode();
 
     /**
      * Декларируем класс поддерживаемых инструментов.

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/vo/HandlerCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/vo/HandlerCode.java
@@ -1,0 +1,70 @@
+package com.alligator.market.domain.provider.model.vo;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Объект-значение кода обработчика.
+ *
+ * <p>Причина создания: код обработчика используется многократно в разных слоях приложения,
+ * поэтому важно гарантировать единый формат кода без многократных единообразных проверок.</p>
+ *
+ * @param value строковое значение кода обработчика
+ */
+public record HandlerCode(
+        String value
+) {
+
+    /* Шаблон допустимых символов для кода обработчика. */
+    public static final String PATTERN = "^[A-Z0-9_]+$";
+
+    /* Максимальная длина кода обработчика. */
+    private static final int MAX_LENGTH = 50;
+
+    /* Шаблон для валидации кода обработчика. */
+    private static final Pattern VALIDATION_PATTERN = Pattern.compile(PATTERN);
+
+    /**
+     * Конструктор.
+     */
+    public HandlerCode {
+        value = normalize(value);
+    }
+
+    /**
+     * Фабрика для создания объекта из строкового кода.
+     */
+    public static HandlerCode of(String raw) {
+        return new HandlerCode(raw);
+    }
+
+    /**
+     * Метод проверки и нормализации входящего значения кода обработчика.
+     *
+     * @param raw исходное строковое значение кода обработчика
+     * @return нормализованное значение кода обработчика
+     */
+    private static String normalize(String raw) {
+        Objects.requireNonNull(raw, "handlerCode must not be null");
+
+        String normalized = raw.strip();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("handlerCode must not be blank");
+        }
+
+        normalized = normalized.toUpperCase(Locale.ROOT);
+
+        if (normalized.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("handlerCode length must be <= " + MAX_LENGTH);
+        }
+
+        if (!VALIDATION_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    "handlerCode must match pattern [A-Z0-9_]+: '" + normalized + "'"
+            );
+        }
+
+        return normalized;
+    }
+}


### PR DESCRIPTION
### Motivation
- Ввести единый объект-значение для кода обработчика по аналогии с `ProviderCode`, чтобы централизовать валидацию и нормализацию кодов обработчиков.
- Уменьшить дублирование проверок строковых кодов и повысить типобезопасность API обработчиков и исключений.

### Description
- Добавлен `record HandlerCode` в `domain/src/main/java/com/alligator/market/domain/provider/model/vo/HandlerCode.java` с нормализацией/валидацией (trim, uppercase, pattern `[A-Z0-9_]+`, max length).
- Изменён контракт `InstrumentHandler.handlerCode()` чтобы возвращать `HandlerCode` вместо `String` и обновлён `AbstractInstrumentHandler` для хранения и использования `HandlerCode` (конструктор, проверки и вызовы исключений).
- Обновлены доменные исключения `InstrumentNotSupportedException`, `InstrumentWrongClassException` и `InstrumentWrongTypeException` для работы с `HandlerCode` и форматирования сообщений через `handlerCode.value()`.
- В `AbstractMarketDataProvider` сменён тип множества уникальных кодов обработчиков на `Set<HandlerCode>` и обновлены сообщения при конфликтах; конкретные обработчики (`MoexIssFxSpotHandler`, `ProFinanceFxSpotHandler`, `TwelveFreeFxSpotHandler`) теперь создают коды как `HandlerCode.of("...")`.

### Testing
- Автоматические тесты и сборка не запускались в рамках этого изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a790477cc832d80815171d9b2f70b)