### PR TITLE
Добавлены отдельные Flyway-миграции для JPA-сущностей backend

### DIFF
--- a/backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql
+++ b/backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql
@@ -1,0 +1,36 @@
+-- instrument: базовая таблица финансовых инструментов (JOINED inheritance root).
+CREATE TABLE instrument
+(
+    -- Суррогатный PK
+    id                BIGSERIAL PRIMARY KEY,
+
+    -- Идентичность инструмента
+    code              VARCHAR(50)  NOT NULL,
+    symbol            VARCHAR(50)  NOT NULL,
+    type              VARCHAR(32)  NOT NULL,
+
+    -- Аудит/версионирование
+    version           BIGINT       NOT NULL DEFAULT 0,
+    created_timestamp TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by        VARCHAR(255) NOT NULL,
+    created_via       VARCHAR(255) NOT NULL,
+    updated_timestamp TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by        VARCHAR(255) NOT NULL,
+    updated_via       VARCHAR(255) NOT NULL,
+
+    -- Ограничения уникальности
+    CONSTRAINT uq_instrument_code UNIQUE (code),
+
+    -- Ограничения доменной валидности
+    CONSTRAINT chk_instrument_code_pattern
+        CHECK (code ~ '^[A-Z0-9_]+$'),
+    CONSTRAINT chk_instrument_symbol_pattern
+        CHECK (symbol ~ '^[A-Z0-9_]+$'),
+    CONSTRAINT chk_instrument_type_allowed
+        CHECK (type IN ('FOREX_SPOT', 'FOREX_FORWARD', 'FOREX_SWAP')),
+    CONSTRAINT chk_instrument_version_non_negative
+        CHECK (version >= 0)
+);
+
+-- Индекс для быстрого отбора по типу инструмента.
+CREATE INDEX idx_instrument_type ON instrument (type);

--- a/backend/src/main/resources/db/migration/V20260303_02__create_currency.sql
+++ b/backend/src/main/resources/db/migration/V20260303_02__create_currency.sql
@@ -1,0 +1,39 @@
+-- currency: справочник валют.
+CREATE TABLE currency
+(
+    -- Суррогатный PK
+    id                BIGSERIAL PRIMARY KEY,
+
+    -- Натуральный ключ
+    code              VARCHAR(3)   NOT NULL,
+
+    -- Данные валюты
+    name              VARCHAR(50)  NOT NULL,
+    country           VARCHAR(100) NOT NULL,
+    fraction_digits   INTEGER      NOT NULL DEFAULT 2,
+
+    -- Аудит/версионирование
+    version           BIGINT       NOT NULL DEFAULT 0,
+    created_timestamp TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by        VARCHAR(255) NOT NULL,
+    created_via       VARCHAR(255) NOT NULL,
+    updated_timestamp TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by        VARCHAR(255) NOT NULL,
+    updated_via       VARCHAR(255) NOT NULL,
+
+    -- Ограничения уникальности
+    CONSTRAINT uq_currency_code UNIQUE (code),
+    CONSTRAINT uq_currency_name UNIQUE (name),
+
+    -- Ограничения доменной валидности
+    CONSTRAINT chk_currency_code_pattern
+        CHECK (code ~ '^[A-Z]{3}$'),
+    CONSTRAINT chk_currency_name_not_blank
+        CHECK (length(btrim(name)) > 0),
+    CONSTRAINT chk_currency_country_not_blank
+        CHECK (length(btrim(country)) > 0),
+    CONSTRAINT chk_currency_fraction_digits
+        CHECK (fraction_digits BETWEEN 0 AND 10),
+    CONSTRAINT chk_currency_version_non_negative
+        CHECK (version >= 0)
+);

--- a/backend/src/main/resources/db/migration/V20260303_03__create_fx_spot.sql
+++ b/backend/src/main/resources/db/migration/V20260303_03__create_fx_spot.sql
@@ -1,0 +1,46 @@
+-- fx_spot: таблица-наследник instrument для инструмента FOREX_SPOT.
+CREATE TABLE fx_spot
+(
+    -- PK одновременно является FK на instrument.id (JOINED inheritance)
+    id                    BIGINT       PRIMARY KEY,
+
+    -- Валютная пара
+    base_currency         VARCHAR(3)   NOT NULL,
+    quote_currency        VARCHAR(3)   NOT NULL,
+    tenor                 VARCHAR(4)   NOT NULL,
+    quote_fraction_digits INTEGER      NOT NULL DEFAULT 4,
+
+    -- Аудит/версионирование
+    version               BIGINT       NOT NULL DEFAULT 0,
+    created_timestamp     TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by            VARCHAR(255) NOT NULL,
+    created_via           VARCHAR(255) NOT NULL,
+    updated_timestamp     TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by            VARCHAR(255) NOT NULL,
+    updated_via           VARCHAR(255) NOT NULL,
+
+    -- Ограничения ссылочной целостности
+    CONSTRAINT fk_fx_spot_instrument
+        FOREIGN KEY (id) REFERENCES instrument (id),
+    CONSTRAINT fk_fx_spot_base
+        FOREIGN KEY (base_currency) REFERENCES currency (code),
+    CONSTRAINT fk_fx_spot_quote
+        FOREIGN KEY (quote_currency) REFERENCES currency (code),
+
+    -- Ограничения уникальности
+    CONSTRAINT uq_fx_spot_pair_tenor UNIQUE (base_currency, quote_currency, tenor),
+
+    -- Ограничения доменной валидности
+    CONSTRAINT chk_fx_spot_base_quote_diff
+        CHECK (base_currency <> quote_currency),
+    CONSTRAINT chk_fx_spot_digits_range
+        CHECK (quote_fraction_digits BETWEEN 0 AND 10),
+    CONSTRAINT chk_fx_spot_tenor_allowed
+        CHECK (tenor IN ('TOD', 'TOM', 'SPOT')),
+    CONSTRAINT chk_fx_spot_version_non_negative
+        CHECK (version >= 0)
+);
+
+-- Индексы на FK-колонках для ускорения join/фильтрации.
+CREATE INDEX idx_fx_spot_base ON fx_spot (base_currency);
+CREATE INDEX idx_fx_spot_quote ON fx_spot (quote_currency);

--- a/backend/src/main/resources/db/migration/V20260303_04__create_instrument_feed_config.sql
+++ b/backend/src/main/resources/db/migration/V20260303_04__create_instrument_feed_config.sql
@@ -1,0 +1,42 @@
+-- instrument_feed_config: конфигурация источников котировок для инструмента.
+CREATE TABLE instrument_feed_config
+(
+    -- Суррогатный PK
+    id                BIGSERIAL PRIMARY KEY,
+
+    -- Связи и бизнес-поля
+    instrument_id     BIGINT       NOT NULL,
+    provider_code     VARCHAR(50)  NOT NULL,
+    feed_role         VARCHAR(16)  NOT NULL,
+    enabled           BOOLEAN      NOT NULL,
+
+    -- Аудит/версионирование
+    version           BIGINT       NOT NULL DEFAULT 0,
+    created_timestamp TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by        VARCHAR(255) NOT NULL,
+    created_via       VARCHAR(255) NOT NULL,
+    updated_timestamp TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by        VARCHAR(255) NOT NULL,
+    updated_via       VARCHAR(255) NOT NULL,
+
+    -- Ограничения ссылочной целостности
+    CONSTRAINT fk_ifc_instrument
+        FOREIGN KEY (instrument_id) REFERENCES instrument (id),
+
+    -- Ограничения уникальности
+    CONSTRAINT uq_ifc_instrument_feed_role UNIQUE (instrument_id, feed_role),
+    CONSTRAINT uq_ifc_instrument_provider_code UNIQUE (instrument_id, provider_code),
+
+    -- Ограничения доменной валидности
+    CONSTRAINT chk_ifc_provider_code_pattern
+        CHECK (provider_code = upper(provider_code) AND provider_code ~ '^[A-Z0-9_.-]+$'),
+    CONSTRAINT chk_ifc_provider_code_not_blank
+        CHECK (length(btrim(provider_code)) > 0),
+    CONSTRAINT chk_ifc_feed_role_allowed
+        CHECK (feed_role IN ('PRIMARY', 'SECONDARY')),
+    CONSTRAINT chk_ifc_version_non_negative
+        CHECK (version >= 0)
+);
+
+-- Индекс для массового отбора включённых конфигураций.
+CREATE INDEX idx_ifc_enabled ON instrument_feed_config (enabled);


### PR DESCRIPTION
### Motivation
- Привести схему БД в соответствие с JPA-аннотациями и отдельно управлять созданием таблиц для каждой JPA-сущности. 
- Обеспечить явные PK/FK, бизнес-ограничения и индексы, которые используются в коде JPA-entity.
- Закрепить audit/version-поля и дефолты на уровне БД для консистентности данных.

### Description
- Добавлены четыре отдельные миграции Flyway в `backend/src/main/resources/db/migration`: `V20260303_01__create_instrument.sql`, `V20260303_02__create_currency.sql`, `V20260303_03__create_fx_spot.sql`, `V20260303_04__create_instrument_feed_config.sql`.
- В миграции `instrument` создана базовая таблица для JOINED-наследования с уникальным `code`, проверками формата `code/symbol/type`, полями аудита и индексом по `type`.
- В миграции `currency` создан справочник валют с натуральным ключом `code`, уникальностью `name`, проверками формата и `fraction_digits` (DEFAULT 2).
- В миграции `fx_spot` создана таблица-наследник с PK=FK на `instrument`, FK на `currency(code)`, уникальностью по паре+тенору, check-ограничениями и индексами на валютные колонки.
- В миграции `instrument_feed_config` создана таблица конфигурации фидов с FK на `instrument`, бизнес-уникальностями, проверкой формата `provider_code` и индексом по `enabled`.

### Testing
- Запуск сборки `./mvnw -pl backend -DskipTests compile` был выполнен как автоматическая проверка сборки, но завершился неудачей из-за ошибочного скачивания Maven Wrapper (`wget: Failed to fetch ...`), поэтому компиляция не прошла.
- Unit/integration тесты не запускались в CI-процессе этого изменения, так как сборка backend не завершилась автоматически в текущем окружении.
- Все созданные миграционные SQL-файлы были добавлены в индекс и закоммичены.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6f984ec60832db45d100529920345)