### PR TITLE
Переименовать таблицы: `instrument` → `instrument_base`, `fx_spot` → `instrument_fx_spot`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/contract/spot/catalog/persistence/jpa/FxSpotEntity.java
@@ -50,7 +50,7 @@ import java.util.Objects;
         )
 })
 @Table(
-        name = "fx_spot",
+        name = "instrument_fx_spot",
         uniqueConstraints = {
                 // Поля, задающие бизнес-уникальность инструмента FOREX_SPOT
                 @UniqueConstraint(name = "uq_fx_spot_pair_tenor",

--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/catalog/persistence/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/catalog/persistence/jpa/InstrumentEntity.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 @Entity
 @Table(
-        name = "instrument",
+        name = "instrument_base",
         uniqueConstraints = {
                 @UniqueConstraint(name = "uq_instrument_code", columnNames = "code")
         },

--- a/backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql
+++ b/backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql
@@ -1,5 +1,5 @@
--- instrument: базовая таблица финансовых инструментов (JOINED inheritance root).
-CREATE TABLE instrument
+-- instrument_base: базовая таблица финансовых инструментов (JOINED inheritance root).
+CREATE TABLE instrument_base
 (
     -- Суррогатный PK
     id                BIGSERIAL PRIMARY KEY,
@@ -32,5 +32,5 @@ CREATE TABLE instrument
 );
 
 -- Индексы для быстрого отбора по доменным признакам инструмента.
-CREATE INDEX idx_instrument_asset_class ON instrument (asset_class);
-CREATE INDEX idx_instrument_contract_type ON instrument (contract_type);
+CREATE INDEX idx_instrument_asset_class ON instrument_base (asset_class);
+CREATE INDEX idx_instrument_contract_type ON instrument_base (contract_type);

--- a/backend/src/main/resources/db/migration/V20260303_03__create_fx_spot.sql
+++ b/backend/src/main/resources/db/migration/V20260303_03__create_fx_spot.sql
@@ -1,7 +1,7 @@
--- fx_spot: таблица-наследник instrument для инструмента FOREX_SPOT.
-CREATE TABLE fx_spot
+-- instrument_fx_spot: таблица-наследник instrument_base для инструмента FOREX_SPOT.
+CREATE TABLE instrument_fx_spot
 (
-    -- PK одновременно является FK на instrument.id (JOINED inheritance)
+    -- PK одновременно является FK на instrument_base.id (JOINED inheritance)
     id                    BIGINT       PRIMARY KEY,
 
     -- Валютная пара
@@ -21,7 +21,7 @@ CREATE TABLE fx_spot
 
     -- Ограничения ссылочной целостности
     CONSTRAINT fk_fx_spot_instrument
-        FOREIGN KEY (id) REFERENCES instrument (id),
+        FOREIGN KEY (id) REFERENCES instrument_base (id),
     CONSTRAINT fk_fx_spot_base
         FOREIGN KEY (base_currency) REFERENCES currency (code),
     CONSTRAINT fk_fx_spot_quote
@@ -42,5 +42,5 @@ CREATE TABLE fx_spot
 );
 
 -- Индексы на FK-колонках для ускорения join/фильтрации.
-CREATE INDEX idx_fx_spot_base ON fx_spot (base_currency);
-CREATE INDEX idx_fx_spot_quote ON fx_spot (quote_currency);
+CREATE INDEX idx_fx_spot_base ON instrument_fx_spot (base_currency);
+CREATE INDEX idx_fx_spot_quote ON instrument_fx_spot (quote_currency);

--- a/backend/src/main/resources/db/migration/V20260303_04__create_instrument_feed_config.sql
+++ b/backend/src/main/resources/db/migration/V20260303_04__create_instrument_feed_config.sql
@@ -21,7 +21,7 @@ CREATE TABLE instrument_feed_config
 
     -- Ограничения ссылочной целостности
     CONSTRAINT fk_ifc_instrument
-        FOREIGN KEY (instrument_id) REFERENCES instrument (id),
+        FOREIGN KEY (instrument_id) REFERENCES instrument_base (id),
 
     -- Ограничения уникальности
     CONSTRAINT uq_ifc_instrument_feed_role UNIQUE (instrument_id, feed_role),

--- a/backend/src/main/resources/db/migration/V20260305_01__fix_fx_spot_joined_audit_columns.sql
+++ b/backend/src/main/resources/db/migration/V20260305_01__fix_fx_spot_joined_audit_columns.sql
@@ -1,9 +1,9 @@
--- В JOINED inheritance аудит/версия хранятся в корневой таблице instrument.
--- Из таблицы-наследника fx_spot убираем дублирующие колонки, которые не заполняются Hibernate.
-ALTER TABLE fx_spot
+-- В JOINED inheritance аудит/версия хранятся в корневой таблице instrument_base.
+-- Из таблицы-наследника instrument_fx_spot убираем дублирующие колонки, которые не заполняются Hibernate.
+ALTER TABLE instrument_fx_spot
     DROP CONSTRAINT IF EXISTS chk_fx_spot_version_non_negative;
 
-ALTER TABLE fx_spot
+ALTER TABLE instrument_fx_spot
     DROP COLUMN IF EXISTS version,
     DROP COLUMN IF EXISTS created_timestamp,
     DROP COLUMN IF EXISTS created_by,

--- a/backend/src/main/resources/db/migration/V20260306_01__extend_fx_spot_tenor_storage.sql
+++ b/backend/src/main/resources/db/migration/V20260306_01__extend_fx_spot_tenor_storage.sql
@@ -1,6 +1,6 @@
 -- Ослабляем ограничение tenor: храним код как строку без фиксированного перечня.
-ALTER TABLE fx_spot
+ALTER TABLE instrument_fx_spot
     DROP CONSTRAINT IF EXISTS chk_fx_spot_tenor_allowed;
 
-ALTER TABLE fx_spot
+ALTER TABLE instrument_fx_spot
     ALTER COLUMN tenor TYPE VARCHAR(5);


### PR DESCRIPTION
### Motivation
- Уточнить наименование корневой таблицы и дочерней таблицы для JOINED inheritance, сделав имена более явными и предотвращая коллизии с другими сущностями.

### Description
- Обновлён JPA-мэппинг корневой сущности: в `InstrumentEntity` таблица переименована в `instrument_base` (аннотация `@Table`).
- Обновлён JPA-мэппинг FX-spot сущности: в `FxSpotEntity` таблица переименована в `instrument_fx_spot` (аннотация `@Table`) и сохранён `@PrimaryKeyJoinColumn(name = "id")` для JOINED inheritance.
- Обновлены Flyway миграции: в `backend/src/main/resources/db/migration/V20260303_01__create_instrument.sql`, `V20260303_03__create_fx_spot.sql`, `V20260303_04__create_instrument_feed_config.sql`, `V20260305_01__fix_fx_spot_joined_audit_columns.sql` и `V20260306_01__extend_fx_spot_tenor_storage.sql` заменены определения и `ALTER TABLE`-операции на новые имена `instrument_base` / `instrument_fx_spot`, а также обновлены соответствующие `REFERENCES` и `CREATE INDEX` в миграциях.
- Изменения сохранены в одном коммите `6f4485a0` и охватывают модификации файлов `InstrumentEntity`, `FxSpotEntity` и перечисленных SQL-миграций.

### Testing
- Попытка собрать бэкенд командой `./mvnw -pl backend -DskipTests compile` была выполнена для быстрой валидации, но не завершилась из-за ошибки загрузки Maven дистрибутива в этом окружении (`wget` failed), сборка не прошла.
- Автоматические тесты не запускались и на текущем шаге не выполнялись из-за невозможности завершить компиляцию в среде исполнения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac79b169a4832db4d73ec76d3cca51)