### PR TITLE
Orchestrator: проверка enabled до логирования "Running"

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/service/ProviderMaintenanceOrchestrator.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/service/ProviderMaintenanceOrchestrator.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Оркестратор задач обслуживания провайдеров.
@@ -37,10 +38,12 @@ public class ProviderMaintenanceOrchestrator {
         List<ProviderMaintenanceTaskResult> results = new ArrayList<>(tasks.size());
 
         for (ProviderMaintenanceTask task : tasks) {
-            final String code = task.code();
-            final long startedAt = System.nanoTime();
+            Objects.requireNonNull(task, "task must not be null");
 
-            log.info("Running provider maintenance task: {}", code);
+            final String code = Objects.requireNonNull(task.code(), "task code must not be null");
+            if (code.isBlank()) {
+                throw new IllegalStateException("Task code must not be blank");
+            }
 
             final boolean enabled = props.isTaskEnabled(code, task.enabledByDefault());
             if (!enabled) {
@@ -54,6 +57,9 @@ public class ProviderMaintenanceOrchestrator {
                 ));
                 continue;
             }
+
+            final long startedAt = System.nanoTime();
+            log.info("Running provider maintenance task: {}", code);
 
             try {
                 task.run();


### PR DESCRIPTION
### Motivation
- Исправить порядок операций в оркестраторе задач, чтобы лог `Running provider maintenance task: ...` появлялся только для реально запускаемых задач и не создавал лишних вычислений.
- Уменьшить засорение логов и повысить предсказуемость отчётов о задачах (чёткое разделение SKIPPED и RUNNING).

### Description
- Перемещён `enabled`-чек до логирования `Running...`, чтобы отключённые задачи сразу помечались как `SKIPPED` и не запускались дальше.
- Добавлены `Objects.requireNonNull(task)` и `Objects.requireNonNull(task.code(), ...)` для явной проверки входных данных и импортирован `java.util.Objects`.
- Добавлена проверка `code.isBlank()` с выбрасыванием `IllegalStateException`, если код задачи пустой.
- Таймер `startedAt` теперь инициализируется только для включённых задач, и лог `Running provider maintenance task: {}` выполняется после этой проверки.

### Testing
- Попытка сборки с `./mvnw -pl backend -DskipTests compile` не прошла из-за ограничения окружения: wrapper не смог загрузить Maven дистрибутив; запуск завершился с ошибкой загрузки.
- Попытка сборки с `mvn -pl backend -DskipTests compile` не прошла из-за ограничения окружения: загрузка зависимостей с Maven Central завершилась `403 Forbidden`.
- Юнит/интеграционные тесты не запускались из-за невозможности завершить сборку в текущем окружении.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698503747a18832d90d9525649f4de87)