### PR TITLE
Добавить доменное исключение для пустого ProviderRegistry

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 public enum DomainErrorCode {
 
     /* Провайдеры: */
+    PROVIDER_REGISTRY_EMPTY(DomainErrorType.BAD_REQUEST),
     PROVIDER_CODE_DUPLICATE(DomainErrorType.CONFLICT),
     PROVIDER_DISPLAY_NAME_DUPLICATE(DomainErrorType.CONFLICT),
     HANDLER_NOT_FOUND(DomainErrorType.NOT_FOUND),

--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderRegistryEmptyException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/ProviderRegistryEmptyException.java
@@ -1,0 +1,29 @@
+package com.alligator.market.domain.provider.exception;
+
+import com.alligator.market.domain.common.exception.BaseDomainException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
+
+/**
+ * Пустой реестр провайдеров.
+ */
+public final class ProviderRegistryEmptyException extends BaseDomainException {
+
+    /**
+     * Создает исключение.
+     */
+    public ProviderRegistryEmptyException() {
+        super(DomainErrorCode.PROVIDER_REGISTRY_EMPTY, "Provider registry must contain at least one provider");
+    }
+
+    /**
+     * Создает исключение с причиной.
+     *
+     * @param cause причина ошибки
+     */
+    @SuppressWarnings("unused")
+    public ProviderRegistryEmptyException(Throwable cause) {
+        super(DomainErrorCode.PROVIDER_REGISTRY_EMPTY,
+                "Provider registry must contain at least one provider",
+                cause);
+    }
+}

--- a/domain/src/main/java/com/alligator/market/domain/provider/registry/SnapshotProviderRegistry.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/registry/SnapshotProviderRegistry.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.provider.registry;
 
 import com.alligator.market.domain.provider.exception.ProviderCodeDuplicateException;
+import com.alligator.market.domain.provider.exception.ProviderRegistryEmptyException;
 import com.alligator.market.domain.provider.exception.ProviderDisplayNameDuplicateException;
 import com.alligator.market.domain.provider.model.MarketDataProvider;
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
@@ -33,7 +34,7 @@ public final class SnapshotProviderRegistry implements ProviderRegistry {
         Objects.requireNonNull(providers, "providers must not be null");
 
         if (providers.isEmpty()) {
-            throw new IllegalArgumentException("providers must not be empty");
+            throw new ProviderRegistryEmptyException();
         }
 
         Map<ProviderCode, MarketDataProvider> providersMap = new LinkedHashMap<>();


### PR DESCRIPTION
### Motivation
- Сделать ошибку пустого реестра провайдеров частью доменной модели и унифицировать обработку ошибок через `BaseDomainException` + `DomainErrorCode`.
- Заменить общее `IllegalArgumentException` на доменное исключение для более явной семантики и кодирования ошибки.

### Description
- Добавлен код ошибки `PROVIDER_REGISTRY_EMPTY` в `DomainErrorCode`.
- Добавлен класс `ProviderRegistryEmptyException` в пакет `domain.provider.exception`, унаследованный от `BaseDomainException` и использующий `DomainErrorCode.PROVIDER_REGISTRY_EMPTY`.
- В `SnapshotProviderRegistry` заменено `throw new IllegalArgumentException("providers must not be empty")` на `throw new ProviderRegistryEmptyException()`.

### Testing
- Запуск `./mvnw -pl domain test -DskipITs` не удался из-за ошибки загрузки дистрибутива Maven (`Failed to fetch apache-maven-3.9.9-bin.zip`), поэтому тесты не выполнены.
- Запуск `mvn -pl domain test -DskipITs` не удался из-за `403 Forbidden` при резолве parent POM с Maven Central, поэтому автоматические тесты не прошли.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf3903110832d8e19d67e60bdbbc2)