### PR TITLE
Убрать дублирующие audit-поля из таблицы fx_spot (миграция)

### DIFF
--- a/backend/src/main/resources/db/migration/V20260305_01__fix_fx_spot_joined_audit_columns.sql
+++ b/backend/src/main/resources/db/migration/V20260305_01__fix_fx_spot_joined_audit_columns.sql
@@ -1,0 +1,13 @@
+-- В JOINED inheritance аудит/версия хранятся в корневой таблице instrument.
+-- Из таблицы-наследника fx_spot убираем дублирующие колонки, которые не заполняются Hibernate.
+ALTER TABLE fx_spot
+    DROP CONSTRAINT IF EXISTS chk_fx_spot_version_non_negative;
+
+ALTER TABLE fx_spot
+    DROP COLUMN IF EXISTS version,
+    DROP COLUMN IF EXISTS created_timestamp,
+    DROP COLUMN IF EXISTS created_by,
+    DROP COLUMN IF EXISTS created_via,
+    DROP COLUMN IF EXISTS updated_timestamp,
+    DROP COLUMN IF EXISTS updated_by,
+    DROP COLUMN IF EXISTS updated_via;


### PR DESCRIPTION
### Motivation
- В `fx_spot` были продублированы поля аудита/версии с `NOT NULL`, тогда как по `JOINED`-наследованию эти поля хранятся в корневой таблице `instrument`, из-за чего вставка в `fx_spot` падала с `created_by is null`.

### Description
- Добавлена flyway-миграция `backend/src/main/resources/db/migration/V20260305_01__fix_fx_spot_joined_audit_columns.sql`, которая удаляет из `fx_spot` дублирующие колонки `version`, `created_timestamp`, `created_by`, `created_via`, `updated_timestamp`, `updated_by`, `updated_via` и сбрасывает ограничение `chk_fx_spot_version_non_negative`.

### Testing
- Попытка запустить модульные тесты бэкенда командой `./mvnw -pl backend test -DskipITs` не удалась из-за проблемы с загрузкой дистрибутива Maven (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99f8837a4832db74c89c15c86c1b4)