### PR TITLE
Добавить read endpoint списка планов источников

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/controller/GetInstrumentSourcePlansController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/controller/GetInstrumentSourcePlansController.java
@@ -1,0 +1,62 @@
+package com.alligator.market.backend.sourcing.plan.api.query.list.controller;
+
+import com.alligator.market.backend.sourcing.plan.api.query.list.dto.InstrumentMarketDataSourceResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.list.dto.InstrumentSourcePlanResponse;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+import com.alligator.market.domain.sourcing.source.InstrumentMarketDataSource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * REST-адаптер чтения списка существующих планов источников.
+ */
+@RestController
+@RequestMapping("/api/v1/instrument-source-plans")
+public class GetInstrumentSourcePlansController {
+
+    /* Репозиторий планов источников. */
+    private final InstrumentSourcePlanRepository instrumentSourcePlanRepository;
+
+    public GetInstrumentSourcePlansController(
+            InstrumentSourcePlanRepository instrumentSourcePlanRepository
+    ) {
+        this.instrumentSourcePlanRepository = Objects.requireNonNull(
+                instrumentSourcePlanRepository,
+                "instrumentSourcePlanRepository must not be null"
+        );
+    }
+
+    /**
+     * Возвращает список всех существующих планов источников.
+     */
+    @GetMapping
+    public List<InstrumentSourcePlanResponse> getAll() {
+        return instrumentSourcePlanRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /* Маппинг доменного плана в DTO ответа. */
+    private InstrumentSourcePlanResponse toResponse(InstrumentSourcePlan plan) {
+        return new InstrumentSourcePlanResponse(
+                plan.instrumentCode().value(),
+                plan.sources().stream()
+                        .map(this::toResponse)
+                        .toList()
+        );
+    }
+
+    /* Маппинг доменного источника в DTO ответа. */
+    private InstrumentMarketDataSourceResponse toResponse(InstrumentMarketDataSource source) {
+        return new InstrumentMarketDataSourceResponse(
+                source.providerCode().value(),
+                source.active(),
+                source.priority()
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/dto/InstrumentMarketDataSourceResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/dto/InstrumentMarketDataSourceResponse.java
@@ -1,0 +1,11 @@
+package com.alligator.market.backend.sourcing.plan.api.query.list.dto;
+
+/**
+ * DTO источника рыночных данных в ответе API.
+ */
+public record InstrumentMarketDataSourceResponse(
+        String providerCode,
+        boolean active,
+        int priority
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/dto/InstrumentSourcePlanResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/dto/InstrumentSourcePlanResponse.java
@@ -1,0 +1,12 @@
+package com.alligator.market.backend.sourcing.plan.api.query.list.dto;
+
+import java.util.List;
+
+/**
+ * DTO плана источников рыночных данных в ответе API.
+ */
+public record InstrumentSourcePlanResponse(
+        String instrumentCode,
+        List<InstrumentMarketDataSourceResponse> sources
+) {
+}


### PR DESCRIPTION
### Motivation
- Нужен простой строго типизированный read-эндпоинт для получения списка планов источников без лишней бизнес-логики и отдельного query-сервиса.
- Уже имеется `InstrumentSourcePlanRepository.findAll()`, поэтому контроллер может напрямую вернуть данные в виде DTO.

### Description
- Добавлен контроллер `GetInstrumentSourcePlansController` с endpoint `GET /api/v1/instrument-source-plans`, который читает все планы через `InstrumentSourcePlanRepository.findAll()` и маппит их в response DTO.
- Добавлены response DTO `InstrumentSourcePlanResponse` и `InstrumentMarketDataSourceResponse` в пакет `backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/dto`.
- В контроллере реализован маппинг доменных моделей `InstrumentSourcePlan` и `InstrumentMarketDataSource` в соответствующие DTO; файлы: `GetInstrumentSourcePlansController.java`, `InstrumentSourcePlanResponse.java`, `InstrumentMarketDataSourceResponse.java`.

### Testing
- Выполнена попытка сборки `./mvnw -f backend/pom.xml -DskipTests compile`, которая не завершилась успешно из‑за того что `mvnw` не смог скачать дистрибутив Maven из `repo.maven.apache.org` в текущем окружении (сетевая ошибка).
- Автоматических тестов в рамках этого изменения не добавлялось.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc52097d4c832dbf5c4e3e3c529bec)