### PR TITLE
Рефакторинг поиска обработчика в AbstractMarketDataProvider#quote

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
@@ -108,21 +108,31 @@ public abstract non-sealed class AbstractMarketDataProvider<P extends MarketData
     public final <I extends Instrument> Publisher<QuoteTick> quote(I instrument) {
         Objects.requireNonNull(instrument, "instrument must not be null");
 
-        // Извлекаем код инструмента
-        InstrumentCode code = Objects.requireNonNull(instrument.instrumentCode(),
-                "instrumentCode must not be null");
+        // Находим обработчик (или бросаем исключение)
+        InstrumentHandler<P, I> handler = findHandlerOrThrow(instrument);
 
-        // Используем карту для поиска обработчика
-        @SuppressWarnings("unchecked")
-        InstrumentHandler<P, I> handler = (InstrumentHandler<P, I>) instrumentHandlerMap.get(code);
+        // Делегируем вызов обработчику
+        return handler.quote(instrument);
+    }
 
-        // Если обработчик не найден, значит инструмент не поддерживается провайдером
+    /* Ищет обработчик инструмента или бросает исключение. */
+    @SuppressWarnings("unchecked")
+    protected final <I extends Instrument> InstrumentHandler<P, I> findHandlerOrThrow(I instrument) {
+        Objects.requireNonNull(instrument, "instrument must not be null");
+
+        InstrumentCode code = Objects.requireNonNull(
+                instrument.instrumentCode(),
+                "instrumentCode must not be null"
+        );
+
+        InstrumentHandler<P, I> handler =
+                (InstrumentHandler<P, I>) instrumentHandlerMap.get(code);
+
         if (handler == null) {
             throw new HandlerNotFoundException(code, providerCode);
         }
 
-        // Делегируем вызов обработчику
-        return handler.quote(instrument);
+        return handler;
     }
 
     //=================================================================================================================


### PR DESCRIPTION
### Motivation
- Упростить и унифицировать поток вызова в `AbstractMarketDataProvider#quote` через вынос логики поиска обработчика в отдельный метод для повышения читаемости и повторного использования.

### Description
- Вынесена логика поиска обработчика в защищённый метод `findHandlerOrThrow(...)` и заменён прямой доступ к карте в `quote(...)` на вызов этого метода при сохранении существующей проверки `null` и поведения с `HandlerNotFoundException`.

### Testing
- Запуск `./mvnw -pl domain test -q` завершился неудачей в этой среде из‑за невозможности загрузить Maven distribution (`apache-maven-3.9.9-bin.zip`).
- Запуск `mvn -pl domain test -q` также не прошёл из‑за ошибки доступа к Maven Central (HTTP 403 при загрузке parent POM `org.springframework.boot:spring-boot-starter-parent:3.4.5`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ab05e34c832dbcf2070f45c7c128)