### PR TITLE
Изменить контракт delete в InstrumentSourcePlanRepository на boolean

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
@@ -31,6 +31,8 @@ public interface InstrumentSourcePlanRepository {
 
     /**
      * Удаляет план источников для заданного инструмента.
+     *
+     * @return true, если план был удалён; false, если плана не было
      */
-    void deleteByInstrumentCode(InstrumentCode instrumentCode);
+    boolean deleteByInstrumentCode(InstrumentCode instrumentCode);
 }


### PR DESCRIPTION
### Motivation
- Изменить контракт удаления в порте `InstrumentSourcePlanRepository`, чтобы метод `deleteByInstrumentCode` возвращал признак успешного удаления вместо `void`, чтобы убрать лишние предварительные обходы в сервисах и упростить логические операции удаления.

### Description
- Обновлён интерфейс `InstrumentSourcePlanRepository`: в файле `domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java` метод `deleteByInstrumentCode(InstrumentCode instrumentCode)` теперь возвращает `boolean` и имеет уточнённый JavaDoc, где `true` — план был удалён, `false` — плана не было.

### Testing
- Автоматические тесты не выполнялись для этого изменения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64343686c832d92c0a69480e6664d)