### PR TITLE
Добавить `//region` блоки в AbstractMarketDataProvider

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
@@ -20,6 +20,8 @@ import java.util.*;
 public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         implements MarketDataProvider {
 
+    //region FIELDS
+
     /* Код провайдера. */
     protected final ProviderCode providerCode;
 
@@ -31,6 +33,10 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
 
     /* Карта "код инструмента → обработчик инструмента". */
     private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentHandlerMap;
+
+    //endregion
+
+    //region CONSTRUCTION
 
     /**
      * Конструктор.
@@ -71,6 +77,10 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         }
     }
 
+    //endregion
+
+    //region PUBLIC API
+
     @Override
     public ProviderCode providerCode() {
         return providerCode;
@@ -100,6 +110,10 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         // Делегируем вызов обработчику
         return handler.quote(instrument);
     }
+
+    //endregion
+
+    //region INTERNALS
 
     /**
      * Собирает неизменяемую карту и валидирует инварианты:
@@ -171,10 +185,16 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         return handler;
     }
 
+    //endregion
+
+    //region EXTENSION POINT
+
     /**
      * F-bounded полиморфизм: возвращает текущий экземпляр провайдера в его конкретном дженерик-типе {@code P}.
      *
      * <p>Назначение: Используется для прикрепления обработчиков к провайдеру.</p>
      */
     protected abstract P self();
+
+    //endregion
 }


### PR DESCRIPTION
### Motivation

- Улучшить читаемость и согласованность класса с реализацией `AbstractInstrumentHandler` путём логической разбивки на зоны `//region`/`//endregion` для быстрого ориентирования в коде.

### Description

- Добавлены маркеры зон `//region`/`//endregion` для секций `FIELDS`, `CONSTRUCTION`, `PUBLIC API`, `INTERNALS` и `EXTENSION POINT` в `AbstractMarketDataProvider`.
- Зоны охватывают поля класса, конструктор, публичные методы (включая `quote`/`providerCode`/`passport`/`policy`), внутренние вспомогательные методы (включая `buildInstrumentHandlerMap` и `findHandlerOrThrow`) и точку расширения `self()`.
- Изменения структурные и комментарные, без каких-либо изменений поведения или логики выполнения.

### Testing

- Применён патч через `apply_patch` и операция завершилась успешно.
- Проверен дифф с помощью `git diff -- domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java` и файл просмотрен командой `nl -ba domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java | sed -n '1,240p'`, оба анализа успешны.
- Изменения закоммичены через `git commit` и статус рабочей директории подтверждён командой `git status --short` (успешно).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44415284c832d817494e81f4ad401)