### PR TITLE
Использовать ProviderRegistry в проекции паспортов провайдеров

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/maintenance/config/projection/db/passport/service/ProviderPassportDbProjectionConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/maintenance/config/projection/db/passport/service/ProviderPassportDbProjectionConfig.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.provider.maintenance.config.projection.db.passport.service;
 
-import com.alligator.market.backend.provider.maintenance.config.scanner.context.ProviderContextScannerConfig;
+import com.alligator.market.backend.provider.registry.wiring.ProviderRegistryWiringConfig;
 import com.alligator.market.backend.provider.maintenance.config.projection.db.passport.dao.ProviderPassportDbProjectionDaoConfig;
-import com.alligator.market.domain.provider.registry.passport.ProviderPassportRegistry;
+import com.alligator.market.domain.provider.registry.ProviderRegistry;
 import com.alligator.market.domain.provider.maintenance.projection.db.passport.dao.ProviderPassportDbProjectionDao;
 import com.alligator.market.domain.provider.maintenance.projection.db.passport.service.ProviderPassportDbProjection;
 import com.alligator.market.domain.provider.readmodel.store.passport.ProviderPassportReadModelStore;
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration(proxyBeanMethods = false)
 @Import({
-        ProviderContextScannerConfig.class,
+        ProviderRegistryWiringConfig.class,
         ProviderPassportDbProjectionDaoConfig.class
 })
 public class ProviderPassportDbProjectionConfig {
@@ -28,12 +28,12 @@ public class ProviderPassportDbProjectionConfig {
      */
     @Bean(BEAN_PROVIDER_PASSPORT_DB_PROJECTION)
     public ProviderPassportDbProjection providerPassportDbProjection(
-            @Qualifier(ProviderContextScannerConfig.BEAN_PROVIDER_CONTEXT_SCANNER)
-            ProviderPassportRegistry scanner,
+            @Qualifier(ProviderRegistryWiringConfig.BEAN_PROVIDER_REGISTRY)
+            ProviderRegistry providerRegistry,
             ProviderPassportReadModelStore repository,
             @Qualifier(ProviderPassportDbProjectionDaoConfig.BEAN_PROVIDER_PASSPORT_DB_PROJECTION_DAO)
             ProviderPassportDbProjectionDao projectionDao
     ) {
-        return new ProviderPassportDbProjection(scanner, repository, projectionDao);
+        return new ProviderPassportDbProjection(providerRegistry, repository, projectionDao);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/service/ProviderPassportDbProjection.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/service/ProviderPassportDbProjection.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.provider.maintenance.projection.db.passport.
 
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
 import com.alligator.market.domain.provider.maintenance.projection.db.passport.dao.ProviderPassportDbProjectionDao;
-import com.alligator.market.domain.provider.registry.passport.ProviderPassportRegistry;
+import com.alligator.market.domain.provider.registry.ProviderRegistry;
 import com.alligator.market.domain.provider.readmodel.store.passport.ProviderPassportReadModelStore;
 
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
@@ -18,7 +18,7 @@ import java.util.Set;
  * <p><b>Логика</b></p>
  * <ul>
  *     <li>Источник истины — контекст приложения.</li>
- *     <li>{@link ProviderPassportRegistry} извлекает из контекста приложения паспорта провайдеров, индексированные
+ *     <li>{@link ProviderRegistry} извлекает из контекста приложения паспорта провайдеров, индексированные
  *     по коду провайдера.</li>
  *     <li>{@link ProviderPassportReadModelStore} извлекает коды провайдеров, для которых в БД есть паспорта.</li>
  *     <li>{@link ProviderPassportDbProjectionDao} пакетно удаляет из БД паспорта, соответствующие устаревшим
@@ -38,7 +38,7 @@ import java.util.Set;
 public class ProviderPassportDbProjection {
 
     /* Сканер контекста. */
-    private final ProviderPassportRegistry contextScanner;
+    private final ProviderRegistry providerRegistry;
 
     /* Репозиторий паспортов. */
     private final ProviderPassportReadModelStore repository;
@@ -47,14 +47,14 @@ public class ProviderPassportDbProjection {
     private final ProviderPassportDbProjectionDao projectionDao;
 
     /* Конструктор. */
-    public ProviderPassportDbProjection(ProviderPassportRegistry contextScanner,
+    public ProviderPassportDbProjection(ProviderRegistry providerRegistry,
                                         ProviderPassportReadModelStore repository,
                                         ProviderPassportDbProjectionDao projectionDao) {
-        Objects.requireNonNull(contextScanner, "contextScanner must not be null");
+        Objects.requireNonNull(providerRegistry, "providerRegistry must not be null");
         Objects.requireNonNull(repository, "repository must not be null");
         Objects.requireNonNull(projectionDao, "projectionDao must not be null");
 
-        this.contextScanner = contextScanner;
+        this.providerRegistry = providerRegistry;
         this.repository = repository;
         this.projectionDao = projectionDao;
     }
@@ -64,7 +64,7 @@ public class ProviderPassportDbProjection {
      */
     public void refresh() {
         // 1) Извлекаем мапу с паспортами из контекста (индексация по кодам провайдеров)
-        Map<ProviderCode, ProviderPassport> ctxPassports = contextScanner.passportsByCode();
+        Map<ProviderCode, ProviderPassport> ctxPassports = providerRegistry.passportsByCode();
         // 2) Извлекаем коды провайдеров для хранящихся в БД паспортов
         Set<ProviderCode> dbProviderCodes = new LinkedHashSet<>(repository.findAllCodes());
 


### PR DESCRIPTION
### Motivation
- Упростить и унифицировать источник данных для проекции паспортов, используя общий реестр провайдеров вместо специализированного интерфейса сканера контекста.

### Description
- В `ProviderPassportDbProjection` заменён импорт и зависимость с `ProviderPassportRegistry` на `ProviderRegistry`, включая поле, аргумент конструктора и проверку `Objects.requireNonNull`.
- Обновлён JavaDoc сервисa, где теперь упоминается `ProviderRegistry` как источник паспортов.
- В методе `refresh()` вызов получения паспортов изменён с `contextScanner.passportsByCode()` на `providerRegistry.passportsByCode()`.
- Обновлён Spring wiring в `ProviderPassportDbProjectionConfig`, где импортируется `ProviderRegistryWiringConfig`, метод бина принимает `ProviderRegistry` с соответствующим `@Qualifier` и передаёт его в конструктор сервиса.

### Testing
- Попытка локальной сборки `./mvnw -q -DskipTests compile` была выполнена, но не завершилась успешно из-за невозможности скачать Maven дистрибутив с `repo.maven.apache.org` в текущем окружении.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69994b7d8b70832db40535583549bc06)