### PR TITLE
refactor(provider): introduce readmodel write store port

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/dao/ProviderPassportDbProjectionDao.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/dao/ProviderPassportDbProjectionDao.java
@@ -1,25 +1,11 @@
 package com.alligator.market.domain.provider.maintenance.projection.db.passport.dao;
 
-import com.alligator.market.domain.provider.model.vo.ProviderCode;
-import com.alligator.market.domain.provider.model.passport.ProviderPassport;
-
-import java.util.Collection;
-import java.util.Map;
+import com.alligator.market.domain.provider.readmodel.store.passport.ProviderPassportReadModelWriteStore;
 
 /**
- * DAO прямых пакетных операций с паспортами провайдеров в БД.
+ * Legacy alias.
  *
- * <p>Используется процессом проекции паспортов провайдеров из контекста приложения в БД.</p>
+ * <p>В домене используем более общий термин readmodel-store. Этот интерфейс будет удалён на следующих шагах.</p>
  */
-public interface ProviderPassportDbProjectionDao {
-
-    /**
-     * Пакетное удаление (DELETE) паспортов по их кодам.
-     */
-    void deleteByCodes(Collection<ProviderCode> codes);
-
-    /**
-     * Пакетная вставка или обновление (UPSERT) паспортов.
-     */
-    void upsertAll(Map<ProviderCode, ProviderPassport> passports);
+public interface ProviderPassportDbProjectionDao extends ProviderPassportReadModelWriteStore {
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/service/ProviderPassportDbProjection.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/service/ProviderPassportDbProjection.java
@@ -1,9 +1,9 @@
 package com.alligator.market.domain.provider.maintenance.projection.db.passport.service;
 
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
-import com.alligator.market.domain.provider.maintenance.projection.db.passport.dao.ProviderPassportDbProjectionDao;
 import com.alligator.market.domain.provider.registry.ProviderRegistry;
 import com.alligator.market.domain.provider.readmodel.store.passport.ProviderPassportReadModelStore;
+import com.alligator.market.domain.provider.readmodel.store.passport.ProviderPassportReadModelWriteStore;
 
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 
@@ -21,17 +21,17 @@ import java.util.Set;
  *     <li>{@link ProviderRegistry} извлекает из контекста приложения паспорта провайдеров, индексированные
  *     по коду провайдера.</li>
  *     <li>{@link ProviderPassportReadModelStore} извлекает коды провайдеров, для которых в БД есть паспорта.</li>
- *     <li>{@link ProviderPassportDbProjectionDao} пакетно удаляет из БД паспорта, соответствующие устаревшим
+ *     <li>{@link ProviderPassportReadModelWriteStore} пакетно удаляет из БД паспорта, соответствующие устаревшим
  *     кодам провайдеров.</li>
- *     <li>{@link ProviderPassportDbProjectionDao} осуществляет пакетный UPSERT паспортов из контекста.</li>
+ *     <li>{@link ProviderPassportReadModelWriteStore} осуществляет пакетный UPSERT паспортов из контекста.</li>
  * </ul>
  *
- * <p><b>Преимущества применения DAO:</b></p>
+ * <p><b>Преимущества пакетной записи:</b></p>
  * <ul>
  *     <li>Минимум обращений к БД → меньше сетевых задержек и нагрузка на пул соединений.</li>
  *     <li>Прямой UPSERT/DELETE без ORM-накладных расходов → быстрее и проще предсказать нагрузку.</li>
  *     <li>Стабильная атомарность операции → все изменения выполняются единым набором пакетных команд.</li>
- *     <li>Единый контракт DAO → легче поддерживать и масштабировать процесс.</li>
+ *     <li>Единый контракт write-store → легче поддерживать и масштабировать процесс.</li>
  * </ul>
  */
 @SuppressWarnings("ClassCanBeRecord")
@@ -43,20 +43,20 @@ public class ProviderPassportDbProjection {
     /* Репозиторий паспортов. */
     private final ProviderPassportReadModelStore repository;
 
-    /* DAO для прямых пакетных операций с паспортами. */
-    private final ProviderPassportDbProjectionDao projectionDao;
+    /* Порт записи read model паспортов. */
+    private final ProviderPassportReadModelWriteStore writeStore;
 
     /* Конструктор. */
     public ProviderPassportDbProjection(ProviderRegistry providerRegistry,
                                         ProviderPassportReadModelStore repository,
-                                        ProviderPassportDbProjectionDao projectionDao) {
+                                        ProviderPassportReadModelWriteStore writeStore) {
         Objects.requireNonNull(providerRegistry, "providerRegistry must not be null");
         Objects.requireNonNull(repository, "repository must not be null");
-        Objects.requireNonNull(projectionDao, "projectionDao must not be null");
+        Objects.requireNonNull(writeStore, "writeStore must not be null");
 
         this.providerRegistry = providerRegistry;
         this.repository = repository;
-        this.projectionDao = projectionDao;
+        this.writeStore = writeStore;
     }
 
     /**
@@ -71,7 +71,7 @@ public class ProviderPassportDbProjection {
         // Если в контексте пусто — чистим таблицу и выходим
         if (ctxPassports.isEmpty()) {
             if (!dbProviderCodes.isEmpty()) {
-                projectionDao.deleteByCodes(dbProviderCodes);
+                writeStore.deleteByCodes(dbProviderCodes);
             }
             return;
         }
@@ -80,11 +80,11 @@ public class ProviderPassportDbProjection {
         Set<ProviderCode> obsolete = new LinkedHashSet<>(dbProviderCodes);
         obsolete.removeAll(ctxPassports.keySet());
         if (!obsolete.isEmpty()) {
-            projectionDao.deleteByCodes(obsolete);
+            writeStore.deleteByCodes(obsolete);
         }
 
         // 4) UPSERT всех паспортов из контекста (новые/изменившиеся обновятся, актуальные — без изменений)
-        projectionDao.upsertAll(ctxPassports);
+        writeStore.upsertAll(ctxPassports);
         // Готово
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/readmodel/store/passport/ProviderPassportReadModelWriteStore.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/readmodel/store/passport/ProviderPassportReadModelWriteStore.java
@@ -1,0 +1,25 @@
+package com.alligator.market.domain.provider.readmodel.store.passport;
+
+import com.alligator.market.domain.provider.model.passport.ProviderPassport;
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Хранилище read model паспортов провайдеров (операции записи).
+ *
+ * <p>Это доменная абстракция: конкретная реализация может быть через JDBC/JPA/файл/кэш и т.п.</p>
+ */
+public interface ProviderPassportReadModelWriteStore {
+
+    /**
+     * Удалить паспорта по кодам провайдеров.
+     */
+    void deleteByCodes(Collection<ProviderCode> codes);
+
+    /**
+     * Сохранить паспорта (insert или update).
+     */
+    void upsertAll(Map<ProviderCode, ProviderPassport> passports);
+}


### PR DESCRIPTION
### Motivation

- Ввести доменный «порт» для записи read-model паспортов провайдеров, чтобы убрать упоминание DAO в домене и задать более общий контракт для будущих реализаций.
- Сохранить обратную совместимость с текущими реализациями через легаси-алиас, чтобы изменения были атомарными и безопасными.

### Description

- Добавлен новый интерфейс `ProviderPassportReadModelWriteStore` для операций записи (`deleteByCodes`, `upsertAll`) в `domain/src/main/java/com/alligator/market/domain/provider/readmodel/store/passport/ProviderPassportReadModelWriteStore.java`.
- Превращён `ProviderPassportDbProjectionDao` в тонкий алиас, который `extends ProviderPassportReadModelWriteStore` в `domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/dao/ProviderPassportDbProjectionDao.java`.
- Переведён `ProviderPassportDbProjection` на зависимость от порта записи: заменено поле/параметр конструктора и все вызовы `deleteByCodes`/`upsertAll` на использование `writeStore` в `domain/src/main/java/com/alligator/market/domain/provider/maintenance/projection/db/passport/service/ProviderPassportDbProjection.java`.

### Testing

- Попытка скомпилировать модуль `domain` командой `./mvnw -pl domain -DskipTests compile` завершилась ошибкой из-за окружения и проблем с загрузкой зависимостей (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).
- Никакие автоматизированные тесты проекта не запускались из-за ограничений окружения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699954110500832db14df9837b445119)