### PR TITLE
Use ResponseEntity and InstrumentMarketDataSource in CreateInstrumentSourcePlanController

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/create/controller/CreateInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/create/controller/CreateInstrumentSourcePlanController.java
@@ -5,9 +5,10 @@ import com.alligator.market.backend.sourcing.plan.application.create.CreateInstr
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import com.alligator.market.domain.sourcing.source.InstrumentMarketDataSource;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -36,18 +37,14 @@ public class CreateInstrumentSourcePlanController {
      * Создаёт новый план источников для инструмента.
      */
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public void create(@Valid @RequestBody CreateInstrumentSourcePlanRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
-
+    public ResponseEntity<Void> create(@Valid @RequestBody CreateInstrumentSourcePlanRequest request) {
         createInstrumentSourcePlanService.create(toPlan(request));
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     /* Маппинг HTTP-запроса в доменный план. */
     private InstrumentSourcePlan toPlan(CreateInstrumentSourcePlanRequest request) {
-        Objects.requireNonNull(request, "request must not be null");
-
-        List<MarketDataSource> sources = request.sources().stream()
+        List<InstrumentMarketDataSource> sources = request.sources().stream()
                 .map(this::toSource)
                 .toList();
 
@@ -58,12 +55,10 @@ public class CreateInstrumentSourcePlanController {
     }
 
     /* Маппинг HTTP-модели источника в доменный источник. */
-    private MarketDataSource toSource(
+    private InstrumentMarketDataSource toSource(
             CreateInstrumentSourcePlanRequest.InstrumentMarketDataSourceRequest request
     ) {
-        Objects.requireNonNull(request, "request must not be null");
-
-        return new MarketDataSource(
+        return new InstrumentMarketDataSource(
                 new ProviderCode(request.providerCode()),
                 request.active(),
                 request.priority()


### PR DESCRIPTION
### Motivation
- Привести контроллер создания плана источников к общему Spring MVC-паттерну: успешный ответ формируется как `ResponseEntity`, а ошибки обрабатываются централизованно через `ProblemDetail`/advice.
- Исправить некорректный тип доменного источника на корректный `InstrumentMarketDataSource` в маппинге HTTP-запроса в доменную модель.
- Убрать избыточные проверки `Objects.requireNonNull` для валидируемых входных DTO, поскольку валидация и биндинг выполняются Spring.

### Description
- Заменён возвращаемый тип метода `create` с `void` + `@ResponseStatus(HttpStatus.CREATED)` на `ResponseEntity<Void>` с явным `201 Created` через `ResponseEntity.status(HttpStatus.CREATED).build()`.
- Импорт и все упоминания типа `MarketDataSource` заменены на `InstrumentMarketDataSource` в `CreateInstrumentSourcePlanController` и в соответствующих местах маппинга.
- Удалены явные `Objects.requireNonNull` в методах `create`, `toPlan` и `toSource`, оставлена проверка DI-зависимости только в конструкторе контроллера.
- Файл изменён: `backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/create/controller/CreateInstrumentSourcePlanController.java`.

### Testing
- Попытка сборки с помощью `./mvnw -pl backend -DskipTests compile` завершилась неудачно из-за того, что Maven Wrapper не смог скачать дистрибутив (`apache-maven-3.9.9-bin.zip`) в текущем окружении.
- Никаких автоматизированных тестов проекта не запускалось в этом окружении после правок.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcce6bd54832dada44a6357530c4d)