### PR TITLE
Добавить region-блоки в MoexIssFxSpotHandler и MoexIssProvider

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
@@ -16,6 +16,8 @@ import java.util.Set;
  */
 public final class MoexIssProvider extends AbstractMarketDataProvider<MoexIssProvider> {
 
+    //region FIELDS
+
     public static final String PROVIDER_CODE_VALUE = "MOEX_ISS";
     public static final ProviderCode PROVIDER_CODE = ProviderCode.of(PROVIDER_CODE_VALUE);
 
@@ -30,6 +32,10 @@ public final class MoexIssProvider extends AbstractMarketDataProvider<MoexIssPro
 
     private static final ProviderPolicy POLICY = ProviderPolicy.ofSeconds(1);
 
+    //endregion
+
+    //region CONSTRUCTION
+
     /**
      * Конструктор адаптера MOEX ISS.
      *
@@ -43,8 +49,14 @@ public final class MoexIssProvider extends AbstractMarketDataProvider<MoexIssPro
         super(PROVIDER_CODE, PASSPORT, POLICY, handlers);
     }
 
+    //endregion
+
+    //region EXTENSION POINT
+
     @Override
     protected MoexIssProvider self() {
         return this;
     }
+
+    //endregion
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
@@ -34,6 +34,8 @@ import java.util.Set;
 @Slf4j
 public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvider, FxSpot> {
 
+    //region FIELDS
+
     /* Код обработчика. */
     private static final HandlerCode HANDLER_CODE = HandlerCode.of("MOEX_ISS_FX_SPOT_HANDLER");
 
@@ -49,9 +51,9 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
     /* Временная зона MOEX (используется для конвертации SYSTIME в Instant). */
     private static final ZoneId MOEX_ZONE = ZoneId.of("Europe/Moscow");
 
-    //=================================================================================================================
-    // КОНСТРУКТОР
-    //=================================================================================================================
+    //endregion
+
+    //region CONSTRUCTION
 
     /**
      * Конструктор обработчика.
@@ -65,9 +67,9 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
         this.webClient = webClient;
     }
 
-    //=================================================================================================================
-    // РЕАЛИЗАЦИЯ МЕТОДОВ КОНТРАКТА
-    //=================================================================================================================
+    //endregion
+
+    //region TEMPLATE METHOD
 
     /**
      * Чистая логика получения потока котировок для переданного инструмента FX_SPOT.
@@ -97,9 +99,9 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
                 .repeatWhen(completed -> completed.delayElements(pollInterval));
     }
 
-    //=================================================================================================================
-    // ВСПОМОГАТЕЛЬНЫЕ МЕТОДЫ
-    //=================================================================================================================
+    //endregion
+
+    //region INTERNALS
 
     /**
      * Один запрос к MOEX ISS --> одна котировка инструмента FX_SPOT.
@@ -259,9 +261,9 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
         );
     }
 
-    //=================================================================================================================
-    // УТИЛИТЫ
-    //=================================================================================================================
+    //endregion
+
+    //region UTILS
 
     /**
      * Поиск индекса колонки по имени в массиве "columns".
@@ -274,4 +276,6 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
         }
         return -1;
     }
+
+    //endregion
 }


### PR DESCRIPTION
### Motivation
- Сделать громоздкие классы `MoexIssFxSpotHandler` и `MoexIssProvider` удобнее для навигации в IDE и привести их структуру к стилю `AbstractInstrumentHandler`/`AbstractMarketDataProvider`.

### Description
- Добавлены `//region`/`//endregion` секции в `backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java` (FIELDS, CONSTRUCTION, TEMPLATE METHOD, INTERNALS, UTILS) и в `backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java` (FIELDS, CONSTRUCTION, EXTENSION POINT).

### Testing
- Выполнена попытка сборки проекта командой `mvn -q -pl backend -DskipTests compile`, но сборка не завершилась из-за невозможности скачать parent POM из Maven Central (HTTP 403), поэтому компиляция изменений в текущем окружении не подтверждена.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a645724c832da68a4e442f55672e)