### PR TITLE
Добавить `providerCode` в ответ API паспортов провайдеров и в таблицу UI

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogService.java
@@ -1,8 +1,9 @@
 package com.alligator.market.backend.provider.catalog.passport.service;
 
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Application-сервис (use case) для операций с паспортами провайдеров рыночных данных.
@@ -12,5 +13,5 @@ public interface PassportCatalogService {
     /**
      * Вернуть все паспорта.
      */
-    List<ProviderPassport> findAll();
+    Map<ProviderCode, ProviderPassport> findAll();
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/service/PassportCatalogServiceImpl.java
@@ -6,7 +6,6 @@ import com.alligator.market.domain.provider.readmodel.passport.query.port.Provid
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -27,13 +26,10 @@ public final class PassportCatalogServiceImpl implements PassportCatalogService 
     }
 
     @Override
-    public List<ProviderPassport> findAll() {
+    public Map<ProviderCode, ProviderPassport> findAll() {
         Map<ProviderCode, ProviderPassport> passports = queryPort.findAll();
 
-        // Сохраняем порядок итерации карты (если адаптер сортирует через ORDER BY).
-        List<ProviderPassport> result = List.copyOf(passports.values());
-
-        log.debug("Found {} provider passports", result.size());
-        return result;
+        log.debug("Found {} provider passports", passports.size());
+        return passports;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/PassportController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/PassportController.java
@@ -28,8 +28,10 @@ public class PassportController {
      */
     @GetMapping
     public ResponseEntity<ApiResponse<List<PassportResponseDto>>> getAll() {
-        List<PassportResponseDto> list = service.findAll().stream()
-                .map(PassportDtoMapper::toProviderPassportResponseDto)
+        var passports = service.findAll();
+
+        List<PassportResponseDto> list = passports.entrySet().stream()
+                .map(entry -> PassportDtoMapper.toProviderPassportResponseDto(entry.getKey(), entry.getValue()))
                 .toList();
         return ResponseEntityFactory.ok(list);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/mapper/PassportDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/mapper/PassportDtoMapper.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.provider.catalog.passport.web.dto.mapper;
 
 import com.alligator.market.backend.provider.catalog.passport.web.dto.out.PassportResponseDto;
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
 
 import java.util.Objects;
 
@@ -20,10 +21,13 @@ public final class PassportDtoMapper {
     /**
      * Модель --> DTO ответа.
      */
-    public static PassportResponseDto toProviderPassportResponseDto(ProviderPassport providerPassport) {
+    public static PassportResponseDto toProviderPassportResponseDto(ProviderCode providerCode,
+                                                                    ProviderPassport providerPassport) {
+        Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(providerPassport, "providerPassport must not be null");
 
         return new PassportResponseDto(
+                providerCode.value(),
                 providerPassport.displayName(),
                 providerPassport.deliveryMode().name(),
                 providerPassport.accessMethod().name(),

--- a/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/out/PassportResponseDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/catalog/passport/web/dto/out/PassportResponseDto.java
@@ -4,6 +4,7 @@ package com.alligator.market.backend.provider.catalog.passport.web.dto.out;
  * DTO для передачи паспорта провайдера (out).
  */
 public record PassportResponseDto(
+        String providerCode,
         String displayName,
         String deliveryMode,
         String accessMethod,

--- a/frontend/src/app/features/provider_passport/models/provider-dto.model.ts
+++ b/frontend/src/app/features/provider_passport/models/provider-dto.model.ts
@@ -2,6 +2,8 @@
  * DTO провайдера, соответствующее backend-контракту ProviderDto.
  */
 export interface ProviderDto {
+  /* Уникальный код провайдера. */
+  providerCode: string;
   /* Отображаемое имя провайдера (user friendly). */
   displayName: string;
   /* Режим доставки рыночных данных. */

--- a/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.html
+++ b/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.html
@@ -7,6 +7,11 @@
     <mat-card-content>
       <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
 
+        <ng-container matColumnDef="providerCode">
+          <th mat-header-cell *matHeaderCellDef>Code</th>
+          <td mat-cell *matCellDef="let passport">{{ passport.providerCode }}</td>
+        </ng-container>
+
         <ng-container matColumnDef="displayName">
           <th mat-header-cell *matHeaderCellDef>Provider</th>
           <td mat-cell *matCellDef="let passport">{{ passport.displayName }}</td>

--- a/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
+++ b/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
@@ -16,6 +16,7 @@ export class PassportListComponent implements OnInit {
 
   /* Список колонок таблицы. */
   displayed: string[] = [
+    'providerCode',
     'displayName',
     'deliveryMode',
     'accessMethod',


### PR DESCRIPTION
### Motivation
- Нужно показывать уникальный код провайдера в UI и передавать его в API вместе с паспортом, сохранив явную связь «код → паспорт» на уровне сервиса.
- Предпочтительно вернуть карту из query-port без лишних преобразований, чтобы сохранить порядок и ключи провайдера.

### Description
- Изменён контракт `PassportCatalogService.findAll()` с `List<ProviderPassport>` на `Map<ProviderCode, ProviderPassport>` и обновлена реализация `PassportCatalogServiceImpl` для прямого возврата карты из `queryPort.findAll()`.
- Добавлено поле `providerCode` в `PassportResponseDto` и расширен `PassportDtoMapper`, который теперь принимает `ProviderCode` и заполняет `providerCode = providerCode.value()`.
- Обновлён `PassportController` для сборки списка ответов из `entrySet()` карты через обновлённый маппер.
- Синхронизирован фронтенд: добавлено поле `providerCode` в `ProviderDto` и колонка `Code` в `passport-list` для отображения кода провайдера; миграция БД не требовалась (колонка `provider_code` уже существует).

### Testing
- `npm run build` в `frontend` выполнился успешно и собрал бандл без ошибок.
- Локально поднят dev-сервер фронтенда (`npm run start`) и автоматически открыт маршрут `/provider-passports`, сделан скриншот страницы с колонкой кода (артефакт сборки создан успешно).
- Попытки собрать backend через `./mvnw -DskipTests compile` и `mvn -DskipTests compile` завершились неудачей из-за доступа к внешнему репозиторию (ошибка при резолве parent POM / HTTP 403), поэтому backend-compile не прошёл.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a570de79cc832d9faed5003d4b34c6)