### PR TITLE
Вынес транзакционной рамки проекции паспортов провайдеров в отдельный сервис

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/ProviderPassportProjectionServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/ProviderPassportProjectionServiceWiringConfig.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.provider.readmodel.passport.config.projection;
+
+import com.alligator.market.backend.provider.readmodel.passport.projection.service.ProviderPassportProjectionService;
+import com.alligator.market.domain.provider.readmodel.passport.projection.ProviderPassportProjector;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/* Wiring use case сервиса проекции. */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        ProviderPassportProjectorWiringConfig.class
+})
+public class ProviderPassportProjectionServiceWiringConfig {
+
+    public static final String BEAN_PROVIDER_PASSPORT_PROJECTION_SERVICE =
+            "providerPassportProjectionService";
+
+    /* Use case сервис проекции паспортов провайдеров. */
+    @Bean(BEAN_PROVIDER_PASSPORT_PROJECTION_SERVICE)
+    public ProviderPassportProjectionService providerPassportProjectionService(
+            ProviderPassportProjector projector,
+            PlatformTransactionManager txManager
+    ) {
+        return new ProviderPassportProjectionService(projector, new TransactionTemplate(txManager));
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
@@ -1,20 +1,24 @@
-package com.alligator.market.backend.provider.readmodel.passport.config.startup;
+package com.alligator.market.backend.provider.readmodel.passport.config.projection.startup;
 
-import com.alligator.market.backend.provider.readmodel.passport.startup.ProviderPassportProjectionStartupRunner;
-import com.alligator.market.domain.provider.readmodel.passport.projection.ProviderPassportProjector;
+import com.alligator.market.backend.provider.readmodel.passport.config.projection.ProviderPassportProjectionServiceWiringConfig;
+import com.alligator.market.backend.provider.readmodel.passport.projection.service.ProviderPassportProjectionService;
+import com.alligator.market.backend.provider.readmodel.passport.projection.startup.ProviderPassportProjectionStartupRunner;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Конфигурация wiring startup-runner для проекции паспортов провайдеров.
  */
 @Configuration(proxyBeanMethods = false)
+@Import({
+        ProviderPassportProjectionServiceWiringConfig.class
+})
 public class ProviderPassportProjectionStartupRunnerWiringConfig {
 
     public static final String BEAN_PROVIDER_PASSPORT_PROJECTION_STARTUP_RUNNER =
@@ -25,16 +29,15 @@ public class ProviderPassportProjectionStartupRunnerWiringConfig {
      */
     @Bean(BEAN_PROVIDER_PASSPORT_PROJECTION_STARTUP_RUNNER)
     @Order(Ordered.LOWEST_PRECEDENCE)
-    @ConditionalOnBean({ProviderPassportProjector.class, TransactionTemplate.class})
+    @ConditionalOnBean(ProviderPassportProjectionService.class)
     @ConditionalOnProperty(
             name = "provider.passport.projection.startup.enabled",
             havingValue = "true",
             matchIfMissing = true
     )
     public ApplicationRunner providerPassportProjectionStartupRunner(
-            ProviderPassportProjector projector,
-            TransactionTemplate tx
+            ProviderPassportProjectionService service
     ) {
-        return new ProviderPassportProjectionStartupRunner(projector, tx);
+        return new ProviderPassportProjectionStartupRunner(service);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/service/ProviderPassportProjectionService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/service/ProviderPassportProjectionService.java
@@ -1,0 +1,32 @@
+package com.alligator.market.backend.provider.readmodel.passport.projection.service;
+
+import com.alligator.market.domain.provider.readmodel.passport.projection.ProviderPassportProjector;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Objects;
+
+/**
+ * Use case: построить/обновить проекцию паспортов провайдеров.
+ *
+ * <p>Здесь задаётся граница транзакции для доменного процесса проекции.</p>
+ */
+public final class ProviderPassportProjectionService {
+
+    private final ProviderPassportProjector projector;
+    private final TransactionTemplate tx;
+
+    public ProviderPassportProjectionService(
+            ProviderPassportProjector projector,
+            TransactionTemplate tx
+    ) {
+        this.projector = Objects.requireNonNull(projector, "projector must not be null");
+        this.tx = Objects.requireNonNull(tx, "tx must not be null");
+    }
+
+    /**
+     * Выполнить проекцию атомарно.
+     */
+    public void project() {
+        tx.executeWithoutResult(status -> projector.project());
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/startup/ProviderPassportProjectionStartupRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/startup/ProviderPassportProjectionStartupRunner.java
@@ -1,10 +1,9 @@
-package com.alligator.market.backend.provider.readmodel.passport.startup;
+package com.alligator.market.backend.provider.readmodel.passport.projection.startup;
 
-import com.alligator.market.domain.provider.readmodel.passport.projection.ProviderPassportProjector;
+import com.alligator.market.backend.provider.readmodel.passport.projection.service.ProviderPassportProjectionService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Objects;
 
@@ -14,15 +13,10 @@ import java.util.Objects;
 @Slf4j
 public final class ProviderPassportProjectionStartupRunner implements ApplicationRunner {
 
-    private final ProviderPassportProjector projector;
-    private final TransactionTemplate tx;
+    private final ProviderPassportProjectionService service;
 
-    public ProviderPassportProjectionStartupRunner(
-            ProviderPassportProjector projector,
-            TransactionTemplate tx
-    ) {
-        this.projector = Objects.requireNonNull(projector, "projector must not be null");
-        this.tx = Objects.requireNonNull(tx, "tx must not be null");
+    public ProviderPassportProjectionStartupRunner(ProviderPassportProjectionService service) {
+        this.service = Objects.requireNonNull(service, "service must not be null");
     }
 
     @Override
@@ -30,7 +24,7 @@ public final class ProviderPassportProjectionStartupRunner implements Applicatio
         log.info("Provider passport projection started");
 
         try {
-            tx.executeWithoutResult(status -> projector.project());
+            service.project();
             log.info("Provider passport projection finished");
         } catch (RuntimeException ex) {
             log.error("Provider passport projection failed", ex);

--- a/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/projection/ProviderPassportProjector.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/projection/ProviderPassportProjector.java
@@ -15,7 +15,7 @@ import java.util.Set;
  *
  * <p>Источник истины — реестр. Результат выполнения {@link #project()} — проекция, эквивалентная реестру.</p>
  *
- * <p>Рекомендуется выполнять вызов атомарно на стороне приложения (например, в транзакции).</p>
+ * <p>Транзакционность обеспечивает вызывающая сторона (application/use-case слой).</p>
  */
 public class ProviderPassportProjector {
 
@@ -51,9 +51,8 @@ public class ProviderPassportProjector {
 
         Set<ProviderCode> activeCodes = Set.copyOf(registryPassports.keySet());
 
-        // Сначала upsert, затем "cleanup": так уменьшаем окно отсутствия активных записей,
-        // если вызывающая сторона не обернула операцию в транзакцию.
-        writeStore.upsertAll(registryPassports);
+        // Синхронизация состава и значений проекции с реестром.
         writeStore.deleteAllExcept(activeCodes);
+        writeStore.upsertAll(registryPassports);
     }
 }


### PR DESCRIPTION
### Motivation
- Транзакция относится к use-case «построить/обновить проекцию», а не к механизму запуска на старте, поэтому её следует вынести из runner в слой приложения. 
- Runner должен быть чистым триггером (логирование + fail-fast), чтобы его можно было переиспользовать из множества источников (startup, scheduler, endpoint). 
- Wiring и размещение класса должны находиться в backend-слое рядом с проекцией, но вне `config/**`, как application/use-case компонент.

### Description
- Добавлен use-case сервис `ProviderPassportProjectionService` с методом `project()` который оборачивает вызов доменного проектора в `TransactionTemplate`. 
- Добавлен wiring-конфиг `ProviderPassportProjectionServiceWiringConfig` который создаёт `ProviderPassportProjectionService` и локально формирует `TransactionTemplate` из `PlatformTransactionManager`. 
- Startup-runner перемещён в пакет `projection.startup` и упрощён: он теперь принимает `ProviderPassportProjectionService` и просто вызывает `service.project()` с логированием и fail-fast политикой. 
- Обновлён wiring для startup-runner: новый конфиг импортирует wiring сервиса и использует `@ConditionalOnBean(ProviderPassportProjectionService.class)` вместо прямой зависимости от `TransactionTemplate`, и сделана соответствующая реорганизация файлов/пакетов; в доменном `ProviderPassportProjector` уточнена документация про транзакционность и изменён порядок синхронизации на `deleteAllExcept(...)` затем `upsertAll(...)`.

### Testing
- Запущена попытка запустить автоматические тесты командой `./mvnw -q test -DskipITs`, выполнение не прошло из-за невозможности скачать дистрибутив Maven из `repo.maven.apache.org` в данном окружении. 
- Локальная инспекция исходников и компоновки конфигураций выполнена (статические проверки файлов), изменений в API не найдено помимо описанных рефакторингов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a537a28c832daea3bec5273943c7)