### PR TITLE
Добавить миграцию `instrument_source_plan`

### DIFF
--- a/backend/src/main/resources/db/migration/sourcing/plan/V20260318_02__create_instrument_source_plan.sql
+++ b/backend/src/main/resources/db/migration/sourcing/plan/V20260318_02__create_instrument_source_plan.sql
@@ -1,0 +1,10 @@
+-- instrument_source_plan: план источников рыночных данных для конкретного инструмента.
+CREATE TABLE instrument_source_plan
+(
+    -- Идентичность плана источников
+    instrument_code VARCHAR(50) PRIMARY KEY,
+
+    -- Ограничение ссылочной целостности
+    CONSTRAINT fk_instr_source_plan_instrument
+        FOREIGN KEY (instrument_code) REFERENCES instrument_base (code)
+);


### PR DESCRIPTION
### Motivation
- Ввести явную родительскую сущность «план источников» для инструмента в схему как минимальную таблицу, соответствующую модели «один план на один instrumentCode». 

### Description
- Добавлен файл `backend/src/main/resources/db/migration/sourcing/plan/V20260318_02__create_instrument_source_plan.sql`, создающий таблицу `instrument_source_plan` с естественным PK `instrument_code` и именованным FK `fk_instr_source_plan_instrument` на `instrument_base(code)`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d29e8090832db2cf82c8194a51c8)