### PR TITLE
Реализация транзакционной замены плана источников в JooqInstrumentSourcePlanRepository.save

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/adapter/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/adapter/JooqInstrumentSourcePlanRepository.java
@@ -95,6 +95,24 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
 
     @Override
     public void save(InstrumentSourcePlan plan) {
-        throw new UnsupportedOperationException("save is not implemented yet");
+        Objects.requireNonNull(plan, "plan must not be null");
+
+        dsl.transaction(configuration -> {
+            DSLContext tx = configuration.dsl();
+
+            // Полностью заменяем план источников для инструмента
+            tx.deleteFrom(INSTRUMENT_MARKET_DATA_SOURCE)
+                    .where(INSTRUMENT_MARKET_DATA_SOURCE.INSTRUMENT_CODE.eq(plan.instrumentCode().value()))
+                    .execute();
+
+            for (InstrumentMarketDataSource source : plan.sources()) {
+                tx.insertInto(INSTRUMENT_MARKET_DATA_SOURCE)
+                        .set(INSTRUMENT_MARKET_DATA_SOURCE.INSTRUMENT_CODE, plan.instrumentCode().value())
+                        .set(INSTRUMENT_MARKET_DATA_SOURCE.PROVIDER_CODE, source.providerCode().value())
+                        .set(INSTRUMENT_MARKET_DATA_SOURCE.ACTIVE, source.active())
+                        .set(INSTRUMENT_MARKET_DATA_SOURCE.PRIORITY, source.priority())
+                        .execute();
+            }
+        });
     }
 }


### PR DESCRIPTION
### Motivation
- Добавить полноценный jOOQ-адаптер для сохранения плана источников одного инструмента с гарантией атомарности и корректного использования transaction-scoped `DSLContext`.

### Description
- Реализован метод `save(InstrumentSourcePlan plan)` в `backend/src/main/java/com/alligator/market/backend/sourcing/plan/adapter/JooqInstrumentSourcePlanRepository.java` с проверкой `plan` на `null`.
- Сохранение обернуто в одну jOOQ-транзакцию через `dsl.transaction(...)` и внутри используется `DSLContext tx = configuration.dsl()` для всех операций.
- Логика сохранения реализована как полная замена: сначала выполняется `DELETE` по `INSTRUMENT_CODE`, затем вставляются записи из `plan.sources()` с полями `PROVIDER_CODE`, `ACTIVE` и `PRIORITY`.

### Testing
- Выполнена попытка сборки с `mvn -pl backend -DskipTests compile`, которая не завершилась из-за проблем с резолвом зависимостей в окружении (`403 Forbidden` при загрузке `spring-boot-starter-parent:3.4.5`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1188e37c832db9446778521e0942)