### PR TITLE
Исправить deprecated методы JsonNode в MoexIssFxSpotHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
@@ -226,7 +226,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
         JsonNode systimeNode = row.get(systimeIdx);
         JsonNode lastNode = row.get(lastIdx);
 
-        if (systimeNode == null || systimeNode.isNull() || !systimeNode.isTextual()) {
+        if (systimeNode == null || systimeNode.isNull() || !systimeNode.isString()) {
             throw new IllegalStateException("MOEX ISS SYSTIME must be non-null string");
         }
         if (lastNode == null || lastNode.isNull() || !lastNode.isNumber()) {
@@ -234,7 +234,11 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
         }
 
         // 7) Парсим "SYSTIME" (строка вида "yyyy-MM-dd HH:mm:ss")
-        String systimeStr = systimeNode.asText();
+        String systimeStr = systimeNode.textValue();
+        if (systimeStr == null) {
+            throw new IllegalStateException("MOEX ISS SYSTIME must be non-null string");
+        }
+
         Instant exchangeTs;
         try {
             LocalDateTime ldt = LocalDateTime.parse(systimeStr, MOEX_DATETIME); // <-- Парсим во временную зону MOEX
@@ -271,7 +275,8 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
      */
     private static int indexOfColumn(ArrayNode columns, String name) {
         for (int i = 0; i < columns.size(); i++) {
-            if (name.equalsIgnoreCase(columns.get(i).asText())) {
+            String columnName = columns.get(i).textValue();
+            if (columnName != null && name.equalsIgnoreCase(columnName)) {
                 return i;
             }
         }


### PR DESCRIPTION
### Motivation
- Устранить предупреждения deprecation от API `tools.jackson` (Jackson 3): старые методы `isTextual()`/`asText()` помечены как deprecated и вызывают предупреждения в коде обработчика MOEX для FOREX_SPOT.
- Сохранить строгую валидацию входного JSON из MOEX ISS при переходе на новые явные методы работы со строковыми значениями.

### Description
- Заменил проверку `systimeNode.isTextual()` на `systimeNode.isString()` для проверки типа поля `SYSTIME`.
- Заменил вызовы `asText()` на `textValue()` при чтении `SYSTIME` и при поиске имени колонки в `columns`.
- Добавил null-safe проверку результата `textValue()` для сохранения прежнего поведения строгой валидации и предотвращения NPE.
- В функции поиска индекса колонки (`indexOfColumn`) добавил извлечение `textValue()` в переменную и проверку на `null` перед сравнением.

### Testing
- Выполнен поиск устаревших вызовов с помощью `rg -n "isTextual\(|asText\(" backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java -S` и совпадений не найдено, что подтверждает замену.
- Попытка сборки `mvn -q -pl backend -DskipTests compile` выполнена в этом окружении и завершилась неудачей из-за невозможности загрузить parent POM Spring Boot (HTTP 403 от Maven Central), поэтому полная компиляция не прошла.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e9f3e3ec832d9b14d30c905fba8a)