### PR TITLE
refactor: use ResponseEntity in DeleteInstrumentSourcePlanController

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/delete/controller/DeleteInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/delete/controller/DeleteInstrumentSourcePlanController.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.sourcing.plan.api.delete.controller;
 
 import com.alligator.market.backend.sourcing.plan.application.delete.DeleteInstrumentSourcePlanService;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Objects;
@@ -30,10 +30,10 @@ public class DeleteInstrumentSourcePlanController {
      * Удаляет план источников для заданного инструмента.
      */
     @DeleteMapping("/{instrumentCode}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable String instrumentCode) {
+    public ResponseEntity<Void> delete(@PathVariable String instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         deleteInstrumentSourcePlanService.delete(new InstrumentCode(instrumentCode));
+        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
### Motivation
- Выравнять подход к формированию HTTP-ответов и сделать поведение `DeleteInstrumentSourcePlanController` консистентным с `CreateInstrumentSourcePlanController` через явный возврат `ResponseEntity`.

### Description
- Заменён `@ResponseStatus(HttpStatus.NO_CONTENT)` и `void`-сигнатура на `ResponseEntity<Void>` и добавлен возврат `ResponseEntity.noContent().build()`, обновлён импорт на `org.springframework.http.ResponseEntity`.

### Testing
- Выполнена попытка сборки `./mvnw -pl backend -DskipTests compile`, но Maven Wrapper не смог скачать дистрибутив и сборка завершилась неудачей (download failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd68588d0832d90f81d3650795f4e)