### PR TITLE
Зарегистрировать JooqInstrumentSourcePlanRepository как Spring Bean

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/config/InstrumentSourcePlanRepositoryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/config/InstrumentSourcePlanRepositoryWiringConfig.java
@@ -1,0 +1,25 @@
+package com.alligator.market.backend.sourcing.plan.config;
+
+import com.alligator.market.backend.sourcing.plan.adapter.JooqInstrumentSourcePlanRepository;
+import com.alligator.market.domain.sourcing.plan.port.InstrumentSourcePlanRepository;
+import org.jooq.DSLContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация wiring репозитория планов источников инструмента.
+ */
+@Configuration(proxyBeanMethods = false)
+public class InstrumentSourcePlanRepositoryWiringConfig {
+
+    public static final String BEAN_INSTRUMENT_SOURCE_PLAN_REPOSITORY =
+            "instrumentSourcePlanRepository";
+
+    /**
+     * Доменный порт репозитория планов источников через jOOQ-адаптер.
+     */
+    @Bean(BEAN_INSTRUMENT_SOURCE_PLAN_REPOSITORY)
+    public InstrumentSourcePlanRepository instrumentSourcePlanRepository(DSLContext dsl) {
+        return new JooqInstrumentSourcePlanRepository(dsl);
+    }
+}


### PR DESCRIPTION
### Motivation

- Нужно завершить wiring для контура: доменная модель, доменный порт, jOOQ-адаптер и регистрация бина, чтобы репозиторий был доступен в Spring-контейнере. 

### Description

- Добавлен конфиг `InstrumentSourcePlanRepositoryWiringConfig` в пакет `backend.sourcing.plan.config` по пути `backend/src/main/java/com/alligator/market/backend/sourcing/plan/config/InstrumentSourcePlanRepositoryWiringConfig.java`.
- Зарегистрирован Spring bean с именем `instrumentSourcePlanRepository` (константа `BEAN_INSTRUMENT_SOURCE_PLAN_REPOSITORY`) который возвращает доменный порт `InstrumentSourcePlanRepository` и создаёт инфраструктурную реализацию `JooqInstrumentSourcePlanRepository` через конструктор `new JooqInstrumentSourcePlanRepository(DSLContext dsl)`.
- Конфиг помечен `@Configuration(proxyBeanMethods = false)` и полагается на доступный `DSLContext` (например, из `spring-boot-starter-jooq`); при наличии собственного `JooqConfig` его можно импортировать через `@Import(...)` при необходимости.

### Testing

- Попытка собрать бэкенд: `./mvnw -pl backend -DskipTests compile` завершилась неудачей из-за невозможности скачать Maven дистрибутив в этой среде (ошибка сети).
- Попытка собрать с локальным Maven: `mvn -pl backend -DskipTests compile` завершилась неудачей из-за `403 Forbidden` при загрузке зависимостей из Maven Central; автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf13c417e0832d86463198df4a0617)