### PR TITLE
Добавить plain jOOQ-адаптер JooqInstrumentSourcePlanRepository (реализован findByInstrumentCode)

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/infra/persistence/sourcing/repository/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/infra/persistence/sourcing/repository/JooqInstrumentSourcePlanRepository.java
@@ -1,0 +1,61 @@
+package com.alligator.market.backend.infra.persistence.sourcing.repository;
+
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.port.InstrumentSourcePlanRepository;
+import com.alligator.market.domain.sourcing.source.InstrumentMarketDataSource;
+import org.jooq.DSLContext;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.alligator.market.backend.infra.jooq.generated.tables.InstrumentMarketDataSource.INSTRUMENT_MARKET_DATA_SOURCE;
+
+/* jOOQ-адаптер репозитория планов источников. */
+public final class JooqInstrumentSourcePlanRepository implements InstrumentSourcePlanRepository {
+
+    /* DSLContext для выполнения SQL через jOOQ. */
+    private final DSLContext dsl;
+
+    public JooqInstrumentSourcePlanRepository(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    @Override
+    public Optional<InstrumentSourcePlan> findByInstrumentCode(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        List<InstrumentMarketDataSource> sources = dsl
+                .select(
+                        INSTRUMENT_MARKET_DATA_SOURCE.PROVIDER_CODE,
+                        INSTRUMENT_MARKET_DATA_SOURCE.ACTIVE,
+                        INSTRUMENT_MARKET_DATA_SOURCE.PRIORITY
+                )
+                .from(INSTRUMENT_MARKET_DATA_SOURCE)
+                .where(INSTRUMENT_MARKET_DATA_SOURCE.INSTRUMENT_CODE.eq(instrumentCode.value()))
+                .orderBy(INSTRUMENT_MARKET_DATA_SOURCE.PRIORITY.asc())
+                .fetch(record -> new InstrumentMarketDataSource(
+                        new ProviderCode(record.get(INSTRUMENT_MARKET_DATA_SOURCE.PROVIDER_CODE)),
+                        record.get(INSTRUMENT_MARKET_DATA_SOURCE.ACTIVE),
+                        record.get(INSTRUMENT_MARKET_DATA_SOURCE.PRIORITY)
+                ));
+
+        if (sources.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new InstrumentSourcePlan(instrumentCode, sources));
+    }
+
+    @Override
+    public List<InstrumentSourcePlan> findAll() {
+        throw new UnsupportedOperationException("findAll is not implemented yet");
+    }
+
+    @Override
+    public void save(InstrumentSourcePlan plan) {
+        throw new UnsupportedOperationException("save is not implemented yet");
+    }
+}


### PR DESCRIPTION
### Motivation
- Сделать первый замкнутый вертикальный срез для планов источников: проверить цепочку таблица → jOOQ → доменная модель. 
- Реализовать минимально необходимую операцию `findByInstrumentCode(...)`, оставив `findAll()` и `save()` на следующие шаги.

### Description
- Добавлен класс `JooqInstrumentSourcePlanRepository` в `backend/src/main/java/com/alligator/market/backend/infra/persistence/sourcing/repository` как простой инфраструктурный адаптер без Spring-аннотаций. 
- В `findByInstrumentCode(InstrumentCode)` выполнен jOOQ-запрос по таблице `instrument_market_data_source` с выборкой полей `PROVIDER_CODE`, `ACTIVE`, `PRIORITY`, сортировкой по `PRIORITY` и маппингом строк в доменную `InstrumentMarketDataSource`. 
- При наличии строк собирается `InstrumentSourcePlan` из `instrumentCode` и списка источников, а при отсутствии возвращается `Optional.empty()`; методы `findAll()` и `save()` бросают `UnsupportedOperationException` для сохранения атомарности изменения. 
- Используется статический импорт `com.alligator.market.backend.infra.jooq.generated.tables.InstrumentMarketDataSource.INSTRUMENT_MARKET_DATA_SOURCE`, при отличающемся имени/пакете сгенерированных jOOQ-классов нужно подправить импорт.

### Testing
- Пытался выполнить автоматическую сборку `./mvnw -pl backend -DskipTests compile`, но она не завершилась успешно из-за проблемы с загрузкой Maven-wrapper дистрибутива (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).
- Автоматические юнит-тесты не выполнялись и изменений, требующих дополнительных тестов, в этом PR не добавлено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf044ea678832db7d82650d37268db)