### PR TITLE
Сделать список таблиц jOOQ `includes` более читаемым

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -116,7 +116,16 @@
                                 <database>
                                     <name>org.jooq.meta.postgres.PostgresDatabase</name>
                                     <inputSchema>public</inputSchema>
-                                    <includes>(instrument_source_plan|instrument_market_data_source|instrument_base|provider_passport)</includes>
+                                    <!-- Таблицы, для которых генерируется jOOQ-код. -->
+                                    <includes>
+                                        (?x)
+                                        (
+                                            instrument_source_plan
+                                            | instrument_market_data_source
+                                            | instrument_base
+                                            | provider_passport
+                                        )
+                                    </includes>
                                 </database>
 
                                 <target>


### PR DESCRIPTION
### Motivation
- Улучшить читаемость и удобство поддержки jOOQ-конфигурации в `backend/pom.xml`, чтобы список таблиц был очевиден и проще расширялся.

### Description
- Переформатировал тег `<includes>` в `backend/pom.xml` в многострочный regex с inline-флагом `(?x)` и добавил комментарий над блоком; список таблиц теперь указан в столбик.

### Testing
- Запуск `mvn -pl backend -DskipTests -q validate` был выполнен и завершился с ошибкой из-за недоступности parent POM в Maven Central (`403 Forbidden`), изменений, влияющих на сборку, не обнаружено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fd82bbb8832dae7430a0ec57af44)