### PR TITLE
Упростить FxSpotTenor до TOD/TOM/SPOT

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/codec/FxSpotCodec.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/codec/FxSpotCodec.java
@@ -38,7 +38,7 @@ public final class FxSpotCodec {
         Objects.requireNonNull(quoteCode, "quoteCode must not be null");
         Objects.requireNonNull(tenor, "tenor must not be null");
 
-        return InstrumentSymbol.of(baseCode.value() + quoteCode.value() + SEP + tenor.value());
+        return InstrumentSymbol.of(baseCode.value() + quoteCode.value() + SEP + tenor.name());
     }
 
     /**
@@ -90,7 +90,7 @@ public final class FxSpotCodec {
         final CurrencyCode quoteCode = CurrencyCode.of(quoteRaw);
 
         // Валидация тенора даты валютирования
-        final FxSpotTenor tenor = FxSpotTenor.fromValue(tenorRaw);
+        final FxSpotTenor tenor = FxSpotTenor.valueOf(tenorRaw);
 
         return new FxSpotCodeParts(baseCode, quoteCode, tenor);
     }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/model/FxSpotTenor.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/model/FxSpotTenor.java
@@ -1,57 +1,10 @@
 package com.alligator.market.domain.instrument.asset.forex.contract.spot.model;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-
 /**
  * Теноры дат валютирования инструмента FOREX_SPOT.
  */
 public enum FxSpotTenor {
-    /* Константы: теноры дат валютирования для инструмента FOREX_SPOT (далее – теноры). */
-    TOD, TOM, SPOT;
-
-    /* Теноры в виде списка и единой строки (для сообщений об ошибках). */
-    private static final List<String> SUPPORTED_TENORS = Arrays.stream(values()).map(Enum::name).toList();
-    private static final String SUPPORTED_TENORS_JOINED = String.join(", ", SUPPORTED_TENORS);
-
-    /**
-     * Парсит тенор (trim + upper-case). В ошибке подсказывает допустимые значения.
-     */
-    public static FxSpotTenor fromValue(String value) {
-        Objects.requireNonNull(value, "FxSpotTenor value must not be null");
-
-        // Обрезаем пробелы
-        String trimmed = value.strip();
-        if (trimmed.isEmpty()) {
-            throw new IllegalArgumentException("FxSpotTenor value is blank");
-        }
-
-        // Делаем нормализацию регистра
-        String normalized = trimmed.toUpperCase(Locale.ROOT);
-
-        // Парсинг
-        try {
-            return FxSpotTenor.valueOf(normalized);
-        } catch (IllegalArgumentException ex) {
-            throw new IllegalArgumentException(
-                    "Unsupported FxSpotTenor value: '" + value + "'. Supported: " + SUPPORTED_TENORS_JOINED, ex);
-        }
-    }
-
-    /**
-     * Возвращает список поддерживаемых теноров (для валидации/документации).
-     */
-    @SuppressWarnings("unused")
-    public static List<String> supportedTenors() {
-        return SUPPORTED_TENORS;
-    }
-
-    /**
-     * Возвращает тенор как строковое значение.
-     */
-    public String value() {
-        return name();
-    }
+    TOD,
+    TOM,
+    SPOT
 }


### PR DESCRIPTION
### Motivation
- Упростить модель тенора FOREX_SPOT до минимального перечисления из трёх значений, чтобы убрать лишнюю служебную логику и стандартизировать поведение.
- Использовать встроенные возможности Java-`enum` вместо кастомных парсеров и вспомогательных методов для уменьшения поверхности ошибок.

### Description
- Заменён `FxSpotTenor` на простой `enum` с тремя константами: `TOD`, `TOM`, `SPOT` и удалены все вспомогательные методы и поля из файла `domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/model/FxSpotTenor.java`.
- Обновлён `FxSpotCodec` для использования `tenor.name()` при формировании символа и `FxSpotTenor.valueOf(tenorRaw)` при разборе кода инструмента в `domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/codec/FxSpotCodec.java`.
- Просканирован репозиторий на предмет использований удалённых методов и подтверждена корректность оставшихся ссылок к новому простому enum (удалены обращения к `fromValue()`, `value()` и `supportedTenors()`).

### Testing
- Выполнен поиск по коду (`rg`) для всех упоминаний `FxSpotTenor` и методов парсинга, чтобы убедиться в совместимости изменений, и результаты проверены.
- Попытка запустить `mvn test -q` завершилась неудачей из-за невозможности загрузить parent POM из Maven Central (HTTP 403) в текущем окружении, поэтому интеграционные/модульные тесты не были выполнены локально.
- Подтверждён `git` статус и сделан коммит с изменениями в файлах, дифф включён в PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac256dbd6c832db4e86179bf2f1750)