### PR TITLE
Добавить query-порты и jOOQ-адаптеры для options в sourcing plan

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/adapter/JooqInstrumentOptionsQueryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/adapter/JooqInstrumentOptionsQueryAdapter.java
@@ -1,0 +1,34 @@
+package com.alligator.market.backend.sourcing.plan.application.query.options.adapter;
+
+import com.alligator.market.backend.sourcing.plan.application.query.options.port.InstrumentOptionsQueryPort;
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+import org.jooq.DSLContext;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.alligator.market.backend.infra.jooq.generated.tables.InstrumentBase.INSTRUMENT_BASE;
+
+/**
+ * jOOQ-адаптер порта получения доступных кодов инструментов.
+ */
+public final class JooqInstrumentOptionsQueryAdapter implements InstrumentOptionsQueryPort {
+
+    /* DSLContext для выполнения SQL-запросов через jOOQ. */
+    private final DSLContext dsl;
+
+    public JooqInstrumentOptionsQueryAdapter(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    @Override
+    public List<InstrumentCode> findAllInstrumentCodes() {
+        return dsl.select(INSTRUMENT_BASE.CODE)
+                .from(INSTRUMENT_BASE)
+                .orderBy(INSTRUMENT_BASE.CODE.asc())
+                .fetch(INSTRUMENT_BASE.CODE)
+                .stream()
+                .map(InstrumentCode::new)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/adapter/JooqProviderOptionsQueryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/adapter/JooqProviderOptionsQueryAdapter.java
@@ -1,0 +1,34 @@
+package com.alligator.market.backend.sourcing.plan.application.query.options.adapter;
+
+import com.alligator.market.backend.sourcing.plan.application.query.options.port.ProviderOptionsQueryPort;
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
+import org.jooq.DSLContext;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.alligator.market.backend.infra.jooq.generated.tables.ProviderPassport.PROVIDER_PASSPORT;
+
+/**
+ * jOOQ-адаптер порта получения доступных кодов провайдеров.
+ */
+public final class JooqProviderOptionsQueryAdapter implements ProviderOptionsQueryPort {
+
+    /* DSLContext для выполнения SQL-запросов через jOOQ. */
+    private final DSLContext dsl;
+
+    public JooqProviderOptionsQueryAdapter(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    @Override
+    public List<ProviderCode> findAllProviderCodes() {
+        return dsl.select(PROVIDER_PASSPORT.PROVIDER_CODE)
+                .from(PROVIDER_PASSPORT)
+                .orderBy(PROVIDER_PASSPORT.PROVIDER_CODE.asc())
+                .fetch(PROVIDER_PASSPORT.PROVIDER_CODE)
+                .stream()
+                .map(ProviderCode::new)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/port/InstrumentOptionsQueryPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/port/InstrumentOptionsQueryPort.java
@@ -1,0 +1,16 @@
+package com.alligator.market.backend.sourcing.plan.application.query.options.port;
+
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+
+import java.util.List;
+
+/**
+ * Порт получения доступных кодов инструментов для UI.
+ */
+public interface InstrumentOptionsQueryPort {
+
+    /**
+     * Возвращает все доступные коды инструментов.
+     */
+    List<InstrumentCode> findAllInstrumentCodes();
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/port/ProviderOptionsQueryPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/port/ProviderOptionsQueryPort.java
@@ -1,0 +1,16 @@
+package com.alligator.market.backend.sourcing.plan.application.query.options.port;
+
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
+
+import java.util.List;
+
+/**
+ * Порт получения доступных кодов провайдеров для UI.
+ */
+public interface ProviderOptionsQueryPort {
+
+    /**
+     * Возвращает все доступные коды провайдеров.
+     */
+    List<ProviderCode> findAllProviderCodes();
+}


### PR DESCRIPTION
### Motivation
- Реализовать query-side часть для опций (dropdown/select) в контексте `sourcing/plan` для снабжения UI списками кодов инструментов и провайдеров.
- Сделать минималистичную, расширяемую реализацию без дополнительных DTO, так как сейчас UI нужны только коды.
- Поместить интерфейсы и адаптеры в `application/query/options` чтобы они были доступны для разных use-case (create/edit/filter/list).

### Description
- Добавлен порт `InstrumentOptionsQueryPort` с методом `List<InstrumentCode> findAllInstrumentCodes()` в `backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/port`.
- Добавлен порт `ProviderOptionsQueryPort` с методом `List<ProviderCode> findAllProviderCodes()` в `backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/port`.
- Реализован `JooqInstrumentOptionsQueryAdapter` в `.../adapter` с выборкой `INSTRUMENT_BASE.CODE`, сортировкой по коду и преобразованием в `InstrumentCode`.
- Реализован `JooqProviderOptionsQueryAdapter` в `.../adapter` с выборкой `PROVIDER_PASSPORT.PROVIDER_CODE`, сортировкой по коду и преобразованием в `ProviderCode`.

### Testing
- Выполнен попыточный сбор проекта: `mvn -pl backend -DskipTests compile` и результат сборки зафиксирован автоматом.
- Результат сборки: неуспех из-за инфраструктурной проблемы с резолвом родительского POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5`, HTTP 403 при обращении в Maven Central).
- Коммиты с добавленными файлами выполнены успешно (4 новых файла с реализациями портов и адаптеров).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc49282270832da44d9369d8d6a780)