### PR TITLE
chore(domain): зафиксировать версии Spring/Avro и перекрыть уязвимые транзитивные зависимости

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -12,6 +12,23 @@
     <name>Alligator Market Domain</name>
     <description>Domain model for Alligator Market</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Управление версией Jackson Core для транзитивных зависимостей -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson-core.version}</version>
+            </dependency>
+            <!-- Управление версией Commons Lang3 для транзитивных зависимостей -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Reactor для реактивных типов домена -->
         <dependency>
@@ -23,12 +40,34 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>${spring-framework.version}</version>
         </dependency>
         <!-- Avro для генерации классов -->
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
+            <exclusions>
+                <!-- Исключаем уязвимые транзитивные версии, подключаем безопасные ниже -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Безопасная версия Jackson Core для Avro -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <!-- Безопасная версия Commons Lang3 для Avro -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,11 @@
     <properties>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <avro.version>1.12.0</avro.version>
+        <avro.version>1.12.1</avro.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <jackson-core.version>2.18.5</jackson-core.version>
         <reactor.version>3.8.0-M3</reactor.version>
+        <spring-framework.version>6.2.9</spring-framework.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Motivation
- Устранить предупреждения о уязвимых зависимостях, приходящих напрямую и транзитивно через `spring-context` и `avro`.
- Обеспечить явный контроль версий для транзитивных артефактов `jackson-core` и `commons-lang3` чтобы снизить риск использования уязвимых версий.

### Description
- В корневом `pom.xml` обновлены и добавлены свойства версий: `avro.version` → `1.12.1`, `spring-framework.version` → `6.2.9`, `jackson-core.version` → `2.18.5`, `commons-lang3.version` → `3.18.0`.
- В `domain/pom.xml` добавлен блок `dependencyManagement` для управления версиями `jackson-core` и `commons-lang3` и у `spring-context` зафиксирована версия `${spring-framework.version}`.
- У зависимости `org.apache.avro:avro` добавлены `exclusions` для `jackson-core` и `commons-lang3`, после чего эти артефакты подключены явно как зависимости (чтобы применять безопасные версии через `dependencyManagement`).

### Testing
- Попытка выполнить `mvn -pl domain -q dependency:tree -Dincludes=org.springframework:spring-context,org.apache.avro:avro -DskipTests` была выполнена, но завершилась ошибкой из-за сетевого запрета к Maven Central (`403 Forbidden`), поэтому резолв зависимостей в этом окружении не прошёл.
- Локальные изменения проверены статическим просмотром `pom.xml` на корректность синтаксиса и соответствие свойств, автоматические интеграционные/модульные проверки не были успешно выполнены из-за сетевой блокировки.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb607f82c832db8ab48387998f8ec)