### PR TITLE
Переименованы общие константы `BEAN_NAME` в явные имена для handler web

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/instrument/forex/spot/web/MoexIssFxSpotWebClientConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/instrument/forex/spot/web/MoexIssFxSpotWebClientConfig.java
@@ -27,7 +27,7 @@ public class MoexIssFxSpotWebClientConfig {
      */
     @Bean(BEAN_NAME)
     public WebClient moexIssFxSpotWebClient(
-            @Qualifier(HandlerBaseWebClientConfig.BEAN_NAME) WebClient globalWebClient,
+            @Qualifier(HandlerBaseWebClientConfig.BEAN_HANDLER_BASE_WEB_CLIENT) WebClient globalWebClient,
             MoexIssFxSpotConnectionProperties props
     ) {
         return globalWebClient.mutate()

--- a/backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/HandlerBaseWebClientConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/HandlerBaseWebClientConfig.java
@@ -19,16 +19,16 @@ import reactor.netty.http.client.HttpClient;
 @Import({HandlerBaseHttpClientConfig.class})
 public class HandlerBaseWebClientConfig {
 
-    public static final String BEAN_NAME = "handlerBaseWebClient";
+    public static final String BEAN_HANDLER_BASE_WEB_CLIENT = "handlerBaseWebClient";
 
     /**
      * Бин базового web-клиента всех обработчиков.
      *
      * @param handlerBaseHttpClient базовый HTTP-клиент всех обработчиков
      */
-    @Bean(BEAN_NAME)
+    @Bean(BEAN_HANDLER_BASE_WEB_CLIENT)
     public WebClient handlerBaseWebClient(
-            @Qualifier(HandlerBaseHttpClientConfig.BEAN_NAME)
+            @Qualifier(HandlerBaseHttpClientConfig.BEAN_HANDLER_BASE_HTTP_CLIENT)
             HttpClient handlerBaseHttpClient
     ) {
         return WebClient.builder()
@@ -37,4 +37,3 @@ public class HandlerBaseWebClientConfig {
                 .build();
     }
 }
-

--- a/backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/http/HandlerBaseHttpClientConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/http/HandlerBaseHttpClientConfig.java
@@ -18,16 +18,16 @@ import java.time.Duration;
 @Import(HandlerBaseConnectionPoolConfig.class)
 public class HandlerBaseHttpClientConfig {
 
-    public static final String BEAN_NAME = "handlerBaseHttpClient";
+    public static final String BEAN_HANDLER_BASE_HTTP_CLIENT = "handlerBaseHttpClient";
 
     /**
      * Бин базового HTTP-клиента всех обработчиков.
      *
      * @param handlerBaseConnectionPool базовый пул TCP-соединений всех обработчиков
      */
-    @Bean(BEAN_NAME)
+    @Bean(BEAN_HANDLER_BASE_HTTP_CLIENT)
     public HttpClient handlerBaseHttpClient(
-            @Qualifier(HandlerBaseConnectionPoolConfig.BEAN_NAME)
+            @Qualifier(HandlerBaseConnectionPoolConfig.BEAN_HANDLER_BASE_CONNECTION_POOL)
             ConnectionProvider handlerBaseConnectionPool
     ) {
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/http/tcp/HandlerBaseConnectionPoolConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/http/tcp/HandlerBaseConnectionPoolConfig.java
@@ -12,13 +12,13 @@ import java.time.Duration;
 @Configuration(proxyBeanMethods = false)
 public class HandlerBaseConnectionPoolConfig {
 
-    public static final String BEAN_NAME = "handlerBaseConnectionPool";
+    public static final String BEAN_HANDLER_BASE_CONNECTION_POOL = "handlerBaseConnectionPool";
     private static final String POOL_NAME = "handler-connection-pool";
 
     /**
      * Бин базового пула TCP-соединений обработчиков.
      */
-    @Bean(value = BEAN_NAME, destroyMethod = "dispose")
+    @Bean(value = BEAN_HANDLER_BASE_CONNECTION_POOL, destroyMethod = "dispose")
     public ConnectionProvider handlerBaseConnectionPool() {
 
         return ConnectionProvider.builder(POOL_NAME)


### PR DESCRIPTION
### Motivation
- Устранить неоднозначность и повысить читаемость конфигураций handler web, заменив общий `BEAN_NAME` на конкретные имена для каждого бина.

### Description
- В `HandlerBaseWebClientConfig` константа `BEAN_NAME` переименована в `BEAN_HANDLER_BASE_WEB_CLIENT` и соответствующие аннотации `@Bean`/`@Qualifier` обновлены на использование новой константы (файл `backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/HandlerBaseWebClientConfig.java`).
- В `HandlerBaseHttpClientConfig` константа `BEAN_NAME` переименована в `BEAN_HANDLER_BASE_HTTP_CLIENT` и обновлены ссылки в `@Bean`/`@Qualifier` (файл `backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/http/HandlerBaseHttpClientConfig.java`).
- В `HandlerBaseConnectionPoolConfig` константа `BEAN_NAME` переименована в `BEAN_HANDLER_BASE_CONNECTION_POOL` и обновлён `@Bean(value = ...)` (файл `backend/src/main/java/com/alligator/market/backend/provider/infra/handler/web/http/tcp/HandlerBaseConnectionPoolConfig.java`).
- Обновлена внешняя ссылка на переименованную константу в `MoexIssFxSpotWebClientConfig` на `HandlerBaseWebClientConfig.BEAN_HANDLER_BASE_WEB_CLIENT` (файл `backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/instrument/forex/spot/web/MoexIssFxSpotWebClientConfig.java`).

### Testing
- Выполнен поиск по проекту для обнаружения старых/новых констант через `rg`, подтверждена замена и отсутствие оставшихся ссылок на старые `BEAN_NAME` в обрабатываемой области; результат — успешно.
- Попытка компиляции модуля backend через `mvn -pl backend -DskipTests compile` завершилась неудачей из-за ограничений окружения (загрузка родительского POM из Maven Central вернула `403 Forbidden`), поэтому полная сборка в этом окружении не была завершена.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699703c81074832db6d04e2ac01dd102)