### PR TITLE
Хранение tenor как строка через конвертер — убрать жёсткий чек

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -2,6 +2,7 @@ package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalo
 
 import com.alligator.market.backend.instrument.catalog.persistence.jpa.InstrumentEntity;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.catalog.persistence.jpa.CurrencyEntity;
+import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.persistence.jpa.converter.FxSpotTenorConverter;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.vo.InstrumentSymbol;
 import com.alligator.market.domain.instrument.type.AssetClass;
@@ -47,10 +48,6 @@ import java.util.Objects;
         @Check(
                 name = "chk_fx_spot_digits_range",
                 constraints = "quote_fraction_digits BETWEEN 0 AND 10"
-        ),
-        @Check(
-                name = "chk_fx_spot_tenor_allowed",
-                constraints = "tenor IN ('TOD','TOM','SPOT')"
         )
 })
 @Table(
@@ -121,9 +118,9 @@ public class FxSpotEntity extends InstrumentEntity {
      */
     @Setter(AccessLevel.NONE)
     @NotNull
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = FxSpotTenorConverter.class)
     @Column(
-            name = "tenor", length = 4,
+            name = "tenor", length = 5,
             nullable = false,
             updatable = false
     )

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/converter/FxSpotTenorConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/converter/FxSpotTenorConverter.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.persistence.jpa.converter;
+
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpotTenor;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Конвертер для хранения {@link FxSpotTenor} в виде строкового значения в БД.
+ */
+@Converter
+public class FxSpotTenorConverter implements AttributeConverter<FxSpotTenor, String> {
+
+    /**
+     * Преобразует доменную модель в значение для БД.
+     */
+    @Override
+    public String convertToDatabaseColumn(FxSpotTenor attribute) {
+        return attribute != null ? attribute.name() : null;
+    }
+
+    /**
+     * Преобразует значение из БД в доменную модель.
+     */
+    @Override
+    public FxSpotTenor convertToEntityAttribute(String dbData) {
+        return dbData != null ? FxSpotTenor.valueOf(dbData) : null;
+    }
+}

--- a/backend/src/main/resources/db/migration/V20260306_01__extend_fx_spot_tenor_storage.sql
+++ b/backend/src/main/resources/db/migration/V20260306_01__extend_fx_spot_tenor_storage.sql
@@ -1,0 +1,6 @@
+-- Ослабляем ограничение tenor: храним код как строку без фиксированного перечня.
+ALTER TABLE fx_spot
+    DROP CONSTRAINT IF EXISTS chk_fx_spot_tenor_allowed;
+
+ALTER TABLE fx_spot
+    ALTER COLUMN tenor TYPE VARCHAR(5);


### PR DESCRIPTION
### Motivation
- Текущий чек `tenor IN ('TOD','TOM','SPOT')` жёстко привязывает БД к текущему набору значений `FxSpotTenor`, и при расширении enum потребуется менять схему БД.
- Нужно позволить добавлять новые теноры (например `SPLIT`) без изменения миграций и структуры таблицы.

### Description
- Убрана JPA-проверка перечня теноров из `FxSpotEntity` и удалён соответствующий `CHECK` в новой миграции.
- Поле `tenor` в `FxSpotEntity` заменено с `@Enumerated(EnumType.STRING)` на `@Convert(converter = FxSpotTenorConverter.class)` и увеличена длина колонки с `4` до `5` символов.
- Добавлен конвертер `FxSpotTenorConverter` для преобразования `FxSpotTenor <-> String` для JPA-персистенции.
- Добавлена Flyway-миграция `V20260306_01__extend_fx_spot_tenor_storage.sql`, которая удаляет `chk_fx_spot_tenor_allowed` и меняет тип колонки `tenor` на `VARCHAR(5)`.

### Testing
- Попытка собрать бэкенд: `./mvnw -pl backend -am -DskipTests compile` была выполнена, но завершилась ошибкой на этапе скачивания дистрибутива Maven (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`), поэтому компиляция в CI/локально не подтверждена.
- Других автоматизированных тестов запущено не было.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac26a9ddd4832db839adff85fad586)