### PR TITLE
Рефакторинг: регистрация PassportCatalogService через конфигурацию

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/config/PassportCatalogServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/config/PassportCatalogServiceWiringConfig.java
@@ -1,0 +1,33 @@
+package com.alligator.market.backend.provider.catalog.passport.config;
+
+import com.alligator.market.backend.provider.catalog.passport.service.PassportCatalogService;
+import com.alligator.market.backend.provider.catalog.passport.service.PassportCatalogServiceImpl;
+import com.alligator.market.backend.provider.readmodel.passport.config.query.ProviderPassportQueryPortWiringConfig;
+import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Конфигурация wiring {@link PassportCatalogService}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        ProviderPassportQueryPortWiringConfig.class
+})
+public class PassportCatalogServiceWiringConfig {
+
+    public static final String BEAN_PASSPORT_CATALOG_SERVICE = "passportCatalogService";
+
+    /**
+     * Сервис каталога паспортов провайдеров.
+     */
+    @Bean(BEAN_PASSPORT_CATALOG_SERVICE)
+    public PassportCatalogService passportCatalogService(
+            @Qualifier(ProviderPassportQueryPortWiringConfig.BEAN_PROVIDER_PASSPORT_QUERY_PORT)
+            ProviderPassportQueryPort queryPort
+    ) {
+        return new PassportCatalogServiceImpl(queryPort);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogServiceImpl.java
@@ -3,31 +3,34 @@ package com.alligator.market.backend.provider.catalog.passport.service;
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Реализация сервиса {@link PassportCatalogService}.
+ *
+ * <p>Чтение выполняется через доменный query-порт materialized view.</p>
  */
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class PassportCatalogServiceImpl implements PassportCatalogService {
+public final class PassportCatalogServiceImpl implements PassportCatalogService {
+
+    private static final Logger log = LoggerFactory.getLogger(PassportCatalogServiceImpl.class);
 
     /* Query-порт чтения паспортов провайдеров из read model (provider_passport). */
     private final ProviderPassportQueryPort queryPort;
 
+    public PassportCatalogServiceImpl(ProviderPassportQueryPort queryPort) {
+        this.queryPort = Objects.requireNonNull(queryPort, "queryPort must not be null");
+    }
+
     @Override
-    @Transactional(readOnly = true)
     public List<ProviderPassport> findAll() {
         Map<ProviderCode, ProviderPassport> passports = queryPort.findAll();
 
-        // Сохраняем порядок итерации карты (если адаптер возвращает LinkedHashMap с ORDER BY в SQL).
+        // Сохраняем порядок итерации карты (если адаптер сортирует через ORDER BY).
         List<ProviderPassport> result = List.copyOf(passports.values());
 
         log.debug("Found {} provider passports", result.size());


### PR DESCRIPTION
### Motivation
- Убрать привязку application/service-слоя к Spring-специфичным аннотациям и привести wiring сервисов к единому подходу через `config/**` для консистентности архитектуры.
- Сохранить контроллеры как инфраструктурные Spring-компоненты (`@RestController`) и не усложнять их регистрацию вручную.

### Description
- Убран `@Service`, `@Transactional`, Lombok-аннотации и преобразован `PassportCatalogServiceImpl` в `final` класс с явным конструктором и проверкой через `Objects.requireNonNull(...)`, добавлен SLF4J `Logger` вместо Lombok `@Slf4j`.
- Сохранена логика чтения паспортов через `queryPort.findAll()` и формирование результата через `List.copyOf(passports.values())`.
- Добавлен новый wiring-конфиг `PassportCatalogServiceWiringConfig` с бином `passportCatalogService`, который импортирует `ProviderPassportQueryPortWiringConfig` и инжектит `ProviderPassportQueryPort` через `@Qualifier`.
- Контроллер `PassportController` оставлен как `@RestController` без изменений.

### Testing
- Выполнена попытка сборки backend-модуля командой `./mvnw -pl backend -DskipTests compile`, которая не завершилась из-за проблемы окружения при скачивании дистрибутива Maven (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).
- Автоматические тесты не запускались из-за неуспешной сборки, поэтому валидация ограничена статической проверкой изменений в коде.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49bffe794832dba1ab6439f0a0262)