### PR TITLE
refactor: использовать createIfAbsent в CreateInstrumentSourcePlanService

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/create/CreateInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/create/CreateInstrumentSourcePlanService.java
@@ -61,11 +61,10 @@ public final class CreateInstrumentSourcePlanService {
         // Проверяем, что все коды провайдеров из плана существуют
         ensureProvidersExist(plan);
 
-        // Проверяем, что сценарий действительно является create, а не попыткой тихо заменить уже существующий план
-        ensurePlanDoesNotExist(plan);
-
-        // После прикладных проверок делегируем создание в репозиторий
-        instrumentSourcePlanRepository.create(plan);
+        // Атомарно создаём план, если он ещё не существует
+        if (!instrumentSourcePlanRepository.createIfAbsent(plan)) {
+            throw new InstrumentSourcePlanAlreadyExistsException(plan.instrumentCode());
+        }
     }
 
     /**
@@ -94,12 +93,4 @@ public final class CreateInstrumentSourcePlanService {
         }
     }
 
-    /**
-     * Проверяет, что план для инструмента ещё не создан.
-     */
-    private void ensurePlanDoesNotExist(InstrumentSourcePlan plan) {
-        if (instrumentSourcePlanRepository.findByInstrumentCode(plan.instrumentCode()).isPresent()) {
-            throw new InstrumentSourcePlanAlreadyExistsException(plan.instrumentCode());
-        }
-    }
 }


### PR DESCRIPTION
### Motivation
- Обновить логику создания плана источников так, чтобы сервис использовал атомарный контракт репозитория `createIfAbsent(...)` вместо предварительной проверки наличия плана.

### Description
- В `CreateInstrumentSourcePlanService#create(...)` удалён вызов `ensurePlanDoesNotExist(plan)` и сам метод `ensurePlanDoesNotExist(...)`, а вызов `instrumentSourcePlanRepository.create(plan)` заменён на атомарный блок `if (!instrumentSourcePlanRepository.createIfAbsent(plan)) { throw new InstrumentSourcePlanAlreadyExistsException(plan.instrumentCode()); }`.

### Testing
- Выполнены проверочные команды `git status --short`, `git diff` и `git commit`, которые завершились успешно, автоматических юнит/inteграционных тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d512b24a24832d843a5285ea3b363e)