### PR TITLE
Добавить wiring-конфиг для ProviderPassportProjectionWriteStore

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/store/ProviderPassportProjectionWriteStoreWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/store/ProviderPassportProjectionWriteStoreWiringConfig.java
@@ -1,0 +1,25 @@
+package com.alligator.market.backend.provider.readmodel.passport.config.store;
+
+import com.alligator.market.backend.provider.readmodel.passport.store.ProviderPassportProjectionWriteStoreJdbcAdapter;
+import com.alligator.market.domain.provider.readmodel.passport.store.ProviderPassportProjectionWriteStore;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Конфигурация wiring write-порта {@link ProviderPassportProjectionWriteStore}.
+ */
+@Configuration(proxyBeanMethods = false)
+public class ProviderPassportProjectionWriteStoreWiringConfig {
+
+    public static final String BEAN_PROVIDER_PASSPORT_PROJECTION_WRITE_STORE =
+            "providerPassportProjectionWriteStore";
+
+    /**
+     * JDBC-реализация write-порта проекции паспортов провайдеров.
+     */
+    @Bean(BEAN_PROVIDER_PASSPORT_PROJECTION_WRITE_STORE)
+    public ProviderPassportProjectionWriteStore providerPassportProjectionWriteStore(JdbcTemplate jdbcTemplate) {
+        return new ProviderPassportProjectionWriteStoreJdbcAdapter(jdbcTemplate);
+    }
+}


### PR DESCRIPTION
### Motivation
- Обеспечить явное Spring wiring для write-порта проекции паспортов провайдеров чтобы оставить контракт `ProviderPassportProjectionWriteStore` внедрённым как бин в контейнере.

### Description
- Добавлен класс `ProviderPassportProjectionWriteStoreWiringConfig` в `backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/store`, который регистрирует именованный бин `providerPassportProjectionWriteStore` и создаёт его через `ProviderPassportProjectionWriteStoreJdbcAdapter` с помощью `JdbcTemplate`.

### Testing
- Попытки сборки модуля через `./mvnw -pl backend -DskipTests compile` и `mvn -pl backend -DskipTests compile` были выполнены, но обе завершились ошибкой разрешения зависимостей из Maven Central (403), поэтому автоматические сборочные проверки не прошли.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfc085028832d8a08ddc995aa7a06)