### PR TITLE
Переименовать `writeStore` в `writePort` в `ProviderPassportProjector`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/projector/ProviderPassportProjectorWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/projector/ProviderPassportProjectorWiringConfig.java
@@ -27,8 +27,8 @@ public class ProviderPassportProjectorWiringConfig {
     @Bean(BEAN_PROVIDER_PASSPORT_PROJECTOR)
     public ProviderPassportProjector providerPassportProjector(
             ProviderRegistry providerRegistry,
-            ProviderPassportProjectionWritePort writeStore
+            ProviderPassportProjectionWritePort writePort
     ) {
-        return new ProviderPassportProjector(providerRegistry, writeStore);
+        return new ProviderPassportProjector(providerRegistry, writePort);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/projection/projector/ProviderPassportProjector.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/readmodel/passport/projection/projector/ProviderPassportProjector.java
@@ -19,20 +19,20 @@ import java.util.Set;
 public class ProviderPassportProjector {
 
     private final ProviderRegistry providerRegistry;
-    private final ProviderPassportProjectionWritePort writeStore;
+    private final ProviderPassportProjectionWritePort writePort;
 
     /**
      * Конструктор.
      *
      * @param providerRegistry реестр провайдеров (источник истины)
-     * @param writeStore write-порт проекции паспортов
+     * @param writePort write-порт проекции паспортов
      */
     public ProviderPassportProjector(
             ProviderRegistry providerRegistry,
-            ProviderPassportProjectionWritePort writeStore
+            ProviderPassportProjectionWritePort writePort
     ) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry must not be null");
-        this.writeStore = Objects.requireNonNull(writeStore, "writeStore must not be null");
+        this.writePort = Objects.requireNonNull(writePort, "writePort must not be null");
     }
 
     /**
@@ -51,7 +51,7 @@ public class ProviderPassportProjector {
         Set<ProviderCode> activeCodes = Set.copyOf(registryPassports.keySet());
 
         // Синхронизация состава и значений проекции с реестром.
-        writeStore.deleteAllExcept(activeCodes);
-        writeStore.upsertAll(registryPassports);
+        writePort.deleteAllExcept(activeCodes);
+        writePort.upsertAll(registryPassports);
     }
 }


### PR DESCRIPTION
### Motivation
- Упростить и унифицировать наименование зависимости проектора паспортов провайдеров, заменив `writeStore` на более согласованное `writePort`.

### Description
- В `domain/src/main/java/.../ProviderPassportProjector.java` переименовал поле и параметр конструктора с `writeStore` в `writePort`, обновил сообщение `requireNonNull`, JavaDoc и вызовы методов записи (`deleteAllExcept`/`upsertAll`).
- В `backend/src/main/java/.../ProviderPassportProjectorWiringConfig.java` переименовал параметр бина с `writeStore` на `writePort` и передаю его в конструктор `ProviderPassportProjector`.

### Testing
- Выполнены текстовые проверки поиска: `rg -n "ProviderPassportProjector|writeStore|writePort"` и `rg -n "writeStore" domain backend`, которые подтвердили отсутствие оставшихся упоминаний `writeStore` в целевых модулях.
- Попытки запустить сборку/тесты через `./mvnw -pl domain,backend -am test -DskipITs` и `mvn -pl domain,backend -am -DskipITs test` завершились неудачей из-за ограничений окружения при загрузке зависимостей из `repo.maven.apache.org` (403/загрузка Maven не удалась).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9997d625c832d9d109ebe92cce481)