### PR TITLE
Убрать sealed/non-sealed у MarketDataProvider и AbstractMarketDataProvider

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
@@ -17,7 +17,7 @@ import java.util.*;
 /**
  * Абстрактная реализация {@link MarketDataProvider}.
  */
-public abstract non-sealed class AbstractMarketDataProvider<P extends MarketDataProvider>
+public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         implements MarketDataProvider {
 
     //=================================================================================================================

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
@@ -10,7 +10,7 @@ import org.reactivestreams.Publisher;
 /**
  * Провайдер рыночных данных.
  */
-public sealed interface MarketDataProvider permits AbstractMarketDataProvider {
+public interface MarketDataProvider {
 
     /**
      * Код провайдера.


### PR DESCRIPTION
### Motivation
- Сделать контракт провайдера (`MarketDataProvider`) открытым для расширения, убрав ограничение `sealed` и соответствующим образом убрать `non-sealed` у `AbstractMarketDataProvider`.

### Description
- Переименовал модификаторы: в `domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java` убран `sealed` и `permits`, а в `domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java` удалён `non-sealed`, при этом публичные API и реализация не изменялись.

### Testing
- Выполнена попытка сборки: `mvn -pl domain -DskipTests compile`, сборка не завершилась из-за инфраструктурной проблемы (Maven Central вернул `403 Forbidden` при загрузке parent POM), поэтому компиляция в этой среде не подтвердила изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44125ce80832d93ce30263cf58fd5)