### PR TITLE
Убрать жёсткие CHECK в миграции `instrument` и добавить JPA-конвертеры

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/InstrumentEntity.java
@@ -1,6 +1,8 @@
 package com.alligator.market.backend.instrument.catalog.persistence.jpa;
 
 import com.alligator.market.backend.common.persistence.jpa.entity.BaseEntity;
+import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter.AssetClassConverter;
+import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter.ContractTypeConverter;
 import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter.InstrumentCodeConverter;
 import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter.InstrumentSymbolConverter;
 import com.alligator.market.domain.instrument.Instrument;
@@ -72,7 +74,7 @@ public abstract class InstrumentEntity extends BaseEntity {
      */
     @Setter(AccessLevel.NONE)
     @NotNull
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = AssetClassConverter.class)
     @Column(name = "asset_class", length = 32, nullable = false, updatable = false)
     private AssetClass assetClass;
 
@@ -81,7 +83,7 @@ public abstract class InstrumentEntity extends BaseEntity {
      */
     @Setter(AccessLevel.NONE)
     @NotNull
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = ContractTypeConverter.class)
     @Column(name = "contract_type", length = 32, nullable = false, updatable = false)
     private ContractType contractType;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/AssetClassConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/AssetClassConverter.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.catalog.persistence.jpa.converter;
+
+import com.alligator.market.domain.instrument.type.AssetClass;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Конвертер для хранения {@link AssetClass} в виде строкового значения в БД.
+ */
+@Converter(autoApply = true)
+public class AssetClassConverter implements AttributeConverter<AssetClass, String> {
+
+    /**
+     * Преобразует доменную модель в значение для БД.
+     */
+    @Override
+    public String convertToDatabaseColumn(AssetClass attribute) {
+        return attribute != null ? attribute.name() : null;
+    }
+
+    /**
+     * Преобразует значение из БД в доменную модель.
+     */
+    @Override
+    public AssetClass convertToEntityAttribute(String dbData) {
+        return dbData != null ? AssetClass.valueOf(dbData) : null;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/ContractTypeConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/ContractTypeConverter.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.catalog.persistence.jpa.converter;
+
+import com.alligator.market.domain.instrument.type.ContractType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Конвертер для хранения {@link ContractType} в виде строкового значения в БД.
+ */
+@Converter(autoApply = true)
+public class ContractTypeConverter implements AttributeConverter<ContractType, String> {
+
+    /**
+     * Преобразует доменную модель в значение для БД.
+     */
+    @Override
+    public String convertToDatabaseColumn(ContractType attribute) {
+        return attribute != null ? attribute.name() : null;
+    }
+
+    /**
+     * Преобразует значение из БД в доменную модель.
+     */
+    @Override
+    public ContractType convertToEntityAttribute(String dbData) {
+        return dbData != null ? ContractType.valueOf(dbData) : null;
+    }
+}

--- a/backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql
+++ b/backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql
@@ -27,10 +27,6 @@ CREATE TABLE instrument
         CHECK (code ~ '^[A-Z0-9_]+$'),
     CONSTRAINT chk_instrument_symbol_pattern
         CHECK (symbol ~ '^[A-Z0-9_]+$'),
-    CONSTRAINT chk_instrument_asset_class_allowed
-        CHECK (asset_class IN ('COMMODITY', 'EQUITY', 'FOREX')),
-    CONSTRAINT chk_instrument_contract_type_allowed
-        CHECK (contract_type IN ('SPOT', 'FORWARD', 'SWAP')),
     CONSTRAINT chk_instrument_version_non_negative
         CHECK (version >= 0)
 );


### PR DESCRIPTION
### Motivation
- Убрать жёсткие `CHECK (asset_class IN (...))` и `CHECK (contract_type IN (...))` из миграции таблицы `instrument`, чтобы не блокировать дальнейшее расширение типов на уровне БД. 
- Обеспечить корректное и предсказуемое хранение значений enum в БД через явные JPA-конвертеры вместо жёсткой зависимости от `@Enumerated`/жёстких ограничений. 

### Description
- Удалены строки с ограничениями `chk_instrument_asset_class_allowed` и `chk_instrument_contract_type_allowed` из миграции `backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql`. 
- Поля `assetClass` и `contractType` в `InstrumentEntity` заменены с `@Enumerated(EnumType.STRING)` на `@Convert(converter = ...)` и добавлены соответствующие импорты в `backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/InstrumentEntity.java`. 
- Добавлены конвертеры `AssetClassConverter` и `ContractTypeConverter` в `backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/` с `@Converter(autoApply = true)` для явного enum↔string маппинга. 

### Testing
- Попытка сборки бекенда с командой `./mvnw -pl backend -DskipTests compile` не удалась из-за невозможности скачать Maven дистрибутив в этом окружении (`Failed to fetch ...apache-maven...`), поэтому проверка через `./mvnw` не прошла. 
- Попытка сборки через `mvn -pl backend -DskipTests compile` также не прошла из-за проблем с разрешением зависимостей из Maven Central (`403 Forbidden`), поэтому автоматические тесты/компиляция не выполнены.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a76289d4f8832d8220d399f20f2922)