### PR TITLE
Исправление обработки строковых JsonNode (Jackson 3) в MoexIssFxSpotHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
@@ -234,10 +234,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
         }
 
         // 7) Парсим "SYSTIME" (строка вида "yyyy-MM-dd HH:mm:ss")
-        String systimeStr = systimeNode.textValue();
-        if (systimeStr == null) {
-            throw new IllegalStateException("MOEX ISS SYSTIME must be non-null string");
-        }
+        String systimeStr = systimeNode.stringValue();
 
         Instant exchangeTs;
         try {
@@ -275,8 +272,15 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
      */
     private static int indexOfColumn(ArrayNode columns, String name) {
         for (int i = 0; i < columns.size(); i++) {
-            String columnName = columns.get(i).textValue();
-            if (columnName != null && name.equalsIgnoreCase(columnName)) {
+            JsonNode columnNode = columns.get(i);
+
+            // Ищем только строковые имена колонок, без scalar-coercion.
+            if (!columnNode.isString()) {
+                continue;
+            }
+
+            String columnName = columnNode.stringValue();
+            if (name.equalsIgnoreCase(columnName)) {
                 return i;
             }
         }


### PR DESCRIPTION
### Motivation
- После перехода на Spring Boot 4 используется Jackson 3, где `JsonNode.textValue()` помечен deprecated, поэтому нужно убрать предупреждения и сохранить строгую семантику работы со строковыми узлами.

### Description
- Заменил вызов `textValue()` на `stringValue()` для чтения `SYSTIME` в `mapMarketdataToQuoteTick(...)` в `MoexIssFxSpotHandler.java`.
- Удалил избыточную проверку `systimeStr == null`, так как перед чтением уже выполняется `systimeNode.isString()`.
- В `indexOfColumn(...)` добавил явную проверку `isString()` и читаю имя колонки через `stringValue()` чтобы избежать scalar-coercion и сохранить прежнюю строгую семантику поиска.

### Testing
- Выполнена попытка сборки модуля с помощью `./mvnw -pl backend -DskipTests compile`, которая завершилась неуспехом из-за невозможности скачать Maven-дистрибутив из `repo.maven.apache.org` (сетевая ошибка), поэтому автоматическая компиляция не прошла.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91501da60832db382b97a1e212cd5)