### PR TITLE
Добавить wiring для ProviderPassportProjector

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/ProviderPassportProjectorWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/ProviderPassportProjectorWiringConfig.java
@@ -1,0 +1,27 @@
+package com.alligator.market.backend.provider.readmodel.passport.config.projection;
+
+import com.alligator.market.domain.provider.readmodel.passport.projection.ProviderPassportProjector;
+import com.alligator.market.domain.provider.readmodel.passport.store.ProviderPassportProjectionWriteStore;
+import com.alligator.market.domain.provider.registry.ProviderRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация wiring доменного {@link ProviderPassportProjector}.
+ */
+@Configuration(proxyBeanMethods = false)
+public class ProviderPassportProjectorWiringConfig {
+
+    public static final String BEAN_PROVIDER_PASSPORT_PROJECTOR = "providerPassportProjector";
+
+    /**
+     * Доменный projector паспортов провайдеров без дополнительного adapter-слоя.
+     */
+    @Bean(BEAN_PROVIDER_PASSPORT_PROJECTOR)
+    public ProviderPassportProjector providerPassportProjector(
+            ProviderRegistry providerRegistry,
+            ProviderPassportProjectionWriteStore writeStore
+    ) {
+        return new ProviderPassportProjector(providerRegistry, writeStore);
+    }
+}


### PR DESCRIPTION
### Motivation
- ProviderPassportProjector — простой доменный projector, для которого достаточно прямого Spring-wiring без дополнительного adapter-слоя, что упрощает конфигурацию и остаётся легко расширяемым в будущем.

### Description
- Добавлен конфигурационный класс `ProviderPassportProjectorWiringConfig` в `backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection`, регистрирующий bean `providerPassportProjector`, который напрямую создаёт `ProviderPassportProjector` из `ProviderRegistry` и `ProviderPassportProjectionWriteStore` без промежуточного адаптера.

### Testing
- Попытка запустить `./mvnw -pl backend -am -DskipTests compile` зафейлилась на этапе бутстрапа Maven из-за ошибки загрузки дистрибутива (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`), поэтому автоматическая сборка/компиляция в этом окружении не прошла.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0172e5e8832d93e6ef32255ef2e4)