### PR TITLE
Сделать deleteByCodes строгим к null в JDBC DAO

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/projection/db/passport/dao/ProviderPassportDbProjectionDaoAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/projection/db/passport/dao/ProviderPassportDbProjectionDaoAdapter.java
@@ -26,7 +26,7 @@ public class ProviderPassportDbProjectionDaoAdapter implements ProviderPassportD
 
     /* Конструктор. */
     public ProviderPassportDbProjectionDaoAdapter(JdbcTemplate jdbc) {
-        this.jdbc = jdbc;
+        this.jdbc = Objects.requireNonNull(jdbc, "jdbc must not be null");
     }
 
     /**
@@ -36,15 +36,20 @@ public class ProviderPassportDbProjectionDaoAdapter implements ProviderPassportD
     public void deleteByCodes(Collection<ProviderCode> codes) {
         if (codes == null || codes.isEmpty()) return;
 
+        // Явно запрещаем null-элементы, чтобы не игнорировать ошибочные входные данные.
+        for (ProviderCode code : codes) {
+            if (code == null) {
+                throw new IllegalArgumentException("codes must not contain null");
+            }
+        }
+
         // SQL-команда
         final String sql = "DELETE FROM provider_passport WHERE provider_code = ?";
 
         // Преобразуем коллекцию в список (предполагаем, что коды уже нормализованы)
         List<String> normalizedCodes = codes.stream()
-                .filter(Objects::nonNull)
                 .map(ProviderCode::value)
                 .toList();
-        if (normalizedCodes.isEmpty()) return;
 
         // Пакетно выполняем DELETE: привязываем provider_code по индексу и задаём размер батча.
         jdbc.batchUpdate(sql, new BatchPreparedStatementSetter() {


### PR DESCRIPTION
### Motivation
- Привести поведение `deleteByCodes` к стилю fail-fast, как в `upsertAll`, чтобы не silently игнорировать некорректные входные данные.

### Description
- В конструкторе `ProviderPassportDbProjectionDaoAdapter` добавлено `Objects.requireNonNull(jdbc, "jdbc must not be null")`, а в `deleteByCodes(Collection<ProviderCode> codes)` добавлена явная проверка элементов и выбрасывается `IllegalArgumentException("codes must not contain null")` при наличии `null`, при этом удалён `filter(Objects::nonNull)` перед `map(ProviderCode::value)`.

### Testing
- Пытался скомпилировать бекенд командой `./mvnw -pl backend -DskipTests compile`, но сборка не прошла из-за ошибки загрузки Maven дистрибутива (скачивание с Maven Central не удалось), поэтому автоматических тестов запущено не было.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698504cc9704832d83ce6af1bcfa795a)