### PR TITLE
Добавить JDBC-адаптер и wiring для ProviderPassport query-порта

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/query/ProviderPassportQueryPortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/query/ProviderPassportQueryPortWiringConfig.java
@@ -1,0 +1,24 @@
+package com.alligator.market.backend.provider.readmodel.passport.config.query;
+
+import com.alligator.market.backend.provider.readmodel.passport.query.jdbc.ProviderPassportQueryPortJdbcAdapter;
+import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Конфигурация wiring {@link ProviderPassportQueryPort}.
+ */
+@Configuration(proxyBeanMethods = false)
+public class ProviderPassportQueryPortWiringConfig {
+
+    public static final String BEAN_PROVIDER_PASSPORT_QUERY_PORT = "providerPassportQueryPort";
+
+    /**
+     * Query-порт чтения паспортов провайдеров из materialized view.
+     */
+    @Bean(BEAN_PROVIDER_PASSPORT_QUERY_PORT)
+    public ProviderPassportQueryPort providerPassportQueryPort(JdbcTemplate jdbcTemplate) {
+        return new ProviderPassportQueryPortJdbcAdapter(jdbcTemplate);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/query/jdbc/ProviderPassportQueryPortJdbcAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/query/jdbc/ProviderPassportQueryPortJdbcAdapter.java
@@ -1,0 +1,83 @@
+package com.alligator.market.backend.provider.readmodel.passport.query.jdbc;
+
+import com.alligator.market.domain.provider.model.passport.AccessMethod;
+import com.alligator.market.domain.provider.model.passport.DeliveryMode;
+import com.alligator.market.domain.provider.model.passport.ProviderPassport;
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
+import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * JDBC-адаптер query-порта {@link ProviderPassportQueryPort}.
+ *
+ * <p>Читает materialized view таблицы {@code provider_passport} для отдачи данных в UI/каталог.</p>
+ */
+public final class ProviderPassportQueryPortJdbcAdapter implements ProviderPassportQueryPort {
+
+    private static final String SQL_FIND_ALL = """
+            SELECT
+              provider_code,
+              display_name,
+              delivery_mode,
+              access_method,
+              bulk_subscription
+            FROM provider_passport
+            ORDER BY provider_code
+            """;
+
+    private final JdbcTemplate jdbc;
+
+    public ProviderPassportQueryPortJdbcAdapter(JdbcTemplate jdbc) {
+        this.jdbc = Objects.requireNonNull(jdbc, "jdbc must not be null");
+    }
+
+    @Override
+    public Map<ProviderCode, ProviderPassport> findAll() {
+        Map<ProviderCode, ProviderPassport> result = new LinkedHashMap<>();
+
+        jdbc.query(SQL_FIND_ALL, rs -> {
+            ProviderCode code = ProviderCode.of(requireNonNull(rs, "provider_code"));
+            ProviderPassport passport = mapPassport(rs);
+
+            ProviderPassport prev = result.put(code, passport);
+            if (prev != null) {
+                // В норме невозможно из-за UNIQUE(provider_code), но если случится — лучше упасть явно.
+                throw new IllegalStateException("Duplicate provider_code in provider_passport: " + code.value());
+            }
+        });
+
+        return Collections.unmodifiableMap(result);
+    }
+
+    private static ProviderPassport mapPassport(ResultSet rs) throws SQLException {
+        String displayName = requireNonNull(rs, "display_name");
+        DeliveryMode deliveryMode = enumValue(DeliveryMode.class, requireNonNull(rs, "delivery_mode"));
+        AccessMethod accessMethod = enumValue(AccessMethod.class, requireNonNull(rs, "access_method"));
+        boolean bulk = rs.getBoolean("bulk_subscription");
+
+        return new ProviderPassport(displayName, deliveryMode, accessMethod, bulk);
+    }
+
+    private static String requireNonNull(ResultSet rs, String column) throws SQLException {
+        String value = rs.getString(column);
+        if (value == null) {
+            throw new IllegalStateException("Column '" + column + "' must not be null");
+        }
+        return value;
+    }
+
+    private static <E extends Enum<E>> E enumValue(Class<E> enumClass, String dbValue) {
+        try {
+            return Enum.valueOf(enumClass, dbValue);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException("Unknown " + enumClass.getSimpleName() + " value: " + dbValue, ex);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Требуется предоставить query-порт чтения паспортов провайдеров из materialized view `provider_passport` для UI/каталога без доступа к бизнес-реестру.
- Изменения следуют существующей структуре проекта и конвенции размещения: `readmodel/passport/query/**` для адаптеров и `config/query/**` для wiring.

### Description
- Добавлен JDBC-адаптер `ProviderPassportQueryPortJdbcAdapter` в `backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/query/jdbc/`, который выполняет запрос `SQL_FIND_ALL` к `provider_passport`, маппит `ResultSet` в `ProviderPassport` и возвращает `Map<ProviderCode, ProviderPassport>`.
- В адаптере реализованы защитные проверки на `null`-колонки, корректность enum-значений и обнаружение дубликатов `provider_code` для явного провала в некорректных ситуациях.
- Добавлен конфиг wiring `ProviderPassportQueryPortWiringConfig` в `backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/query/`, регистрирующий bean `providerPassportQueryPort` на базе `JdbcTemplate`.
- Добавленные файлы: `ProviderPassportQueryPortJdbcAdapter.java` и `ProviderPassportQueryPortWiringConfig.java`.

### Testing
- Попытка собрать модуль `backend` через `./mvnw -pl backend -DskipTests compile` завершилась ошибкой загрузки wrapper/Maven в среде (не удалось скачать Maven). 
- Попытка сборки через `mvn -pl backend -DskipTests compile` не удалась из-за ошибки разрешения зависимостей (`org.springframework.boot:spring-boot-starter-parent:3.4.5`), получена ошибка `403 Forbidden` от Maven Central, поэтому компиляция не прошла.
- Автоматические тесты/юнит-тесты не добавлялись в этом изменении.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48bffa6b0832da2703220998138a0)