### PR TITLE
Вынести карту задач в ProviderMaintenanceProperties (убрать TasksProperties)

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/properties/ProviderMaintenanceProperties.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/properties/ProviderMaintenanceProperties.java
@@ -40,10 +40,10 @@ public class ProviderMaintenanceProperties {
     @NotNull
     private BootstrapProperties bootstrap = new BootstrapProperties();
 
-    /* Настройки задач maintenance (вкл/выкл задач и т.п.). */
+    /* Настройки задач maintenance по коду: provider.maintenance.tasks.<task-code>.* */
     @Valid
     @NotNull
-    private TasksProperties tasks = new TasksProperties();
+    private Map<String, TaskProperties> tasks = new HashMap<>();
 
     /**
      * Удобный метод: проверить, включена ли задача по её коду.
@@ -55,7 +55,8 @@ public class ProviderMaintenanceProperties {
         if (code.isBlank()) {
             throw new IllegalArgumentException("task code must not be blank");
         }
-        return tasks.isTaskEnabled(code, defaultEnabled);
+        TaskProperties props = tasks.get(code);
+        return props == null ? defaultEnabled : props.enabled;
     }
 
     /**
@@ -70,30 +71,6 @@ public class ProviderMaintenanceProperties {
 
         /* provider.maintenance.bootstrap.fail-fast */
         private boolean failFast = false;
-    }
-
-    /**
-     * Группа настроек {@code provider.maintenance.tasks.*}.
-     */
-    @Getter
-    @Setter
-    public static class TasksProperties {
-
-        /**
-         * Настройки задач по коду задачи.
-         *
-         * <p>Пример: ключ {@code provider-passport-db-projection} попадёт в {@code map.get("provider-passport-db-projection")}.</p>
-         */
-        @NotNull
-        private Map<String, TaskProperties> map = new HashMap<>();
-
-        /**
-         * Удобный метод: если задача не описана в конфиге, вернуть {@code defaultEnabled}.
-         */
-        public boolean isTaskEnabled(String code, boolean defaultEnabled) {
-            TaskProperties props = map.get(code);
-            return props == null ? defaultEnabled : props.enabled;
-        }
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Упростить структуру конфигурации, чтобы ключи вида `provider.maintenance.tasks.<task-code>.enabled` биндовались напрямую без вложенного контейнера.
- Сделать API настроек более естественным и предсказуемым при чтении и настройке задач maintenance.

### Description
- Заменён вложенный контейнер `TasksProperties` на прямое поле `private Map<String, TaskProperties> tasks = new HashMap<>();` в `ProviderMaintenanceProperties`.
- Упрощён метод `isTaskEnabled(String code, boolean defaultEnabled)`: теперь он читает `TaskProperties` прямо из `tasks` и возвращает `defaultEnabled`, если записи нет.
- Удалён внутренний класс `TasksProperties` и соответствующая обёртка `map`, оставлен класс `TaskProperties` с полем `enabled`.
- Обновлены комментарии и валидационные аннотации в `backend/src/main/java/com/alligator/market/backend/provider/maintenance/orchestration/properties/ProviderMaintenanceProperties.java`.

### Testing
- Попытка сборки модуля с помощью `mvn -pl backend -DskipTests compile` была выполнена автоматически и завершилась с ошибкой из-за ограничения окружения при разрешении parent POM в Maven Central (`403 Forbidden`).
- Никаких автоматических unit/integration тестов выполнить не удалось по причине ошибки разрешения зависимостей.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948c67e310832da90a78d3b4b134cd)