### PR TITLE
Вынесение UTC в константу и упрощение комментариев AppTimeProperties

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
+++ b/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
@@ -16,9 +16,11 @@ import java.util.TimeZone;
 @ConfigurationPropertiesScan("com.alligator.market")
 public class BackendApplication {
 
+    private static final TimeZone TECHNICAL_TIME_ZONE = TimeZone.getTimeZone(ZoneOffset.UTC);
+
     public static void main(String[] args) {
-        // Глобальная техническая зона приложения.
-        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        // Глобальная техническая зона JVM для всего приложения.
+        TimeZone.setDefault(TECHNICAL_TIME_ZONE);
 
         SpringApplication.run(BackendApplication.class, args);
     }

--- a/backend/src/main/java/com/alligator/market/backend/infra/time/prop/AppTimeProperties.java
+++ b/backend/src/main/java/com/alligator/market/backend/infra/time/prop/AppTimeProperties.java
@@ -4,14 +4,11 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-/**
- * Настройки времени приложения.
- *
- * <p>Данные параметры автоматически считываются из файла настроек приложения.</p>
- */
+/* Настройки времени приложения. */
 @Validated
 @ConfigurationProperties("app.time")
 public record AppTimeProperties(
+        /* Бизнесовая временная зона приложения. */
         @NotBlank String businessZoneId
 ) {
 }


### PR DESCRIPTION
### Motivation
- Сделать техническую UTC-зону JVM явной и читабельной через константу и привести документацию для свойств времени к минималистичному формату в соответствии с целевой схемой wiring для Boot 4.

### Description
- Добавлена константа `TECHNICAL_TIME_ZONE` и использована в `BackendApplication` вместо повторного вызова `TimeZone.getTimeZone(...)`, а комментарии в `AppTimeProperties` сокращены до компактных русскоязычных пояснений над объектом и полем.

### Testing
- Запуск сборки с `./mvnw -pl backend -DskipTests compile` и `mvn -pl backend -DskipTests compile` был выполнен как проверка, но оба не завершились успешно из‑за недоступности артефактов (ошибка загрузки Maven дистрибутива и `403 Forbidden` при резолве `spring-boot-starter-parent:4.0.5`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c916042b8c832d8b32fb707aec9ee6)