### PR TITLE
Возвращать options планов источников через ResponseEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/controller/InstrumentSourcePlanOptionsQueryController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/options/controller/InstrumentSourcePlanOptionsQueryController.java
@@ -5,6 +5,7 @@ import com.alligator.market.backend.sourcing.plan.api.query.options.dto.Instrume
 import com.alligator.market.backend.sourcing.plan.api.query.options.dto.ProviderOptionDto;
 import com.alligator.market.backend.sourcing.plan.application.query.options.port.InstrumentOptionsQueryPort;
 import com.alligator.market.backend.sourcing.plan.application.query.options.port.ProviderOptionsQueryPort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,8 +41,8 @@ public class InstrumentSourcePlanOptionsQueryController {
      * Возвращает данные для dropdown экрана управления планами источников.
      */
     @GetMapping("/api/v1/instrument-source-plans/options")
-    public InstrumentSourcePlanOptionsResponse getOptions() {
-        return new InstrumentSourcePlanOptionsResponse(
+    public ResponseEntity<InstrumentSourcePlanOptionsResponse> getOptions() {
+        InstrumentSourcePlanOptionsResponse response = new InstrumentSourcePlanOptionsResponse(
                 instrumentOptionsQueryPort.findAllInstrumentCodes().stream()
                         .map(code -> new InstrumentOptionDto(code.value()))
                         .toList(),
@@ -49,5 +50,7 @@ public class InstrumentSourcePlanOptionsQueryController {
                         .map(code -> new ProviderOptionDto(code.value()))
                         .toList()
         );
+
+        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
### Motivation
- Метод контроллера `getOptions` должен возвращать HTTP-ответ, чтобы иметь возможность управлять статусом и заголовками вместо прямого возврата DTO.  

### Description
- Изменена сигнатура `getOptions()` на `ResponseEntity<InstrumentSourcePlanOptionsResponse>`, добавлен импорт `org.springframework.http.ResponseEntity`, введена локальная переменная `response` и результат возвращается через `ResponseEntity.ok(response)`.  

### Testing
- Попытка выполнить `./mvnw -pl backend -DskipTests compile` не удалась из-за проблем окружения при скачивании Maven (`wget: Failed to fetch https://repo.maven.apache.org/.../apache-maven-3.9.9-bin.zip`), поэтому автоматическая сборка не была подтверждена.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfdbe62c20832da2629d2cc1a6f3fa)