### PR TITLE
Bootstrap provider maintenance: единый источник конфигурации через ProviderMaintenanceProps

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/bootstrap/ProviderMaintenanceBootstrap.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/bootstrap/ProviderMaintenanceBootstrap.java
@@ -2,11 +2,11 @@ package com.alligator.market.backend.provider.maintenance.orchestration.bootstra
 
 import com.alligator.market.backend.config.audit.context.AuditContext;
 import com.alligator.market.backend.config.audit.context.AuditContextHolder;
+import com.alligator.market.backend.provider.maintenance.orchestration.config.ProviderMaintenanceProps;
 import com.alligator.market.backend.provider.maintenance.orchestration.report.ProviderMaintenanceReport;
 import com.alligator.market.backend.provider.maintenance.orchestration.service.ProviderMaintenanceOrchestrator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -22,16 +22,14 @@ public class ProviderMaintenanceBootstrap implements ApplicationRunner {
     /* Оркестратор процессов обслуживания провайдеров. */
     private final ProviderMaintenanceOrchestrator orchestrator;
 
-    /* Флаг: запускать ли обслуживание провайдеров при старте приложения (по умолчанию включено). */
-    @Value("${provider.maintenance.on-startup:true}")
-    private boolean runOnStartup;
-
-    /* Флаг: "падать" ли приложению при сбое хотя бы одного из процессов обслуживания (по умолчанию выключено). */
-    @Value("${provider.maintenance.fail-fast:false}")
-    private boolean failFast;
+    /* Единый источник конфигурации для provider maintenance. */
+    private final ProviderMaintenanceProps props;
 
     @Override
     public void run(ApplicationArguments args) {
+        final boolean runOnStartup = props.isOnStartup();
+        final boolean failFast = props.isFailFast();
+
         if (!runOnStartup) {
             log.info("Provider maintenance on startup is disabled (property 'provider.maintenance.on-startup=false')");
             return;


### PR DESCRIPTION
### Motivation
- Убрать дублирование конфигурации: ранее `ProviderMaintenanceOrchestrator` читал параметры из `ProviderMaintenanceProps`, а `ProviderMaintenanceBootstrap` — через полевые `@Value`, что приводило к двум системам конфигурации для одной фичи.
- Сделать `ProviderMaintenanceProps` единственным источником правды для флагов `on-startup` и `fail-fast`.

### Description
- В `ProviderMaintenanceBootstrap` удалены полевые `@Value` для `provider.maintenance.on-startup` и `provider.maintenance.fail-fast` и добавлена инъекция `ProviderMaintenanceProps` (файл: `backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/bootstrap/ProviderMaintenanceBootstrap.java`).
- Логика работы сохранена; значения теперь получаются через `props.isOnStartup()` и `props.isFailFast()` и используются в тех же ветках выполнения (`run`/`fail-fast` обработка).
- Проверена согласованность с `application.properties`, в котором присутствуют `provider.maintenance.on-startup` и `provider.maintenance.fail-fast` (файл: `backend/src/main/resources/application.properties`).

### Testing
- Проверил наличие свойств в `application.properties` вручную и убедился, что `provider.maintenance.on-startup` и `provider.maintenance.fail-fast` заданы; проверка успешна.
- Попытки компиляции: `./mvnw -pl backend -DskipTests compile` не завершился из-за невозможности скачать Maven wrapper дистрибутив, и `mvn -pl backend -DskipTests compile` завершился с ошибкой разрешения зависимостей (Maven Central вернул HTTP 403), поэтому полноценная сборка в этом окружении выполнить не удалось.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ff3bc3e0832d8c948b9315f345e7)