### PR TITLE
Подключить jOOQ code generation в backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -17,6 +17,7 @@
         <commons-compress.version>1.26.2</commons-compress.version>
         <flyway.version>11.8.2</flyway.version>
         <jsoup.version>1.21.2</jsoup.version>
+        <jooq.version>3.19.21</jooq.version>
         <kafka-avro-serializer.version>7.6.0</kafka-avro-serializer.version>
         <market-domain.version>1.0-SNAPSHOT</market-domain.version>
         <mockwebserver.version>5.1.0</mockwebserver.version>
@@ -163,6 +164,49 @@
                     <password>1234</password>
                     <schemas>main</schemas>
                 </configuration>
+            </plugin>
+            <!-- Генерация jOOQ-кода из схемы БД -->
+            <plugin>
+                <groupId>org.jooq</groupId>
+                <artifactId>jooq-codegen-maven</artifactId>
+                <version>${jooq.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-jooq</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <jdbc>
+                                <driver>org.postgresql.Driver</driver>
+                                <url>jdbc:postgresql://localhost:5432/postgres</url>
+                                <user>postgres</user>
+                                <password>1234</password>
+                            </jdbc>
+                            <generator>
+                                <database>
+                                    <name>org.jooq.meta.postgres.PostgresDatabase</name>
+                                    <inputSchema>main</inputSchema>
+                                    <includes>.*</includes>
+                                    <excludes>flyway_schema_history</excludes>
+                                </database>
+                                <target>
+                                    <packageName>com.alligator.market.backend.infra.jooq.generated</packageName>
+                                    <directory>${project.build.directory}/generated-sources/jooq</directory>
+                                </target>
+                            </generator>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <!-- JDBC драйвер для подключения к PostgreSQL -->
+                    <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>42.7.7</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <!-- Настройки компилятора и Lombok -->
             <plugin>


### PR DESCRIPTION
### Motivation
- Интегрировать генерацию jOOQ в Maven lifecycle backend-модуля для получения типобезопасных классов базы данных. 
- Использовать существующие параметры подключения/схему (аналогично Flyway) чтобы сгенерированный код соответствовал миграциям проекта.

### Description
- Добавлено свойство `jooq.version` в `backend/pom.xml` для управления версией плагина. 
- Подключен плагин `jooq-codegen-maven` в фазу `generate-sources` с конфигурацией JDBC (`jdbc:postgresql://localhost:5432/postgres`, `postgres/1234`) и `inputSchema` = `main` с исключением `flyway_schema_history`.
- Настроен target-пакет `com.alligator.market.backend.infra.jooq.generated` и директория генерации `${project.build.directory}/generated-sources/jooq`.
- Добавлена зависимость плагина на PostgreSQL JDBC-драйвер (`org.postgresql:postgresql:42.7.7`) чтобы codegen мог подключаться к БД во время генерации.

### Testing
- Попытка запустить `./mvnw -pl backend -DskipTests generate-sources` не удалась из-за невозможности скачать Maven Wrapper (`apache-maven-3.9.9-bin.zip`).
- Запуск `mvn -pl backend -DskipTests generate-sources` прервался из-за `403 Forbidden` при доступе к Maven Central, поэтому фактическая генерация в CI/локально не была подтверждена.
- Локальная проверка инструментов выполнена командой `mvn -v`, которая вернула установленную версию Maven; тесты/юнит-тесты проекта при этом не запускались и не изменялись.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea7f42af4832d8b87304a95f7a70e)