### PR TITLE
Валидация кодов задач в ProviderMaintenanceOrchestrator.runAll

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/service/ProviderMaintenanceOrchestrator.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/service/ProviderMaintenanceOrchestrator.java
@@ -10,8 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Оркестратор задач обслуживания провайдеров.
@@ -35,15 +37,23 @@ public class ProviderMaintenanceOrchestrator {
      * <p>Важно: оркестратор не падает при первой ошибке, а пытается выполнить все задачи и вернуть отчёт.</p>
      */
     public ProviderMaintenanceReport runAll() {
-        List<ProviderMaintenanceTaskResult> results = new ArrayList<>(tasks.size());
-
+        Set<String> seenCodes = new HashSet<>();
         for (ProviderMaintenanceTask task : tasks) {
             Objects.requireNonNull(task, "task must not be null");
 
-            final String code = Objects.requireNonNull(task.code(), "task code must not be null");
+            String code = Objects.requireNonNull(task.code(), "task code must not be null");
             if (code.isBlank()) {
                 throw new IllegalStateException("Task code must not be blank");
             }
+            if (!seenCodes.add(code)) {
+                throw new IllegalStateException("Duplicate provider maintenance task code: '" + code + "'");
+            }
+        }
+
+        List<ProviderMaintenanceTaskResult> results = new ArrayList<>(tasks.size());
+
+        for (ProviderMaintenanceTask task : tasks) {
+            final String code = Objects.requireNonNull(task.code(), "task code must not be null");
 
             final boolean enabled = props.isTaskEnabled(code, task.enabledByDefault());
             if (!enabled) {


### PR DESCRIPTION
### Motivation
- Добавить минимальную и чистую пред-валидацию списка maintenance задач перед выполнением, чтобы раннее обнаружение некорректных или дублирующих кодов предотвратило непредсказуемое поведение во время оркестрации.

### Description
- В `ProviderMaintenanceOrchestrator.runAll()` добавлен предварительный проход, который проверяет, что каждый `task` не `null`, `task.code()` не `null` и не пустая строка, и что все коды уникальны с помощью `Set`/`HashSet`.
- Основной цикл выполнения оставлен сфокусированным на запуске задач и по-прежнему получает `code` в локальную переменную перед использованием.
- Добавлены импорты `HashSet` и `Set` и переставлены объявления коллекций так, чтобы валидация выполнялась до создания результатов.

### Testing
- Попытка запустить автоматические тесты через `./mvnw -pl backend test -DskipITs` была выполнена, но завершилась неудачей из‑за того, что Maven Wrapper не смог скачать дистрибутив Maven (`wget: Failed to fetch ...`).
- В среде изменения не были прогнаны через другие автоматические тесты или сборки из‑за ограничения окружения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698506ed56ac832d947c1d25a64252b8)