### PR TITLE
Добавить InstrumentSourcePlanNotFoundException и сгруппировать исключения для InstrumentSourcePlan

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/CreateInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/create/CreateInstrumentSourcePlanService.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.sourcing.plan.application.create;
 
 import com.alligator.market.backend.sourcing.plan.application.create.exception.InstrumentCodeNotFoundException;
-import com.alligator.market.backend.sourcing.plan.application.create.exception.InstrumentSourcePlanAlreadyExistsException;
+import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentSourcePlanAlreadyExistsException;
 import com.alligator.market.backend.sourcing.plan.application.create.exception.ProviderCodesNotFoundException;
 import com.alligator.market.backend.sourcing.plan.application.create.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.create.port.ProviderCodeExistencePort;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/delete/DeleteInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/delete/DeleteInstrumentSourcePlanService.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.sourcing.plan.application.delete;
 
+import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentSourcePlanNotFoundException;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 
@@ -39,9 +40,7 @@ public final class DeleteInstrumentSourcePlanService {
      */
     private void ensurePlanExists(InstrumentCode instrumentCode) {
         if (instrumentSourcePlanRepository.findByInstrumentCode(instrumentCode).isEmpty()) {
-            throw new IllegalStateException(
-                    "Instrument source plan for instrument '" + instrumentCode.value() + "' does not exist"
-            );
+            throw new InstrumentSourcePlanNotFoundException(instrumentCode);
         }
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/exception/InstrumentSourcePlanAlreadyExistsException.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/exception/InstrumentSourcePlanAlreadyExistsException.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.sourcing.plan.application.create.exception;
+package com.alligator.market.backend.sourcing.plan.application.exception;
 
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/exception/InstrumentSourcePlanNotFoundException.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/exception/InstrumentSourcePlanNotFoundException.java
@@ -1,0 +1,15 @@
+package com.alligator.market.backend.sourcing.plan.application.exception;
+
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+
+import java.util.Objects;
+
+/* Исключение: план источников для инструмента не найден. */
+public final class InstrumentSourcePlanNotFoundException extends IllegalStateException {
+
+    public InstrumentSourcePlanNotFoundException(InstrumentCode instrumentCode) {
+        super("Instrument source plan for instrument '" +
+                Objects.requireNonNull(instrumentCode, "instrumentCode must not be null").value() +
+                "' does not exist");
+    }
+}


### PR DESCRIPTION
### Motivation
- Сделать поведение строгого удаления (`delete`) семантически понятным: отсутствие плана — это прикладная ошибка, которую удобно маппить в `404 Not Found`.
- Сгруппировать связанные доменные исключения для `InstrumentSourcePlan` в одном пакете `application/exception` для единообразия и удобства сопровождения.

### Description
- Добавлен класс исключения `InstrumentSourcePlanNotFoundException` в `backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/exception`.
- `DeleteInstrumentSourcePlanService` изменён на бросание `InstrumentSourcePlanNotFoundException` вместо `IllegalStateException` при отсутствии плана.
- `InstrumentSourcePlanAlreadyExistsException` перемещён в общий пакет `backend/.../application/exception` и соответствующим образом обновлён импорт в `CreateInstrumentSourcePlanService`.
- Обновлены импорты и исправлены ссылки в `CreateInstrumentSourcePlanService` и `DeleteInstrumentSourcePlanService`.

### Testing
- Запущена попытка сборки `mvn -pl backend -DskipTests compile`, которая не прошла из-за ограничений окружения при загрузке внешнего parent POM (403 Forbidden от Maven Central), поэтому полная компиляция в текущем окружении не подтверждена.
- Локальных автоматизированных тестов не запускали из-за проблемы с получением зависимостей.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc28bb26c4832da42c7900d7291a0d)