### PR TITLE
Rename domain FxSpot to InstrumentFxSpot

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -9,7 +9,7 @@ import com.alligator.market.domain.instrument.model.AssetClass;
 import com.alligator.market.domain.instrument.model.ContractType;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.codec.FxSpotCodec;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpotTenor;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -28,7 +28,7 @@ import java.util.Objects;
  * JPA-сущность финансового инструмента FOREX_SPOT.
  *
  * <p>Назначение: хранение и представление финансового инструмента FOREX_SPOT в базе данных;
- * поля сущности соответствуют доменной модели инструмента FOREX_SPOT {@link FxSpot}.</p>
+ * поля сущности соответствуют доменной модели инструмента FOREX_SPOT {@link InstrumentFxSpot}.</p>
  *
  * <p>Пояснение некоторых аннотаций:</p>
  * <ul>

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalo
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.catalog.persistence.jpa.CurrencyEntityMapper;
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 
 import java.util.Objects;
 
@@ -24,8 +24,8 @@ public final class FxSpotEntityMapper {
     /**
      * Доменная модель + JPA-сущности валют -> JPA-сущность инструмента FOREX_SPOT.
      */
-    public static FxSpotEntity toNewEntity(FxSpot model, CurrencyEntity baseEntity, CurrencyEntity quoteEntity) {
-        Objects.requireNonNull(model, "FxSpot model must not be null");
+    public static FxSpotEntity toNewEntity(InstrumentFxSpot model, CurrencyEntity baseEntity, CurrencyEntity quoteEntity) {
+        Objects.requireNonNull(model, "InstrumentFxSpot model must not be null");
         Objects.requireNonNull(baseEntity, "entity of base currency must not be null");
         Objects.requireNonNull(quoteEntity, "entity of quote currency must not be null");
 
@@ -45,7 +45,7 @@ public final class FxSpotEntityMapper {
     /**
      * Обновляет изменяемые поля JPA-сущности из доменной модели.
      */
-    public static void applyToEntity(FxSpot m, FxSpotEntity e) {
+    public static void applyToEntity(InstrumentFxSpot m, FxSpotEntity e) {
         Objects.requireNonNull(m, "model must not be null");
         Objects.requireNonNull(e, "entity must not be null");
 
@@ -64,7 +64,7 @@ public final class FxSpotEntityMapper {
     /**
      * JPA-сущность -> доменная модель FOREX_SPOT.
      */
-    public static FxSpot toDomain(FxSpotEntity e) {
+    public static InstrumentFxSpot toDomain(FxSpotEntity e) {
         Objects.requireNonNull(e, "entity must not be null");
 
         // Поле defaultQuoteFractionDigits не является идентичностью сущности и теоретически может быть null,
@@ -73,7 +73,7 @@ public final class FxSpotEntityMapper {
                 "defaultQuoteFractionDigits must not be null");
 
         // Собираем и возвращаем доменную модель
-        return new FxSpot(
+        return new InstrumentFxSpot(
                 CurrencyEntityMapper.toDomain(e.getBaseCurrency()),
                 CurrencyEntityMapper.toDomain(e.getQuoteCurrency()),
                 e.getTenor(),

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
@@ -10,7 +10,7 @@ import com.alligator.market.domain.instrument.asset.forex.contract.spot.exceptio
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.repository.FxSpotRepository;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +38,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     private final CurrencyJpaRepository currencyJpaRepository;
 
     @Override
-    public FxSpot create(FxSpot fxSpot) {
+    public InstrumentFxSpot create(InstrumentFxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         // Ищем JPA-сущности составных валют (бизнес‑ошибки при отсутствии)
@@ -69,7 +69,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
-    public FxSpot update(FxSpot fxSpot) {
+    public InstrumentFxSpot update(InstrumentFxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot model must not be null");
 
         // Ищем JPA-сущность инструмента FOREX_SPOT к обновлению
@@ -116,7 +116,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
-    public Optional<FxSpot> findByCode(InstrumentCode instrumentCode) {
+    public Optional<InstrumentFxSpot> findByCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         // Строковое значение кода инструмента для запроса в БД
         String codeValue = instrumentCode.value();
@@ -126,7 +126,7 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     }
 
     @Override
-    public List<FxSpot> findAll() {
+    public List<InstrumentFxSpot> findAll() {
 
         return jpaRepository.findAll(Sort.by(Sort.Order.asc("code")))
                 .stream()

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogService.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.service;
 
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.List;
@@ -13,12 +13,12 @@ public interface FxSpotCatalogService {
     /**
      * Создать новый инструмент.
      */
-    FxSpot create(FxSpot fxSpot);
+    InstrumentFxSpot create(InstrumentFxSpot fxSpot);
 
     /**
      * Обновить существующий инструмент.
      */
-    void update(FxSpot fxSpot);
+    void update(InstrumentFxSpot fxSpot);
 
     /**
      * Удалить инструмент по коду.
@@ -28,5 +28,5 @@ public interface FxSpotCatalogService {
     /**
      * Вернуть все инструменты.
      */
-    List<FxSpot> findAll();
+    List<InstrumentFxSpot> findAll();
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogServiceImpl.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.service;
 
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.exception.FxSpotNotFoundException;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.repository.FxSpotRepository;
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import lombok.RequiredArgsConstructor;
@@ -24,22 +24,22 @@ public class FxSpotCatalogServiceImpl implements FxSpotCatalogService {
 
     @Override
     @Transactional
-    public FxSpot create(FxSpot fxSpot) {
+    public InstrumentFxSpot create(InstrumentFxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         // Без пред‑проверок на уникальность (устраняем TOCTOU) – уникальность проверяет адаптер репозитория
-        FxSpot created = fxSpotRepository.create(fxSpot);
+        InstrumentFxSpot created = fxSpotRepository.create(fxSpot);
         log.info("FX_SPOT instrument {} created", created.instrumentCode().value());
         return created;
     }
 
     @Override
     @Transactional
-    public void update(FxSpot fxSpot) {
+    public void update(InstrumentFxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         // Ищем инструмент к обновлению
-        FxSpot current = fxSpotRepository.findByCode(fxSpot.instrumentCode())
+        InstrumentFxSpot current = fxSpotRepository.findByCode(fxSpot.instrumentCode())
                 .orElseThrow(() -> new FxSpotNotFoundException(fxSpot.instrumentCode()));
 
         // Если изменений нет – возвращаем текущее состояние без записи в БД
@@ -49,7 +49,7 @@ public class FxSpotCatalogServiceImpl implements FxSpotCatalogService {
         }
 
         // Проверки целостности (валидация JPA/ограничения БД) и маппинг ошибок выполнит адаптер репозитория
-        FxSpot updated = fxSpotRepository.update(fxSpot);
+        InstrumentFxSpot updated = fxSpotRepository.update(fxSpot);
         log.info("FX_SPOT instrument {} updated", updated.instrumentCode().value());
     }
 
@@ -65,9 +65,9 @@ public class FxSpotCatalogServiceImpl implements FxSpotCatalogService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FxSpot> findAll() {
+    public List<InstrumentFxSpot> findAll() {
 
-        List<FxSpot> result = fxSpotRepository.findAll();
+        List<InstrumentFxSpot> result = fxSpotRepository.findAll();
         log.debug("Found {} FX_SPOT instruments", result.size());
         return result;
     }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotDomainFactory.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotDomainFactory.java
@@ -8,7 +8,7 @@ import com.alligator.market.domain.instrument.asset.forex.reference.currency.mod
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.codec.FxSpotCodec;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -31,7 +31,7 @@ public class FxSpotDomainFactory {
      *
      * <p>Загружает валюты из репозитория и возвращает полностью собранную доменную модель.</p>
      */
-    public FxSpot fromCreateDto(FxSpotCreateDto dto) {
+    public InstrumentFxSpot fromCreateDto(FxSpotCreateDto dto) {
         Objects.requireNonNull(dto, "dto must not be null");
 
         // Обращаемся к репозиторию для получения валют
@@ -41,7 +41,7 @@ public class FxSpotDomainFactory {
                 .orElseThrow(() -> new CurrencyNotFoundException(CurrencyCode.of(dto.quoteCurrency())));
 
         // Собираем и возвращаем доменную модель
-        return new FxSpot(base, quote, dto.tenor(), dto.defaultQuoteFractionDigits());
+        return new InstrumentFxSpot(base, quote, dto.tenor(), dto.defaultQuoteFractionDigits());
     }
 
     /**
@@ -50,7 +50,7 @@ public class FxSpotDomainFactory {
      * <p>Парсит код инструмента с помощью {@link FxSpotCodec} для получения кодов валют,
      * загружает валюты из репозитория {@link CurrencyRepository} и собирает доменную модель.</p>
      */
-    public FxSpot fromUpdateDto(InstrumentCode instrumentCode, FxSpotUpdateDto dto) {
+    public InstrumentFxSpot fromUpdateDto(InstrumentCode instrumentCode, FxSpotUpdateDto dto) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
         Objects.requireNonNull(dto, "dto must not be null");
 
@@ -66,6 +66,6 @@ public class FxSpotDomainFactory {
                 .orElseThrow(() -> new CurrencyNotFoundException(quoteCode));
 
         // Собираем и возвращаем доменную модель
-        return new FxSpot(base, quote, parts.tenor(), dto.defaultQuoteFractionDigits());
+        return new InstrumentFxSpot(base, quote, parts.tenor(), dto.defaultQuoteFractionDigits());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/web/FxSpotController.java
@@ -9,7 +9,7 @@ import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.mapper.FxSpotDtoMapper;
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.out.FxSpotResponseDto;
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +35,7 @@ public class FxSpotController {
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@RequestBody FxSpotCreateDto dto) {
 
-        FxSpot created = service.create(factory.fromCreateDto(dto));
+        InstrumentFxSpot created = service.create(factory.fromCreateDto(dto));
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{instrumentCode}")

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/web/dto/mapper/FxSpotDtoMapper.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.mapper;
 
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.out.FxSpotResponseDto;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 
 import java.util.Objects;
 
@@ -20,7 +20,7 @@ public class FxSpotDtoMapper {
     /**
      * Модель --> DTO ответа.
      */
-    public static FxSpotResponseDto toFxSpotResponseDto(FxSpot fxSpot) {
+    public static FxSpotResponseDto toFxSpotResponseDto(InstrumentFxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         return new FxSpotResponseDto(

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
@@ -4,7 +4,7 @@ import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.support.MoexIssFxSpotSupportCatalog;
 import com.alligator.market.domain.instrument.model.AssetClass;
 import com.alligator.market.domain.instrument.model.ContractType;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.model.passport.AccessMethod;
@@ -33,7 +33,7 @@ import java.util.Set;
  * Обработчик инструментов FOREX_SPOT провайдера MOEX ISS {@link MoexIssProvider}.
  */
 @Slf4j
-public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvider, FxSpot> {
+public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvider, InstrumentFxSpot> {
 
     //region FIELDS
 
@@ -62,7 +62,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
      * @param webClient web-клиент настроенный для запросов провайдеру MOEX ISS по инструментам класса FOREX с типом контракта SPOT
      */
     public MoexIssFxSpotHandler(WebClient webClient) {
-        super(HANDLER_CODE, FxSpot.class, AssetClass.FOREX, ContractType.SPOT, SUPPORTED_CODES);
+        super(HANDLER_CODE, InstrumentFxSpot.class, AssetClass.FOREX, ContractType.SPOT, SUPPORTED_CODES);
 
         Objects.requireNonNull(webClient, "webClient must not be null");
         this.webClient = webClient;
@@ -79,7 +79,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
      * один запрос --> один тик --> пауза согласно "политике" провайдера --> повтор.</p>
      */
     @Override
-    protected Publisher<QuoteTick> doQuote(FxSpot instrument) {
+    protected Publisher<QuoteTick> doQuote(InstrumentFxSpot instrument) {
         // 1) Получаем минимальный интервал обновления из "политики" провайдера
         Duration pollInterval = provider().policy().minUpdateInterval();
 
@@ -117,7 +117,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
      *
      * <p>Примечание: пункты 3) и 4) вынесены в отдельный метод {@link #mapMarketdataToQuoteTick(InstrumentCode, JsonNode)}.</p>
      */
-    private Mono<QuoteTick> fetchQuoteOnce(FxSpot instrument) {
+    private Mono<QuoteTick> fetchQuoteOnce(InstrumentFxSpot instrument) {
         // Примечание: проверка выполняется в AbstractInstrumentHandler, поэтому здесь не требуется
 
         // 1) Код инструмента --> SECID MOEX ISS

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/support/MoexIssFxSpotSupportCatalog.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/support/MoexIssFxSpotSupportCatalog.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.
 
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpotTenor;
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
@@ -21,8 +21,8 @@ public class MoexIssFxSpotSupportCatalog {
     private static final Currency CNY = new Currency(CurrencyCode.of("CNY"), "Chinese Yuan", "China", 2);
 
     /* Доменные инструменты. */
-    private static final FxSpot USD_RUB = new FxSpot(USD, RUB, FxSpotTenor.TOM, 4);
-    private static final FxSpot CNY_RUB = new FxSpot(CNY, RUB, FxSpotTenor.TOM, 4);
+    private static final InstrumentFxSpot USD_RUB = new InstrumentFxSpot(USD, RUB, FxSpotTenor.TOM, 4);
+    private static final InstrumentFxSpot CNY_RUB = new InstrumentFxSpot(CNY, RUB, FxSpotTenor.TOM, 4);
 
     /* Карта соответствий: код инструмента ↔ SECID. */
     private static final Map<InstrumentCode, String> DOMAIN_CODE_TO_SECID;

--- a/backend/src/main/java/com/alligator/market/backend/quote/feed/resolver/DefaultInstrumentProviderResolver.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/feed/resolver/DefaultInstrumentProviderResolver.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.quote.feed.resolver;
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.domain.instrument.model.Instrument;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.quote.feed.InstrumentProviderResolver;
 import org.springframework.stereotype.Service;
@@ -27,7 +27,7 @@ public class DefaultInstrumentProviderResolver implements InstrumentProviderReso
         Objects.requireNonNull(instrument, "instrument must not be null");
 
         // Пока что вся FOREX_SPOT-линейка обслуживается только MOEX ISS.
-        if (instrument instanceof FxSpot) {
+        if (instrument instanceof InstrumentFxSpot) {
             return MOEX_ISS_PROVIDER_CODE;
         }
 

--- a/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamSmokeRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamSmokeRunner.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.quote.streaming;
 
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpotTenor;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +38,7 @@ public class QuoteStreamSmokeRunner {
         // Строим доменную модель инструмента, поддерживаемого MOEX ISS.
         Currency cny = new Currency(CurrencyCode.of("CNY"), "Chinese Yuan", "China", 2);
         Currency rub = new Currency(CurrencyCode.of("RUB"), "Russian Ruble", "Russian Federation", 2);
-        FxSpot instrument = new FxSpot(cny, rub, FxSpotTenor.TOM, 4);
+        InstrumentFxSpot instrument = new InstrumentFxSpot(cny, rub, FxSpotTenor.TOM, 4);
 
         subscription = Flux.from(orchestrator.buildQuoteStream(instrument))
                 // Безопасность: если долго нет ни одного тика, завершаем (иначе runner может висеть бесконечно).

--- a/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
@@ -4,7 +4,7 @@ import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.handler.MoexIssFxSpotHandler;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpotTenor;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;
 import org.junit.jupiter.api.Disabled;
@@ -44,7 +44,7 @@ class MoexIssFxSpotHandlerQuoteLiveTest {
         // 3) Инструмент для теста
         Currency cny = new Currency(CurrencyCode.of("CNY"), "Chinese Yuan", "China", 2);
         Currency rub = new Currency(CurrencyCode.of("RUB"), "Russian Ruble", "Russian Federation", 2);
-        FxSpot cnyRubTom = new FxSpot(cny, rub, FxSpotTenor.TOM, 4);
+        InstrumentFxSpot cnyRubTom = new InstrumentFxSpot(cny, rub, FxSpotTenor.TOM, 4);
 
         // 4) Запускаем запрос к реальному MOEX ISS
         Mono<QuoteTick> result = Mono.from(provider.quote(cnyRubTom));

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/model/InstrumentFxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/model/InstrumentFxSpot.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  * @param tenor                      Тенор даты валютирования
  * @param defaultQuoteFractionDigits Количество знаков после запятой в котировке по умолчанию
  */
-public record FxSpot(
+public record InstrumentFxSpot(
         Currency base,
         Currency quote,
         FxSpotTenor tenor,
@@ -32,7 +32,7 @@ public record FxSpot(
     /**
      * Конструктор с проверками.
      */
-    public FxSpot {
+    public InstrumentFxSpot {
         Objects.requireNonNull(base, "base must not be null");
         Objects.requireNonNull(quote, "quote must not be null");
         Objects.requireNonNull(tenor, "tenor must not be null");

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/repository/FxSpotRepository.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.instrument.asset.forex.contract.spot.reposit
 
 import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
-import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
+import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.InstrumentFxSpot;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,12 +15,12 @@ public interface FxSpotRepository {
     /**
      * Создать новый инструмент.
      */
-    FxSpot create(FxSpot fxSpot);
+    InstrumentFxSpot create(InstrumentFxSpot fxSpot);
 
     /**
      * Обновить инструмент.
      */
-    FxSpot update(FxSpot fxSpot);
+    InstrumentFxSpot update(InstrumentFxSpot fxSpot);
 
     /**
      * Удалить инструмент по коду.
@@ -30,12 +30,12 @@ public interface FxSpotRepository {
     /**
      * Найти инструмент по коду.
      */
-    Optional<FxSpot> findByCode(InstrumentCode instrumentCode);
+    Optional<InstrumentFxSpot> findByCode(InstrumentCode instrumentCode);
 
     /**
      * Вернуть все инструменты.
      */
-    List<FxSpot> findAll();
+    List<InstrumentFxSpot> findAll();
 
     /**
      * Проверить, используется ли код валюты хотя бы в одном инструменте.


### PR DESCRIPTION
### Motivation
- Уточнить и избежать неоднозначности имени доменной модели, разделив доменный тип и внешнее/фичевое имя `FxSpot` путём переименования доменной record в `InstrumentFxSpot`.
- Пропагировать новое имя по слоям приложения, чтобы все репозитории, сервисы, адаптеры и провайдеры использовали единый доменный тип.

### Description
- Переименована доменная модель `FxSpot` → `InstrumentFxSpot` (файл `domain/src/main/java/.../model/InstrumentFxSpot.java`).
- Обновлены сигнатуры репозитория и интерфейсов на `InstrumentFxSpot` в `domain` (`FxSpotRepository`) и соответствующие изменения в адаптере JPA `FxSpotRepositoryAdapter`.
- Пропагированы изменения в backend-слое: `FxSpotDomainFactory`, `FxSpotCatalogService` / `FxSpotCatalogServiceImpl`, `FxSpotController`, DTO маппер `FxSpotDtoMapper`, JPA маппер `FxSpotEntityMapper` и сущность/репозитории (`FxSpotEntity`, `FxSpotJpaRepository`) — все используют `InstrumentFxSpot`.
- Обновлены места интеграции провайдеров/обработчиков: `MoexIssFxSpotHandler`, `MoexIssFxSpotSupportCatalog`, `DefaultInstrumentProviderResolver`, `QuoteStreamSmokeRunner` и связанный интеграционный тест `MoexIssFxSpotHandlerQuoteLiveTest` для нового типа.
- Коммит с сообщением `Rename domain FxSpot to InstrumentFxSpot` создан и PR с описанием сформирован через `make_pr`.

### Testing
- Запущена сборка-компиляция `mvn -pl domain,backend -am compile`, которая завершилась с ошибкой из окружения: Maven не смог скачать parent POM из Maven Central (`403 Forbidden`).
- Выполнен автоматический поисковый контроль наличия старых ссылок и конструкторов (`rg`) по `domain`/`backend`/`backend test` и не обнаружено оставшихся упоминаний `model.FxSpot` или `new FxSpot(...)` после рефактора (проверка успешно прошла).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac355a0e30832da7096f5d9d6daeac)