### PR TITLE
Переименование таблиц: instrument → instrument_base и fx_spot → instrument_fx_spot; обновление JPA и миграции

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -3,10 +3,10 @@ package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalo
 import com.alligator.market.backend.instrument.catalog.persistence.jpa.InstrumentEntity;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.persistence.jpa.converter.FxSpotTenorConverter;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.vo.InstrumentSymbol;
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.type.ContractType;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentSymbol;
+import com.alligator.market.domain.instrument.model.AssetClass;
+import com.alligator.market.domain.instrument.model.ContractType;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.codec.FxSpotCodec;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -32,8 +32,8 @@ import java.util.Objects;
  *
  * <p>Пояснение некоторых аннотаций:</p>
  * <ul>
- *     <li>{@link PrimaryKeyJoinColumn}: PK таблицы {@code fx_spot} является одновременно FK на PK таблицы
- *     {@code instrument}; таблица {@code fx_spot} является наследницей таблицы {@code instrument}, которая содержит
+ *     <li>{@link PrimaryKeyJoinColumn}: PK таблицы {@code instrument_fx_spot} является одновременно FK на PK таблицы
+ *     {@code instrument_base}; таблица {@code instrument_fx_spot} является наследницей таблицы {@code instrument_base}, которая содержит
  *     общие поля для всех финансовых инструментов.</li>
  *     <li>{@link NoArgsConstructor} с {@code PROTECTED}: конструктор без аргументов нужен только для ORM;
  *     вручную сущность создается через специализированный конструктор.</li>
@@ -42,26 +42,26 @@ import java.util.Objects;
 @Entity
 @Checks({
         @Check(
-                name = "chk_fx_spot_base_quote_diff",
+                name = "chk_instrument_fx_spot_base_quote_diff",
                 constraints = "base_currency <> quote_currency"
         ),
         @Check(
-                name = "chk_fx_spot_digits_range",
+                name = "chk_instrument_fx_spot_digits_range",
                 constraints = "quote_fraction_digits BETWEEN 0 AND 10"
         )
 })
 @Table(
-        name = "fx_spot",
+        name = "instrument_fx_spot",
         uniqueConstraints = {
                 // Поля, задающие бизнес-уникальность инструмента FOREX_SPOT
-                @UniqueConstraint(name = "uq_fx_spot_pair_tenor",
+                @UniqueConstraint(name = "uq_instrument_fx_spot_pair_tenor",
                         columnNames = {"base_currency", "quote_currency", "tenor"})
         },
         indexes = {
                 // Индекс на FK-колонке ускоряет операции
-                @Index(name = "idx_fx_spot_base", columnList = "base_currency"),
+                @Index(name = "idx_instrument_fx_spot_base", columnList = "base_currency"),
                 // Индекс на FK-колонке ускоряет операции
-                @Index(name = "idx_fx_spot_quote", columnList = "quote_currency")
+                @Index(name = "idx_instrument_fx_spot_quote", columnList = "quote_currency")
         }
 )
 @PrimaryKeyJoinColumn(name = "id")
@@ -88,7 +88,7 @@ public class FxSpotEntity extends InstrumentEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(
             name = "base_currency", referencedColumnName = "code",
-            foreignKey = @ForeignKey(name = "fk_fx_spot_base"),
+            foreignKey = @ForeignKey(name = "fk_instrument_fx_spot_base"),
             nullable = false,
             updatable = false
     )
@@ -104,7 +104,7 @@ public class FxSpotEntity extends InstrumentEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(
             name = "quote_currency", referencedColumnName = "code",
-            foreignKey = @ForeignKey(name = "fk_fx_spot_quote"),
+            foreignKey = @ForeignKey(name = "fk_instrument_fx_spot_quote"),
             nullable = false,
             updatable = false
     )

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalo
 
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.catalog.persistence.jpa.CurrencyEntity;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.catalog.persistence.jpa.CurrencyEntityMapper;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
 
 import java.util.Objects;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
@@ -7,7 +7,7 @@ import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.persistence.jpa.FxSpotEntityMapper;
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.persistence.jpa.FxSpotJpaRepository;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.exception.*;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogService.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.service;
 
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotCatalogServiceImpl.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalo
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.exception.FxSpotNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.repository.FxSpotRepository;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotDomainFactory.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/service/FxSpotDomainFactory.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.instrument.asset.forex.contract.spot.catalo
 
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.in.FxSpotCreateDto;
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.in.FxSpotUpdateDto;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/web/FxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/web/FxSpotController.java
@@ -8,7 +8,7 @@ import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.in.FxSpotUpdateDto;
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.mapper.FxSpotDtoMapper;
 import com.alligator.market.backend.instrument.asset.forex.contract.spot.catalog.web.dto.out.FxSpotResponseDto;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/InstrumentEntity.java
@@ -5,11 +5,11 @@ import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter
 import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter.ContractTypeConverter;
 import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter.InstrumentCodeConverter;
 import com.alligator.market.backend.instrument.catalog.persistence.jpa.converter.InstrumentSymbolConverter;
-import com.alligator.market.domain.instrument.Instrument;
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.type.ContractType;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.vo.InstrumentSymbol;
+import com.alligator.market.domain.instrument.model.Instrument;
+import com.alligator.market.domain.instrument.model.AssetClass;
+import com.alligator.market.domain.instrument.model.ContractType;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentSymbol;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/InstrumentEntity.java
@@ -28,13 +28,13 @@ import java.util.Objects;
  */
 @Entity
 @Table(
-        name = "instrument",
+        name = "instrument_base",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uq_instrument_code", columnNames = "code")
+                @UniqueConstraint(name = "uq_instrument_base_code", columnNames = "code")
         },
         indexes = {
-                @Index(name = "idx_instrument_asset_class", columnList = "asset_class"),
-                @Index(name = "idx_instrument_contract_type", columnList = "contract_type")
+                @Index(name = "idx_instrument_base_asset_class", columnList = "asset_class"),
+                @Index(name = "idx_instrument_base_contract_type", columnList = "contract_type")
         }
 )
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/AssetClassConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/AssetClassConverter.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.catalog.persistence.jpa.converter;
 
-import com.alligator.market.domain.instrument.type.AssetClass;
+import com.alligator.market.domain.instrument.model.AssetClass;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/ContractTypeConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/ContractTypeConverter.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.catalog.persistence.jpa.converter;
 
-import com.alligator.market.domain.instrument.type.ContractType;
+import com.alligator.market.domain.instrument.model.ContractType;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/InstrumentCodeConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/InstrumentCodeConverter.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.catalog.persistence.jpa.converter;
 
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/InstrumentSymbolConverter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/catalog/persistence/jpa/converter/InstrumentSymbolConverter.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.catalog.persistence.jpa.converter;
 
-import com.alligator.market.domain.instrument.vo.InstrumentSymbol;
+import com.alligator.market.domain.instrument.model.vo.InstrumentSymbol;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.adapter.moex.iss;
 
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.provider.model.AbstractMarketDataProvider;
 import com.alligator.market.domain.provider.model.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssProviderConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssProviderConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss.config;
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.handlers.MoexIssHandlersConfig;
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.provider.model.handler.AbstractInstrumentHandler;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/handlers/MoexIssHandlersConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/handlers/MoexIssHandlersConfig.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss.config.handlers;
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.instrument.forex.spot.handler.MoexIssFxSpotHandlerConfig;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.handler.MoexIssFxSpotHandler;
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.provider.model.handler.AbstractInstrumentHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
@@ -2,10 +2,10 @@ package com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.support.MoexIssFxSpotSupportCatalog;
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.type.ContractType;
+import com.alligator.market.domain.instrument.model.AssetClass;
+import com.alligator.market.domain.instrument.model.ContractType;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.handler.AbstractInstrumentHandler;
 import com.alligator.market.domain.provider.model.passport.AccessMethod;
 import com.alligator.market.domain.provider.model.vo.HandlerCode;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/support/MoexIssFxSpotSupportCatalog.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/support/MoexIssFxSpotSupportCatalog.java
@@ -4,7 +4,7 @@ import com.alligator.market.domain.instrument.asset.forex.reference.currency.mod
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpotTenor;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.*;
 

--- a/backend/src/main/java/com/alligator/market/backend/quote/feed/catalog/persistence/jpa/InstrumentFeedConfigEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/feed/catalog/persistence/jpa/InstrumentFeedConfigEntity.java
@@ -81,7 +81,7 @@ public class InstrumentFeedConfigEntity extends BaseEntity {
     @JoinColumn(
             name = "instrument_id",
             referencedColumnName = "id",
-            foreignKey = @ForeignKey(name = "fk_ifc_instrument"),
+            foreignKey = @ForeignKey(name = "fk_ifc_instrument_base"),
             nullable = false,
             updatable = false
     )

--- a/backend/src/main/java/com/alligator/market/backend/quote/feed/resolver/DefaultInstrumentProviderResolver.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/feed/resolver/DefaultInstrumentProviderResolver.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.quote.feed.resolver;
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.quote.feed.InstrumentProviderResolver;

--- a/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamingOrchestrator.java
+++ b/backend/src/main/java/com/alligator/market/backend/quote/streaming/QuoteStreamingOrchestrator.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.quote.streaming;
 
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.provider.model.MarketDataProvider;
 import com.alligator.market.domain.quote.feed.InstrumentProviderResolver;

--- a/backend/src/main/resources/db/migration/V20260306_02__rename_instrument_tables.sql
+++ b/backend/src/main/resources/db/migration/V20260306_02__rename_instrument_tables.sql
@@ -1,0 +1,45 @@
+-- Переименовываем базовую таблицу инструментов для явного разделения с таблицами-наследниками.
+ALTER TABLE IF EXISTS instrument
+    RENAME TO instrument_base;
+
+-- Приводим имя таблицы FOREX_SPOT к единому стандарту именования инструментов.
+ALTER TABLE IF EXISTS fx_spot
+    RENAME TO instrument_fx_spot;
+
+-- Переименовываем индексы базовой таблицы.
+ALTER INDEX IF EXISTS idx_instrument_asset_class
+    RENAME TO idx_instrument_base_asset_class;
+ALTER INDEX IF EXISTS idx_instrument_contract_type
+    RENAME TO idx_instrument_base_contract_type;
+
+-- Переименовываем индексы таблицы FOREX_SPOT.
+ALTER INDEX IF EXISTS idx_fx_spot_base
+    RENAME TO idx_instrument_fx_spot_base;
+ALTER INDEX IF EXISTS idx_fx_spot_quote
+    RENAME TO idx_instrument_fx_spot_quote;
+
+-- Переименовываем ограничения для консистентного нейминга.
+ALTER TABLE IF EXISTS instrument_base
+    RENAME CONSTRAINT uq_instrument_code TO uq_instrument_base_code;
+ALTER TABLE IF EXISTS instrument_base
+    RENAME CONSTRAINT chk_instrument_code_pattern TO chk_instrument_base_code_pattern;
+ALTER TABLE IF EXISTS instrument_base
+    RENAME CONSTRAINT chk_instrument_symbol_pattern TO chk_instrument_base_symbol_pattern;
+ALTER TABLE IF EXISTS instrument_base
+    RENAME CONSTRAINT chk_instrument_version_non_negative TO chk_instrument_base_version_non_negative;
+
+ALTER TABLE IF EXISTS instrument_fx_spot
+    RENAME CONSTRAINT fk_fx_spot_instrument TO fk_instrument_fx_spot_instrument_base;
+ALTER TABLE IF EXISTS instrument_fx_spot
+    RENAME CONSTRAINT fk_fx_spot_base TO fk_instrument_fx_spot_base;
+ALTER TABLE IF EXISTS instrument_fx_spot
+    RENAME CONSTRAINT fk_fx_spot_quote TO fk_instrument_fx_spot_quote;
+ALTER TABLE IF EXISTS instrument_fx_spot
+    RENAME CONSTRAINT uq_fx_spot_pair_tenor TO uq_instrument_fx_spot_pair_tenor;
+ALTER TABLE IF EXISTS instrument_fx_spot
+    RENAME CONSTRAINT chk_fx_spot_base_quote_diff TO chk_instrument_fx_spot_base_quote_diff;
+ALTER TABLE IF EXISTS instrument_fx_spot
+    RENAME CONSTRAINT chk_fx_spot_digits_range TO chk_instrument_fx_spot_digits_range;
+
+ALTER TABLE IF EXISTS instrument_feed_config
+    RENAME CONSTRAINT fk_ifc_instrument TO fk_ifc_instrument_base;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/codec/FxSpotCodec.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/codec/FxSpotCodec.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.instrument.asset.forex.contract.spot.codec;
 
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.vo.InstrumentSymbol;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentSymbol;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpotTenor;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotAlreadyExistsException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotAlreadyExistsException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.instrument.asset.forex.contract.spot.excepti
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.Objects;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotCreateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotCreateException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.instrument.asset.forex.contract.spot.excepti
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.Objects;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotDeleteException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotDeleteException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.instrument.asset.forex.contract.spot.excepti
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.Objects;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotNotFoundException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.instrument.asset.forex.contract.spot.excepti
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.Objects;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotUpdateException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/exception/FxSpotUpdateException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.instrument.asset.forex.contract.spot.excepti
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 
 import java.util.Objects;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/model/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/model/FxSpot.java
@@ -1,10 +1,10 @@
 package com.alligator.market.domain.instrument.asset.forex.contract.spot.model;
 
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.type.ContractType;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.Instrument;
-import com.alligator.market.domain.instrument.vo.InstrumentSymbol;
+import com.alligator.market.domain.instrument.model.AssetClass;
+import com.alligator.market.domain.instrument.model.ContractType;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.Instrument;
+import com.alligator.market.domain.instrument.model.vo.InstrumentSymbol;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.Currency;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.codec.FxSpotCodec;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.exception.FxSpotSameCurrenciesException;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/contract/spot/repository/FxSpotRepository.java
@@ -1,6 +1,6 @@
 package com.alligator.market.domain.instrument.asset.forex.contract.spot.repository;
 
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.contract.spot.model.FxSpot;
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/model/AssetClass.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/model/AssetClass.java
@@ -1,4 +1,4 @@
-package com.alligator.market.domain.instrument.type;
+package com.alligator.market.domain.instrument.model;
 
 /**
  * Класс актива, к которому относится финансовый инструмент.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/model/ContractType.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/model/ContractType.java
@@ -1,4 +1,4 @@
-package com.alligator.market.domain.instrument.type;
+package com.alligator.market.domain.instrument.model;
 
 /**
  * Тип контракта финансового инструмента.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/model/Instrument.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/model/Instrument.java
@@ -1,9 +1,7 @@
-package com.alligator.market.domain.instrument;
+package com.alligator.market.domain.instrument.model;
 
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.type.ContractType;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.vo.InstrumentSymbol;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentSymbol;
 
 /**
  * Базовый контракт финансового инструмента.
@@ -32,5 +30,4 @@ public interface Instrument {
      * Тип контракта финансового инструмента.
      */
     ContractType contractType();
-
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/model/vo/InstrumentCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/model/vo/InstrumentCode.java
@@ -1,4 +1,4 @@
-package com.alligator.market.domain.instrument.vo;
+package com.alligator.market.domain.instrument.model.vo;
 
 import java.util.Locale;
 import java.util.Objects;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/model/vo/InstrumentSymbol.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/model/vo/InstrumentSymbol.java
@@ -1,4 +1,4 @@
-package com.alligator.market.domain.instrument.vo;
+package com.alligator.market.domain.instrument.model.vo;
 
 import java.util.Locale;
 import java.util.Objects;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/AbstractMarketDataProvider.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.provider.model;
 
-import com.alligator.market.domain.instrument.Instrument;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.Instrument;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.handler.exception.HandlerNotFoundException;
 import com.alligator.market.domain.provider.model.handler.InstrumentHandler;
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/MarketDataProvider.java
@@ -1,6 +1,6 @@
 package com.alligator.market.domain.provider.model;
 
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.provider.model.passport.ProviderPassport;
 import com.alligator.market.domain.provider.model.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/AbstractInstrumentHandler.java
@@ -1,9 +1,9 @@
 package com.alligator.market.domain.provider.model.handler;
 
-import com.alligator.market.domain.instrument.Instrument;
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.type.ContractType;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.Instrument;
+import com.alligator.market.domain.instrument.model.AssetClass;
+import com.alligator.market.domain.instrument.model.ContractType;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.MarketDataProvider;
 import com.alligator.market.domain.provider.model.handler.exception.*;
 import com.alligator.market.domain.provider.model.vo.HandlerCode;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/InstrumentHandler.java
@@ -1,9 +1,9 @@
 package com.alligator.market.domain.provider.model.handler;
 
-import com.alligator.market.domain.instrument.Instrument;
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.type.ContractType;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.Instrument;
+import com.alligator.market.domain.instrument.model.AssetClass;
+import com.alligator.market.domain.instrument.model.ContractType;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.MarketDataProvider;
 import com.alligator.market.domain.provider.model.vo.HandlerCode;
 import com.alligator.market.domain.quote.tick.model.QuoteTick;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/HandlerNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/HandlerNotFoundException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.provider.model.handler.exception;
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 
 import java.util.Objects;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentNotSupportedException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentNotSupportedException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.provider.model.handler.exception;
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.HandlerCode;
 
 import java.util.Objects;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentWrongAssetClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentWrongAssetClassException.java
@@ -2,8 +2,8 @@ package com.alligator.market.domain.provider.model.handler.exception;
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.type.AssetClass;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.AssetClass;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.HandlerCode;
 
 import java.util.Objects;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentWrongClassException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentWrongClassException.java
@@ -2,7 +2,7 @@ package com.alligator.market.domain.provider.model.handler.exception;
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.HandlerCode;
 
 import java.util.Objects;

--- a/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentWrongContractTypeException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/model/handler/exception/InstrumentWrongContractTypeException.java
@@ -2,8 +2,8 @@ package com.alligator.market.domain.provider.model.handler.exception;
 
 import com.alligator.market.domain.common.exception.BaseDomainException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.domain.instrument.type.ContractType;
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.ContractType;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.HandlerCode;
 
 import java.util.Objects;

--- a/domain/src/main/java/com/alligator/market/domain/quote/feed/InstrumentProviderResolver.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/feed/InstrumentProviderResolver.java
@@ -1,6 +1,6 @@
 package com.alligator.market.domain.quote.feed;
 
-import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.model.Instrument;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 
 /**

--- a/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
+++ b/domain/src/main/java/com/alligator/market/domain/quote/tick/model/QuoteTick.java
@@ -1,6 +1,6 @@
 package com.alligator.market.domain.quote.tick.model;
 
-import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.instrument.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 
 import java.math.BigDecimal;


### PR DESCRIPTION
### Motivation
- Выровнять имена физических таблиц и ограничений с каноническим неймингом для корневой таблицы инструментов и её наследников.
- Упростить понимание схемы БД: явное разделение корня `instrument_base` и дочерних таблиц, например `instrument_fx_spot`.

### Description
- Добавлена миграция `backend/src/main/resources/db/migration/V20260306_02__rename_instrument_tables.sql`, которая переименовывает таблицы `instrument` → `instrument_base` и `fx_spot` → `instrument_fx_spot`, а также соответствующие индексы и constraints, включая FK в `instrument_feed_config`.
- Обновлена JPA-модель `InstrumentEntity` (`backend/src/main/java/.../InstrumentEntity.java`): `@Table(name = "instrument_base")` и синхронизированы имена уникального ограничения и индексов (`uq_instrument_base_code`, `idx_instrument_base_asset_class`, `idx_instrument_base_contract_type`).
- Обновлена JPA-модель `FxSpotEntity` (`backend/src/main/java/.../FxSpotEntity.java`): `@Table(name = "instrument_fx_spot")`, переименованы check/unique/index/FK ограничения и соответствующие JavaDoc-описания (`uq_instrument_fx_spot_pair_tenor`, `chk_instrument_fx_spot_*`, `idx_instrument_fx_spot_*`, `fk_instrument_fx_spot_*`).
- Обновлена JPA-модель `InstrumentFeedConfigEntity` (`backend/src/main/java/.../InstrumentFeedConfigEntity.java`): FK в аннотации `@ForeignKey` приведён к `fk_ifc_instrument_base`.

### Testing
- Попытка сборки проекта: `./mvnw -pl backend -am compile -DskipTests` была выполнена автоматически, но в текущем окружении Maven wrapper не смог скачать дистрибутив (`wget: Failed to fetch ...`), поэтому компиляция не завершилась успешно.
- Юнит-тесты не запускались в результате неудачной сборки; синтаксические изменения в коде проверялись поиском и заменой по дереву проекта (скрипты и `rg`), без полной сборки/packaging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac365c4330832d9cdbfafd9bd924af)