### PR TITLE
chore: убрать интеграцию Flyway в модуле backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -64,18 +64,6 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
 
-        <!-- Миграции БД -->
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
-        </dependency>
-
-        <!-- Поддержка PostgreSQL в Flyway -->
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-database-postgresql</artifactId>
-        </dependency>
-
         <!-- JDBC драйвер PostgreSQL -->
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -135,7 +123,6 @@
                                     <name>org.jooq.meta.postgres.PostgresDatabase</name>
                                     <inputSchema>public</inputSchema>
                                     <includes>instrument_market_data_source</includes>
-                                    <excludes>flyway_schema_history</excludes>
                                 </database>
 
                                 <target>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,11 +17,6 @@ spring.datasource.username=postgres
 spring.datasource.password=1234
 
 # ===============================
-# FLYWAY MIGRATION
-# ===============================
-spring.flyway.enabled=false
-
-# ===============================
 # SQL INIT
 # ===============================
 spring.sql.init.mode=never


### PR DESCRIPTION
### Motivation
- Flyway в рантайме не нужен на этапе одиночной разработки, при этом SQL-миграции уже лежат в `backend/src/main/resources/db/migration` и их удобно запускать вручную (например, из IntelliJ IDEA).

### Description
- Удалены зависимости `org.flywaydb:flyway-core` и `org.flywaydb:flyway-database-postgresql` из `backend/pom.xml`.
- Удалено исключение `flyway_schema_history` из конфигурации jOOQ codegen в `backend/pom.xml`.
- Удалена настройка `spring.flyway.enabled=false` и связанный комментарий из `backend/src/main/resources/application.properties`.

### Testing
- Попытка запуска `./mvnw -pl backend test -DskipITs` была выполнена, но сборка не прошла из-за невозможности скачать Maven дистрибутив с `repo.maven.apache.org`, поэтому автоматические тесты не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51f6008d0832dbed3ebb3f78509dd)