### PR TITLE
Переименовать MoexIssAdapterProps в MoexIssAdapterProperties

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssAdapter.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.adapter.moex.iss;
 
-import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProps;
+import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProperties;
 import com.alligator.market.backend.provider.adapter.moex.iss.handler.forex.spot.MoexIssFxSpotHandler;
 import com.alligator.market.backend.provider.adapter.common.SpringMarketDataProvider;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
@@ -16,7 +16,7 @@ import java.util.Set;
 
 /* TODO: есть такая проблема с обработчиками, нужно разобраться:
 Меня немного смущает что переданные в конструктор
-        MoexIssAdapterProps props,
+        MoexIssAdapterProperties props,
         @Qualifier("moexIssWebClient") WebClient webClient
         как бы насквозь переходят а обработчик: Set.of(new MoexIssFxSpotHandler(props, webClient))
         А что если у меня будет несколько обработчиков для которых нужны разные props и webClient. Конечно же, можно на входе конструктора передать несколько вариантов props и webClient, но мне не кажется это хорошим решением.
@@ -53,11 +53,11 @@ public class MoexIssAdapter extends SpringMarketDataProvider<MoexIssAdapter> {
      * <p>Входные параметры {@code props} и {@code webClient} передаются конструктору
      * для сборки обработчика {@link MoexIssFxSpotHandler}.</p>
      *
-     * @param props     параметры подключения к провайдеру {@see MoexIssAdapterProps}
+     * @param props     параметры подключения к провайдеру {@see MoexIssAdapterProperties}
      * @param webClient web-клиент, настроенный для данного провайдера {@see MoexIssWebConfig}
      */
     public MoexIssAdapter(
-            MoexIssAdapterProps props,
+            MoexIssAdapterProperties props,
             @Qualifier("moexIssWebClient") WebClient webClient
     ) {
         // Инициализируем базовый класс

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssAdapterProperties.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssAdapterProperties.java
@@ -12,7 +12,7 @@ import org.springframework.validation.annotation.Validated;
  */
 @Validated
 @ConfigurationProperties("provider.connection-config.moex.iss")
-public record MoexIssAdapterProps(
+public record MoexIssAdapterProperties(
         @NotBlank
         String baseUrl
 ) {

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssWebConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssWebConfig.java
@@ -12,13 +12,13 @@ import reactor.netty.http.client.HttpClient;
  * Конфигурация web-клиента провайдера рыночных данных MOEX ISS.
  *
  * <p>Использует единый для всех провайдеров HTTP-клиент из {@link ProviderHttpConfigGlobal}
- * и параметры подключения из {@link MoexIssAdapterProps}.</p>
+ * и параметры подключения из {@link MoexIssAdapterProperties}.</p>
  */
 @Configuration
 public class MoexIssWebConfig {
 
     /* Параметры подключения к провайдеру MOEX ISS. */
-    private final MoexIssAdapterProps props;
+    private final MoexIssAdapterProperties props;
 
     /* Единый HTTP-клиент провайдеров. */
     private final HttpClient httpClient;
@@ -27,7 +27,7 @@ public class MoexIssWebConfig {
      * Конструктор конфигурации web-клиента MOEX ISS.
      */
     public MoexIssWebConfig(
-            MoexIssAdapterProps props, // <-- инжекция бина с параметрами подключения
+            MoexIssAdapterProperties props, // <-- инжекция бина с параметрами подключения
             @Qualifier("providerHttpClient") HttpClient httpClient // <-- инжекция бина единого HTTP-клиента для провайдеров
 
     ) {

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandler.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss.handler.forex.spo
 
 import com.alligator.market.backend.config.time.TimeZoneConfig;
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssAdapter;
-import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProps;
+import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProperties;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssWebConfig;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.type.InstrumentType;
@@ -58,11 +58,11 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssAdapt
     /**
      * Конструктор обработчика.
      *
-     * @param props     параметры подключения к провайдеру {@link MoexIssAdapterProps}
+     * @param props     параметры подключения к провайдеру {@link MoexIssAdapterProperties}
      * @param webClient web-клиент, настроенный для данного провайдера {@link MoexIssWebConfig}
      */
     public MoexIssFxSpotHandler(
-            MoexIssAdapterProps props,
+            MoexIssAdapterProperties props,
             WebClient webClient
     ) {
         // Инициализируем базовый класс

--- a/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.adapter.moex.iss.handler.forex.spot;
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssAdapter;
-import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProps;
+import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProperties;
 import com.alligator.market.domain.instrument.type.forex.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
@@ -30,7 +30,7 @@ class MoexIssFxSpotHandlerQuoteLiveTest {
     void liveQuoteForCnyRubTom() {
         // 1) Собираем WebClient с реальным baseUrl и задаем настройки подключения
         String baseUrl = "https://iss.moex.com/iss";
-        MoexIssAdapterProps props = new MoexIssAdapterProps(baseUrl);
+        MoexIssAdapterProperties props = new MoexIssAdapterProperties(baseUrl);
 
         WebClient webClient = WebClient.builder()
                 .baseUrl(baseUrl)

--- a/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteMockTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteMockTest.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.adapter.moex.iss.handler.forex.spot;
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssAdapter;
-import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProps;
+import com.alligator.market.backend.provider.adapter.moex.iss.config.MoexIssAdapterProperties;
 import com.alligator.market.domain.instrument.type.forex.currency.model.Currency;
 import com.alligator.market.domain.instrument.type.forex.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.type.forex.spot.model.FxSpot;
@@ -51,7 +51,7 @@ class MoexIssFxSpotHandlerQuoteMockTest {
 
         // 2) Готовим baseUrl для WebClient и props
         String baseUrl = mockWebServer.url("/iss").toString();
-        MoexIssAdapterProps props = new MoexIssAdapterProps(baseUrl);
+        MoexIssAdapterProperties props = new MoexIssAdapterProperties(baseUrl);
 
         // 3) Создаём WebClient с тестовым baseUrl
         WebClient webClient = WebClient.builder()


### PR DESCRIPTION
### Motivation
- Переименование делает имя конфигурационного record более явным и согласованным (`Props` → `Properties`).
- Цель — улучшить читаемость API и привести имя типа к общему стилю проекта.

### Description
- Переименован record в `backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config` на `MoexIssAdapterProperties` и файл соответственно перемещён/переименован.
- Обновлены все импорты и ссылки на новый тип в `MoexIssWebConfig`, `MoexIssAdapter`, `MoexIssFxSpotHandler` и связанных тестовых классах.
- Обновлены Javadoc/ссылки внутри изменённых файлов, без изменения логики выполнения или поведения адаптера.

### Testing
- Автоматические тесты не запускались после изменений.
- Обновлённые тестовые файлы `MoexIssFxSpotHandlerQuoteLiveTest` и `MoexIssFxSpotHandlerQuoteMockTest` теперь используют `MoexIssAdapterProperties`, при этом эти интеграционные тесты помечены `@Disabled` и предназначены для ручочного запуска.
- Рекомендуется запустить проектные тесты в CI (`mvn test`) для подтверждения сборки и отсутствия регрессий.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698761795e7c832d8d9b81fdcc6264a8)