### PR TITLE
Изменить контракт InstrumentSourcePlanRepository: `create` → `createIfAbsent` (boolean)

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
@@ -22,9 +22,12 @@ public interface InstrumentSourcePlanRepository {
     List<InstrumentSourcePlan> findAll();
 
     /**
-     * Создаёт план источников для заданного инструмента.
+     * Создаёт план источников для заданного инструмента,
+     * если он ещё не существует.
+     *
+     * @return true, если план создан; false, если план уже существует
      */
-    void create(InstrumentSourcePlan plan);
+    boolean createIfAbsent(InstrumentSourcePlan plan);
 
     /**
      * Удаляет план источников для заданного инструмента.


### PR DESCRIPTION
### Motivation
- Порт `InstrumentSourcePlanRepository` ранее выражал семантику «просто создать», тогда как требуется атомарная операция: попытаться создать план только если он отсутствует и вернуть результат попытки (`true`/`false`).

### Description
- В файле `domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java` заменён `void create(InstrumentSourcePlan plan)` на `boolean createIfAbsent(InstrumentSourcePlan plan)` и обновлён JavaDoc, чтобы зафиксировать новую семантику и значение возвращаемого результата.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f94f615c832db5da32a7b13c1c31)