### PR TITLE
Добавить isAttached в контракт InstrumentHandler

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
@@ -101,6 +101,11 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
         }
     }
 
+    @Override
+    public final boolean isAttached() {
+        return providerRef.get() != null;
+    }
+
     //endregion
 
     //region TEMPLATE METHOD
@@ -134,7 +139,9 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
         //Проверки:
 
         // Обработчик прикреплён к провайдеру
-        requireProviderAttached();
+        if (!isAttached()) {
+            throw new ProviderNotAttachedException(handlerCode);
+        }
 
         // Класс инструмента соответствует контракту
         validateInstrumentClass(instrument);
@@ -177,15 +184,6 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
     //endregion
 
     //region INTERNALS
-
-    /**
-     * Проверка: обработчик уже прикреплён к провайдеру.
-     */
-    private void requireProviderAttached() {
-        if (providerRef.get() == null) {
-            throw new ProviderNotAttachedException(handlerCode);
-        }
-    }
 
     /**
      * Проверка: класс инструмента соответствует контракту обработчика.

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/InstrumentHandler.java
@@ -42,6 +42,13 @@ public interface InstrumentHandler<P extends MarketDataProvider, I extends Instr
     void attachTo(P provider);
 
     /**
+     * Признак: обработчик уже прикреплён к провайдеру.
+     *
+     * <p>Назначение: безопасная проверка состояния жизненного цикла (до вызова {@link #quote(Instrument)}).</p>
+     */
+    boolean isAttached();
+
+    /**
      * Поток котировок для заданного инструмента.
      */
     Publisher<QuoteTick> quote(I instrument);


### PR DESCRIPTION
### Motivation
- Добавить в контракт способ безопасно проверять привязку обработчика к провайдеру до вызова `quote(...)`, чтобы вынести логику lifecycle-проверки в интерфейс и обеспечить единообразную реализацию в абстрактном хендлере.

### Description
- В `InstrumentHandler` добавлен метод `boolean isAttached()`; в `AbstractInstrumentHandler` добавлена `final`-реализация `isAttached()` через `providerRef.get() != null`, проверка привязки в `quote(...)` заменена на вызов `isAttached()`, и удалён приватный метод `requireProviderAttached()`.

### Testing
- Запущена команда `./mvnw -pl domain -am test -DskipITs`, автоматические тесты не завершились из-за ошибки окружения при скачивании Maven дистрибутива (`wget: Failed to fetch https://repo.maven.apache.org/...`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3feb8646c832da556a4e5da136895)