### PR TITLE
Вынес исключения use-case для создания плана источников

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/CreateInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/CreateInstrumentSourcePlanService.java
@@ -1,5 +1,8 @@
 package com.alligator.market.backend.sourcing.plan.application.create;
 
+import com.alligator.market.backend.sourcing.plan.application.create.exception.InstrumentCodeNotFoundException;
+import com.alligator.market.backend.sourcing.plan.application.create.exception.InstrumentSourcePlanAlreadyExistsException;
+import com.alligator.market.backend.sourcing.plan.application.create.exception.ProviderCodesNotFoundException;
 import com.alligator.market.backend.sourcing.plan.application.create.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.create.port.ProviderCodeExistencePort;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
@@ -70,9 +73,7 @@ public final class CreateInstrumentSourcePlanService {
      */
     private void ensureInstrumentExists(InstrumentSourcePlan plan) {
         if (!instrumentCodeExistencePort.existsByCode(plan.instrumentCode())) {
-            throw new IllegalArgumentException(
-                    "Instrument code '" + plan.instrumentCode().value() + "' does not exist"
-            );
+            throw new InstrumentCodeNotFoundException(plan.instrumentCode());
         }
     }
 
@@ -89,9 +90,7 @@ public final class CreateInstrumentSourcePlanService {
         }
 
         if (!missingProviderCodes.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Provider codes do not exist: " + String.join(", ", missingProviderCodes)
-            );
+            throw new ProviderCodesNotFoundException(missingProviderCodes);
         }
     }
 
@@ -100,9 +99,7 @@ public final class CreateInstrumentSourcePlanService {
      */
     private void ensurePlanDoesNotExist(InstrumentSourcePlan plan) {
         if (instrumentSourcePlanRepository.findByInstrumentCode(plan.instrumentCode()).isPresent()) {
-            throw new IllegalStateException(
-                    "Instrument source plan for instrument '" + plan.instrumentCode().value() + "' already exists"
-            );
+            throw new InstrumentSourcePlanAlreadyExistsException(plan.instrumentCode());
         }
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/exception/InstrumentCodeNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/exception/InstrumentCodeNotFoundException.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.sourcing.plan.application.create.exception;
+
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+
+import java.util.Objects;
+
+/* Исключение: инструмент с указанным кодом не найден. */
+public final class InstrumentCodeNotFoundException extends IllegalArgumentException {
+
+    public InstrumentCodeNotFoundException(InstrumentCode instrumentCode) {
+        super("Instrument code '" + Objects.requireNonNull(instrumentCode, "instrumentCode must not be null").value()
+                + "' does not exist");
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/exception/InstrumentSourcePlanAlreadyExistsException.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/exception/InstrumentSourcePlanAlreadyExistsException.java
@@ -1,0 +1,15 @@
+package com.alligator.market.backend.sourcing.plan.application.create.exception;
+
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+
+import java.util.Objects;
+
+/* Исключение: план источников для инструмента уже существует. */
+public final class InstrumentSourcePlanAlreadyExistsException extends IllegalStateException {
+
+    public InstrumentSourcePlanAlreadyExistsException(InstrumentCode instrumentCode) {
+        super("Instrument source plan for instrument '" +
+                Objects.requireNonNull(instrumentCode, "instrumentCode must not be null").value() +
+                "' already exists");
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/exception/ProviderCodesNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/exception/ProviderCodesNotFoundException.java
@@ -1,0 +1,24 @@
+package com.alligator.market.backend.sourcing.plan.application.create.exception;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/* Исключение: один или несколько кодов провайдеров не найдены. */
+public final class ProviderCodesNotFoundException extends IllegalArgumentException {
+
+    public ProviderCodesNotFoundException(Collection<String> providerCodes) {
+        super(buildMessage(providerCodes));
+    }
+
+    private static String buildMessage(Collection<String> providerCodes) {
+        Objects.requireNonNull(providerCodes, "providerCodes must not be null");
+
+        StringJoiner joiner = new StringJoiner(", ");
+        for (String providerCode : providerCodes) {
+            joiner.add(Objects.requireNonNull(providerCode, "providerCode must not be null"));
+        }
+
+        return "Provider codes do not exist: " + joiner;
+    }
+}


### PR DESCRIPTION
### Motivation
- Сократить область видимости ошибок, относящихся только к сценарию `create` для плана источников, и улучшить семантику бросаемых исключений.

### Description
- Добавлены специализированные исключения в `backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/exception/`:
  - `InstrumentCodeNotFoundException` (наследует `IllegalArgumentException`),
  - `ProviderCodesNotFoundException` (наследует `IllegalArgumentException`),
  - `InstrumentSourcePlanAlreadyExistsException` (наследует `IllegalStateException`).
- Обновлён `CreateInstrumentSourcePlanService` для выбрасывания новых исключений в методах `ensureInstrumentExists(...)`, `ensureProvidersExist(...)` и `ensurePlanDoesNotExist(...)` вместо inline-строковых `IllegalArgumentException`/`IllegalStateException`.

### Testing
- Выполнена попытка сборки проекта: `./mvnw -pl backend -am -DskipTests compile`, но сборка не завершилась из-за ошибки скачивания Maven дистрибутива (`wget: Failed to fetch ...apache-maven-3.9.9-bin.zip`).
- Автоматические тесты не запускались в этом наборе изменений.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc26701ae4832d9677e7e7735c44e8)