### PR TITLE
Использовать `isCompatible(...)` в проверке контракта `quote`

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
@@ -174,6 +174,10 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
      * Требование контракта: инструмент совместим с обработчиком (класс + тип).
      */
     private void requireCompatible(I instrument) {
+        if (isCompatible(instrument)) {
+            return;
+        }
+
         if (!instrumentClass.isInstance(instrument)) {
             throw new InstrumentWrongClassException(
                     instrument.instrumentCode(),


### PR DESCRIPTION
### Motivation
- Сделать `isCompatible(...)` частью канонического сценария `quote(...)`, чтобы предикат реально использовался и не выглядел неиспользуемым, при этом сохранив точные доменные исключения по классу/типу.

### Description
- В `domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java` метод `requireCompatible` изменён на быстрый путь: сначала `if (isCompatible(instrument)) return;`, далее оставлены прежние проверки и соответствующие исключения `InstrumentWrongClassException` и `InstrumentWrongTypeException`.

### Testing
- Автоматические тесты не удалось выполнить: `./mvnw -q test -DskipITs` завершился ошибкой из-за невозможности скачать Maven дистрибутив, а `mvn -q test -DskipITs` завершился ошибкой из-за `403 Forbidden` при резолве `org.springframework.boot:spring-boot-starter-parent`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a440a69238832d80f9ed036ad60164)