### PR TITLE
Enforce non-empty provider registry invariant and tighten projection write-port

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/store/write/jdbc/ProviderPassportProjectionWriteStoreJdbcAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/store/write/jdbc/ProviderPassportProjectionWriteStoreJdbcAdapter.java
@@ -25,8 +25,6 @@ import java.util.*;
  */
 public class ProviderPassportProjectionWriteStoreJdbcAdapter implements ProviderPassportProjectionWriteStore {
     
-    private static final String SQL_DELETE_ALL = "DELETE FROM provider_passport";
-
     // PostgreSQL: "<> ALL (array)" эквивалентно "NOT IN (...)".
     private static final String SQL_DELETE_ALL_EXCEPT = """
             DELETE FROM provider_passport
@@ -72,23 +70,17 @@ public class ProviderPassportProjectionWriteStoreJdbcAdapter implements Provider
     }
 
     @Override
-    public void deleteAll() {
-        jdbc.update(SQL_DELETE_ALL);
-    }
-
-    @Override
     public void deleteAllExcept(Set<ProviderCode> activeCodes) {
         if (activeCodes == null) {
             throw new IllegalArgumentException("activeCodes must not be null");
+        }
+        if (activeCodes.isEmpty()) {
+            throw new IllegalArgumentException("activeCodes must not be empty");
         }
         for (ProviderCode code : activeCodes) {
             if (code == null) {
                 throw new IllegalArgumentException("activeCodes must not contain null");
             }
-        }
-        if (activeCodes.isEmpty()) {
-            deleteAll();
-            return;
         }
 
         // Передаём набор кодов в PostgreSQL как массив (быстрее и чище, чем динамический IN (...)).

--- a/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/projection/ProviderPassportProjector.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/projection/ProviderPassportProjector.java
@@ -1,6 +1,7 @@
 package com.alligator.market.domain.provider.readmodel.passport.projection;
 
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
+import com.alligator.market.domain.provider.exception.ProviderRegistryEmptyException;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.provider.readmodel.passport.store.ProviderPassportProjectionWriteStore;
 import com.alligator.market.domain.provider.registry.ProviderRegistry;
@@ -43,10 +44,9 @@ public class ProviderPassportProjector {
                 Objects.requireNonNull(providerRegistry.passportsByCode(), "passportsByCode must not be null")
         );
 
-        // Реестр пуст -> проекция должна быть пустой.
+        // Инвариант доменной модели: реестр активных провайдеров не бывает пустым.
         if (registryPassports.isEmpty()) {
-            writeStore.deleteAll();
-            return;
+            throw new ProviderRegistryEmptyException();
         }
 
         Set<ProviderCode> activeCodes = Set.copyOf(registryPassports.keySet());

--- a/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/store/ProviderPassportProjectionWriteStore.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/store/ProviderPassportProjectionWriteStore.java
@@ -17,8 +17,7 @@ import java.util.Set;
  *
  * <p>Типовой сценарий синхронизации:</p>
  * <ul>
- *   <li>Если реестр пуст — {@link #deleteAll()};</li>
- *   <li>Иначе — {@link #deleteAllExcept(Set)} и затем {@link #upsertAll(Map)}.</li>
+ *   <li>{@link #deleteAllExcept(Set)} и затем {@link #upsertAll(Map)}.</li>
  * </ul>
  *
  * <p>Примечания:</p>
@@ -31,13 +30,6 @@ import java.util.Set;
 public interface ProviderPassportProjectionWriteStore {
 
     /**
-     * Удалить все записи проекции.
-     *
-     * <p>Операция идемпотентна.</p>
-     */
-    void deleteAll();
-
-    /**
      * Удалить все записи проекции, кроме указанных кодов провайдеров.
      *
      * <p>Семантика: после успешного выполнения в проекции остаются записи только для кодов из {@code activeCodes}.</p>
@@ -45,11 +37,10 @@ public interface ProviderPassportProjectionWriteStore {
      * <p>Требования:</p>
      * <ul>
      *   <li>{@code activeCodes} не {@code null};</li>
+     *   <li>{@code activeCodes} не пуст;</li>
      *   <li>{@code activeCodes} не содержит {@code null}-элементов;</li>
      *   <li>Операция идемпотентна относительно множества {@code activeCodes} (порядок элементов не важен).</li>
      * </ul>
-     *
-     * <p>Если {@code activeCodes} пуст, операция эквивалентна {@link #deleteAll()}.</p>
      *
      * @param activeCodes коды активных провайдеров
      */


### PR DESCRIPTION
### Motivation

- Упростить контракт write-порта проекции: модель реестра не может быть пустой, поэтому операция «удалить всё» не нужна и расширяет API без пользы.
- Защитить проектор от нарушения доменного инварианта — явное падение при пустом реестре лучше скрытого побочного поведения.
- Сделать JDBC-адаптер более строгим и безопасным — не допускать передачи пустого набора `activeCodes` и убрать «опасный» SQL `DELETE ALL`.

### Description

- Интерфейс `ProviderPassportProjectionWriteStore` изменён: удалён метод `deleteAll()` и в документации зафиксировано требование, что `deleteAllExcept(Set)` принимает `activeCodes`, который не может быть пустым (и не может содержать `null`).
- `ProviderPassportProjector` теперь явно проверяет результат `providerRegistry.passportsByCode()` и при пустом реестре бросает доменное исключение `ProviderRegistryEmptyException` вместо вызова очистки проекции.
- JDBC-адаптер `ProviderPassportProjectionWriteStoreJdbcAdapter` очищён от `SQL_DELETE_ALL` и реализации `deleteAll()`, а метод `deleteAllExcept(...)` усилил валидацию: проверка на `null`, на пустоту и на отсутствие `null`-элементов, и использует один запрос с PostgreSQL array для удаления.
- Документация и комментарии в коде обновлены, поведение синхронизации описано как `upsertAll(...)` затем `deleteAllExcept(activeCodes)` с инвариантом непустого реестра.

### Testing

- Попытка сборки (без тестов) выполнена командой `./mvnw -DskipTests compile`, но в этой среде bootstrap Maven не удался из-за сетевой/загрузочной ошибки (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`), поэтому полноценная компиляция в CI не была завершена.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc80987c0832d97bcb2f97c3d23ed)