### PR TITLE
Исправить FK миграции instrument_market_data_source на instrument_source_plan

### DIFF
--- a/backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_instrument_market_data_source.sql
+++ b/backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_instrument_market_data_source.sql
@@ -11,7 +11,10 @@ CREATE TABLE instrument_market_data_source
     priority        INTEGER     NOT NULL,
 
     -- Ограничения ссылочной целостности
-    CONSTRAINT fk_instr_market_data_source_instrument FOREIGN KEY (instrument_code) REFERENCES instrument_base (code),
+    CONSTRAINT fk_instr_market_data_source_plan
+        FOREIGN KEY (instrument_code)
+            REFERENCES instrument_source_plan (instrument_code)
+            ON DELETE CASCADE,
 
     -- Ограничения уникальности
     CONSTRAINT uk_instr_market_data_source_instr_provider UNIQUE (instrument_code, provider_code),


### PR DESCRIPTION
### Motivation
- Обеспечить корректную ссылочную целостность: `instrument_market_data_source` должен ссылаться на план источников `instrument_source_plan`, а не на базовую сущность `instrument_base`.

### Description
- Обновлён файл миграции `backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_instrument_market_data_source.sql` — внешний ключ сменён с `instrument_base (code)` на `instrument_source_plan (instrument_code)`, ограничение переименовано в `fk_instr_market_data_source_plan` и добавлен `ON DELETE CASCADE`.

### Testing
- Миграцию нашли с помощью `rg` и проверили содержимое файла командами `sed -n '1,220p'` и `nl -ba`, подтвердив, что строки с FK и именем ограничения обновлены правильно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f7f677a4832d9f5c1a40767680de)