### PR TITLE
fix: delete plan from instrument_source_plan in repository

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/repository/adapter/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/repository/adapter/JooqInstrumentSourcePlanRepository.java
@@ -119,8 +119,8 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
     public void deleteByInstrumentCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
-        dsl.deleteFrom(INSTRUMENT_MARKET_DATA_SOURCE)
-                .where(INSTRUMENT_MARKET_DATA_SOURCE.INSTRUMENT_CODE.eq(instrumentCode.value()))
+        dsl.deleteFrom(INSTRUMENT_SOURCE_PLAN)
+                .where(INSTRUMENT_SOURCE_PLAN.INSTRUMENT_CODE.eq(instrumentCode.value()))
                 .execute();
     }
 


### PR DESCRIPTION
### Motivation
- После введения родительской таблицы факт существования плана хранится в `instrument_source_plan`, и удаление только дочерних строк оставляло «пустой» план, что ломало поведение `createIfAbsent(...)`.

### Description
- В файле `backend/src/main/java/com/alligator/market/backend/sourcing/plan/repository/adapter/JooqInstrumentSourcePlanRepository.java` метод `deleteByInstrumentCode(...)` заменён на `dsl.deleteFrom(INSTRUMENT_SOURCE_PLAN)` вместо удаления из `INSTRUMENT_MARKET_DATA_SOURCE`.
- Условие удаления теперь использует `INSTRUMENT_SOURCE_PLAN.INSTRUMENT_CODE`.
- Изменение сохранено в репозитории (коммит выполнен).

### Testing
- Попытка запустить `./gradlew :backend:compileJava` не выполнена, так как `./gradlew` отсутствует в проекте.
- Попытка запустить `./mvnw -pl backend -DskipTests compile` завершилась с ошибкой из-за невозможности загрузить Maven дистрибутив (`Failed to fetch ... apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d63fedc760832dba8909c6cee5cde9)