### PR TITLE
Добавить read-API для options экрана управления планами источников

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/query/options/InstrumentSourcePlanOptionsQueryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/query/options/InstrumentSourcePlanOptionsQueryWiringConfig.java
@@ -1,0 +1,35 @@
+package com.alligator.market.backend.sourcing.config.plan.query.options;
+
+import com.alligator.market.backend.sourcing.plan.application.query.options.adapter.JooqInstrumentOptionsQueryAdapter;
+import com.alligator.market.backend.sourcing.plan.application.query.options.adapter.JooqProviderOptionsQueryAdapter;
+import com.alligator.market.backend.sourcing.plan.application.query.options.port.InstrumentOptionsQueryPort;
+import com.alligator.market.backend.sourcing.plan.application.query.options.port.ProviderOptionsQueryPort;
+import org.jooq.DSLContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация wiring query-портов получения options для UI.
+ */
+@Configuration(proxyBeanMethods = false)
+public class InstrumentSourcePlanOptionsQueryWiringConfig {
+
+    public static final String BEAN_INSTRUMENT_OPTIONS_QUERY_PORT = "instrumentOptionsQueryPort";
+    public static final String BEAN_PROVIDER_OPTIONS_QUERY_PORT = "providerOptionsQueryPort";
+
+    /**
+     * Query-порт получения доступных кодов инструментов.
+     */
+    @Bean(BEAN_INSTRUMENT_OPTIONS_QUERY_PORT)
+    public InstrumentOptionsQueryPort instrumentOptionsQueryPort(DSLContext dsl) {
+        return new JooqInstrumentOptionsQueryAdapter(dsl);
+    }
+
+    /**
+     * Query-порт получения доступных кодов провайдеров.
+     */
+    @Bean(BEAN_PROVIDER_OPTIONS_QUERY_PORT)
+    public ProviderOptionsQueryPort providerOptionsQueryPort(DSLContext dsl) {
+        return new JooqProviderOptionsQueryAdapter(dsl);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/controller/InstrumentSourcePlanOptionsQueryController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/controller/InstrumentSourcePlanOptionsQueryController.java
@@ -1,0 +1,53 @@
+package com.alligator.market.backend.sourcing.plan.api.query.options.controller;
+
+import com.alligator.market.backend.sourcing.plan.api.query.options.dto.InstrumentOptionDto;
+import com.alligator.market.backend.sourcing.plan.api.query.options.dto.InstrumentSourcePlanOptionsResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.options.dto.ProviderOptionDto;
+import com.alligator.market.backend.sourcing.plan.application.query.options.port.InstrumentOptionsQueryPort;
+import com.alligator.market.backend.sourcing.plan.application.query.options.port.ProviderOptionsQueryPort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
+
+/**
+ * REST-адаптер чтения options для экрана управления планами источников.
+ */
+@RestController
+public class InstrumentSourcePlanOptionsQueryController {
+
+    /* Query-порт получения доступных инструментов. */
+    private final InstrumentOptionsQueryPort instrumentOptionsQueryPort;
+
+    /* Query-порт получения доступных провайдеров. */
+    private final ProviderOptionsQueryPort providerOptionsQueryPort;
+
+    public InstrumentSourcePlanOptionsQueryController(
+            InstrumentOptionsQueryPort instrumentOptionsQueryPort,
+            ProviderOptionsQueryPort providerOptionsQueryPort
+    ) {
+        this.instrumentOptionsQueryPort = Objects.requireNonNull(
+                instrumentOptionsQueryPort,
+                "instrumentOptionsQueryPort must not be null"
+        );
+        this.providerOptionsQueryPort = Objects.requireNonNull(
+                providerOptionsQueryPort,
+                "providerOptionsQueryPort must not be null"
+        );
+    }
+
+    /**
+     * Возвращает данные для dropdown экрана управления планами источников.
+     */
+    @GetMapping("/api/v1/instrument-source-plans/options")
+    public InstrumentSourcePlanOptionsResponse getOptions() {
+        return new InstrumentSourcePlanOptionsResponse(
+                instrumentOptionsQueryPort.findAllInstrumentCodes().stream()
+                        .map(code -> new InstrumentOptionDto(code.value()))
+                        .toList(),
+                providerOptionsQueryPort.findAllProviderCodes().stream()
+                        .map(code -> new ProviderOptionDto(code.value()))
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/dto/InstrumentOptionDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/dto/InstrumentOptionDto.java
@@ -1,0 +1,9 @@
+package com.alligator.market.backend.sourcing.plan.api.query.options.dto;
+
+/**
+ * DTO доступного инструмента для dropdown.
+ */
+public record InstrumentOptionDto(
+        String code
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/dto/InstrumentSourcePlanOptionsResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/dto/InstrumentSourcePlanOptionsResponse.java
@@ -1,0 +1,12 @@
+package com.alligator.market.backend.sourcing.plan.api.query.options.dto;
+
+import java.util.List;
+
+/**
+ * Ответ с options для экрана управления планами источников.
+ */
+public record InstrumentSourcePlanOptionsResponse(
+        List<InstrumentOptionDto> instruments,
+        List<ProviderOptionDto> providers
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/dto/ProviderOptionDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/dto/ProviderOptionDto.java
@@ -1,0 +1,9 @@
+package com.alligator.market.backend.sourcing.plan.api.query.options.dto;
+
+/**
+ * DTO доступного провайдера для dropdown.
+ */
+public record ProviderOptionDto(
+        String code
+) {
+}


### PR DESCRIPTION
### Motivation
- Обеспечить простой read/query-контур для предзагрузки dropdown-опций на фронтенде одним запросом.
- Для такой простой read-логики избегаем дополнительного сервиса и даём контроллеру работать напрямую с query-портами.
- Унифицировать места подключения query-портов через отдельный wiring-конфиг для прозрачности и тестируемости.

### Description
- Добавлен wiring-конфиг `InstrumentSourcePlanOptionsQueryWiringConfig` с бин-ами `instrumentOptionsQueryPort` и `providerOptionsQueryPort`, реализованными через jOOQ-адаптеры. 
- Добавлены DTO: `InstrumentSourcePlanOptionsResponse`, `InstrumentOptionDto` и `ProviderOptionDto` для ответа с перечнем опций. 
- Добавлен контроллер `InstrumentSourcePlanOptionsQueryController` с эндпоинтом `GET /api/v1/instrument-source-plans/options`, который собирает оба списка через порты и возвращает объединённый ответ. 
- Новые файлы расположены под `backend/src/main/java/com/alligator/market/backend/sourcing/...` в каталогах `config/plan/query/options`, `plan/api/query/options/controller` и `plan/api/query/options/dto`.

### Testing
- Попытка сборки `./mvnw -pl backend -DskipTests compile` была выполнена, но завершилась неудачей из-за ошибки загрузки Maven дистрибутива в окружении (`wget: Failed to fetch ...`).
- Автоматические тесты не запускались и компиляция в CI локально не подтверждена по указанной причине.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc4e299aa8832d9de413b2372f0819)