### PR TITLE
Локальные поля `@Version` в сущностях; убрано наследование от `BaseEntity`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/catalog/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/catalog/persistence/jpa/CurrencyEntity.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.catalog.persistence.jpa;
 
-import com.alligator.market.backend.common.persistence.jpa.entity.BaseEntity;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import jakarta.persistence.*;
@@ -53,7 +52,7 @@ import java.util.Objects;
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CurrencyEntity extends BaseEntity {
+public class CurrencyEntity {
 
     /**
      * Суррогатный PK.
@@ -62,6 +61,10 @@ public class CurrencyEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
 
     /**
      * Код валюты (натуральный ключ).

--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/catalog/persistence/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/catalog/persistence/jpa/InstrumentEntity.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.base.catalog.persistence.jpa;
 
-import com.alligator.market.backend.common.persistence.jpa.entity.BaseEntity;
 import com.alligator.market.backend.instrument.base.catalog.persistence.jpa.converter.AssetClassConverter;
 import com.alligator.market.backend.instrument.base.catalog.persistence.jpa.converter.ContractTypeConverter;
 import com.alligator.market.backend.instrument.base.catalog.persistence.jpa.converter.InstrumentCodeConverter;
@@ -40,7 +39,7 @@ import java.util.Objects;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public abstract class InstrumentEntity extends BaseEntity {
+public abstract class InstrumentEntity {
 
     /**
      * Суррогатный PK.
@@ -49,6 +48,10 @@ public abstract class InstrumentEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
 
     /**
      * Внутренний код инструмента (идентификатор).


### PR DESCRIPTION
### Motivation
- Сделать `CurrencyEntity` независимой JPA-сущностью с локальным полем версии (`@Version`), чтобы убрать зависимость от иерархии `BaseEntity`.
- По аналогии перевести на локальное поле версии другие сущности, которые расширяют `BaseEntity`, чтобы упростить модель и подготовить дальнейшие изменения.

### Description
- Убрано `extends BaseEntity` и добавлено локальное поле версии `@Version @Column(name = "version", nullable = false) private Long version;` в `CurrencyEntity` (`backend/.../CurrencyEntity.java`).
- По той же схеме убрано наследование и добавлено локальное поле версии в `InstrumentEntity` (`backend/.../InstrumentEntity.java`).
- Файл `BaseEntity` оставлен без изменений.

### Testing
- Выполнена попытка компиляции бэкенда командой `./mvnw -pl backend -DskipTests compile`, которая завершилась неудачей из‑за невозможности скачать дистрибутив Maven с `repo.maven.apache.org` (сетевая/окруженческая проблема).
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62ec0a4d8832d9f678d1f0929a39b)