### PR TITLE
Удалить sealed/permits у InstrumentHandler

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
@@ -16,7 +16,7 @@ import java.util.Set;
 /**
  * Абстрактная реализация обработчика инструмента {@link InstrumentHandler}.
  */
-public abstract non-sealed class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
+public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
         implements InstrumentHandler<P, I> {
 
     //region FIELDS

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/InstrumentHandler.java
@@ -14,8 +14,7 @@ import java.util.Set;
 /**
  * Обработчик (handler) финансового инструмента {@link Instrument} для заданного провайдера {@link MarketDataProvider}.
  */
-public sealed interface InstrumentHandler<P extends MarketDataProvider, I extends Instrument>
-        permits AbstractInstrumentHandler {
+public interface InstrumentHandler<P extends MarketDataProvider, I extends Instrument> {
 
     /**
      * Код обработчика.


### PR DESCRIPTION
### Motivation
- Сделать контракт `InstrumentHandler` открытым, чтобы упростить использование с прокси/моками/AOP и снять жесткое ограничение наследования.

### Description
- Заменил `public sealed interface InstrumentHandler ... permits AbstractInstrumentHandler` на `public interface InstrumentHandler ...` и убрал `non-sealed` у `AbstractInstrumentHandler`, оставив его как `public abstract class AbstractInstrumentHandler`.

### Testing
- Запущена команда `./mvnw -q -pl domain -am test -DskipITs`, но запуск завершился неудачей из-за того, что Maven wrapper не смог скачать дистрибутив (`Failed to fetch apache-maven-3.9.9-bin.zip`), поэтому автоматические тесты не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3fcf9ad28832db13efb4b1d04ef1a)