### PR TITLE
Переименование ProviderMaintenanceProps в ProviderMaintenanceProperties

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/bootstrap/ProviderMaintenanceBootstrap.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/bootstrap/ProviderMaintenanceBootstrap.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.maintenance.orchestration.bootstra
 
 import com.alligator.market.backend.config.audit.context.AuditContext;
 import com.alligator.market.backend.config.audit.context.AuditContextHolder;
-import com.alligator.market.backend.provider.maintenance.orchestration.config.ProviderMaintenanceProps;
+import com.alligator.market.backend.provider.maintenance.orchestration.config.ProviderMaintenanceProperties;
 import com.alligator.market.backend.provider.maintenance.orchestration.report.ProviderMaintenanceReport;
 import com.alligator.market.backend.provider.maintenance.orchestration.service.ProviderMaintenanceOrchestrator;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class ProviderMaintenanceBootstrap implements ApplicationRunner {
     private final ProviderMaintenanceOrchestrator orchestrator;
 
     /* Единый источник конфигурации для provider maintenance. */
-    private final ProviderMaintenanceProps props;
+    private final ProviderMaintenanceProperties props;
 
     @Override
     public void run(ApplicationArguments args) {

--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/config/ProviderMaintenanceProperties.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/config/ProviderMaintenanceProperties.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 @Setter
 @Validated
 @ConfigurationProperties(prefix = "provider.maintenance")
-public class ProviderMaintenanceProps {
+public class ProviderMaintenanceProperties {
 
     /* Запускать ли maintenance при старте приложения. */
     private boolean onStartup = true;

--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/service/ProviderMaintenanceOrchestrator.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/service/ProviderMaintenanceOrchestrator.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.maintenance.orchestration.service;
 
-import com.alligator.market.backend.provider.maintenance.orchestration.config.ProviderMaintenanceProps;
+import com.alligator.market.backend.provider.maintenance.orchestration.config.ProviderMaintenanceProperties;
 import com.alligator.market.backend.provider.maintenance.orchestration.report.ProviderMaintenanceReport;
 import com.alligator.market.backend.provider.maintenance.orchestration.report.ProviderMaintenanceTaskResult;
 import com.alligator.market.backend.provider.maintenance.orchestration.report.ProviderMaintenanceTaskStatus;
@@ -29,7 +29,7 @@ public class ProviderMaintenanceOrchestrator {
     private final List<ProviderMaintenanceTask> tasks;
 
     /* Настройки maintenance. */
-    private final ProviderMaintenanceProps props;
+    private final ProviderMaintenanceProperties props;
 
     /**
      * Запустить все задачи обслуживания и вернуть отчёт.


### PR DESCRIPTION
### Motivation
- Сделать имя класса конфигурации более понятным и семантически верным — заменить сокращённое `ProviderMaintenanceProps` на `ProviderMaintenanceProperties`.

### Description
- Файл конфигурации переименован в `ProviderMaintenanceProperties` и соответствующие импорты и поля обновлены в `ProviderMaintenanceOrchestrator` и `ProviderMaintenanceBootstrap`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875ff46e9c832d961c8633f9146689)