### PR TITLE
Добавить миграцию instrument_market_data_source

### DIFF
--- a/backend/src/main/resources/db/migration/sourcing/source/V20260318_01__create_instrument_market_data_source.sql
+++ b/backend/src/main/resources/db/migration/sourcing/source/V20260318_01__create_instrument_market_data_source.sql
@@ -1,0 +1,34 @@
+-- instrument_market_data_source: источники рыночных данных для конкретного инструмента.
+CREATE TABLE instrument_market_data_source
+(
+    -- Суррогатный PK
+    id              BIGSERIAL   PRIMARY KEY,
+
+    -- Натуральные ссылки на инструмент и провайдера
+    instrument_code VARCHAR(50) NOT NULL,
+    provider_code   VARCHAR(50) NOT NULL,
+
+    -- Управление активностью и порядком выбора источника
+    active          BOOLEAN     NOT NULL,
+    priority        INTEGER     NOT NULL,
+
+    -- Ограничения ссылочной целостности
+    CONSTRAINT fk_instr_market_data_source_instrument
+        FOREIGN KEY (instrument_code) REFERENCES instrument_base (code),
+    CONSTRAINT fk_instr_market_data_source_provider
+        FOREIGN KEY (provider_code) REFERENCES provider_passport (provider_code),
+
+    -- Ограничения уникальности
+    CONSTRAINT uk_instr_market_data_source_instr_provider
+        UNIQUE (instrument_code, provider_code),
+    CONSTRAINT uk_instr_market_data_source_instr_priority
+        UNIQUE (instrument_code, priority),
+
+    -- Ограничения доменной валидности
+    CONSTRAINT chk_instr_market_data_source_priority
+        CHECK (priority >= 0)
+);
+
+-- Индекс для ускорения выборок/джойнов по провайдеру.
+CREATE INDEX idx_instr_market_data_source_provider
+    ON instrument_market_data_source (provider_code);


### PR DESCRIPTION
### Motivation
- Требуется хранить источники рыночных данных для конкретного инструмента с ссылочной целостностью на существующие доменные таблицы и согласованной размерностью ключей.

### Description
- Добавлен файл миграции `backend/src/main/resources/db/migration/sourcing/source/V20260318_01__create_instrument_market_data_source.sql` с определением таблицы `instrument_market_data_source`.
- Определены колонки `instrument_code VARCHAR(50)` и `provider_code VARCHAR(50)`, а также `active BOOLEAN` и `priority INTEGER` для управления доступностью и порядком источников.
- Добавлены внешние ключи на `instrument_base(code)` и `provider_passport(provider_code)`, уникальные ограничения на `(instrument_code, provider_code)` и `(instrument_code, priority)`, а также проверка `CHECK (priority >= 0)`.
- Добавлен индекс `idx_instr_market_data_source_provider` на `provider_code`, и стиль SQL оформлен в соответствии с существующими миграциями (структурные комментарии и явные `CONSTRAINT`).

### Testing
- Выполнена проверка синтаксиса/диффа с помощью `git diff --check`, которая прошла успешно.
- Выполнена проверка статуса репозитория через `git status --short`, которая показала добавление нового файла.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb12df28e0832d9ba3047cc8d22d52)