### PR TITLE
Добавить чтение плана источников для инструмента (GET)

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
@@ -1,0 +1,32 @@
+package com.alligator.market.backend.sourcing.config.plan.application.query.get;
+
+import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.plan.application.query.get.GetInstrumentSourcePlanService;
+import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Конфигурация wiring {@link GetInstrumentSourcePlanService}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        InstrumentSourcePlanRepositoryWiringConfig.class
+})
+public class GetInstrumentSourcePlanServiceWiringConfig {
+
+    public static final String BEAN_GET_INSTRUMENT_SOURCE_PLAN_SERVICE = "getInstrumentSourcePlanService";
+
+    /**
+     * Сервис чтения плана источников рыночных данных для инструмента.
+     */
+    @Bean(BEAN_GET_INSTRUMENT_SOURCE_PLAN_SERVICE)
+    public GetInstrumentSourcePlanService getInstrumentSourcePlanService(
+            @Qualifier(InstrumentSourcePlanRepositoryWiringConfig.BEAN_INSTRUMENT_SOURCE_PLAN_REPOSITORY)
+            InstrumentSourcePlanRepository instrumentSourcePlanRepository
+    ) {
+        return new GetInstrumentSourcePlanService(instrumentSourcePlanRepository);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.sourcing.plan.api.command.create.controller.CreateInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.delete.controller.DeleteInstrumentSourcePlanController;
+import com.alligator.market.backend.sourcing.plan.api.query.get.controller.GetInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.query.options.controller.InstrumentSourcePlanOptionsQueryController;
 import com.alligator.market.backend.sourcing.plan.application.command.create.exception.InstrumentCodeNotFoundException;
 import com.alligator.market.backend.sourcing.plan.application.command.create.exception.ProviderCodesNotFoundException;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(assignableTypes = {
         CreateInstrumentSourcePlanController.class,
         DeleteInstrumentSourcePlanController.class,
+        GetInstrumentSourcePlanController.class,
         InstrumentSourcePlanOptionsQueryController.class
 })
 public class InstrumentSourcePlanRestExceptionHandler {

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/controller/GetInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/controller/GetInstrumentSourcePlanController.java
@@ -1,0 +1,63 @@
+package com.alligator.market.backend.sourcing.plan.api.query.get.controller;
+
+import com.alligator.market.backend.sourcing.plan.api.query.get.dto.InstrumentSourcePlanResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.get.dto.MarketDataSourceResponse;
+import com.alligator.market.backend.sourcing.plan.application.query.get.GetInstrumentSourcePlanService;
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * REST-адаптер чтения одного плана источников инструмента.
+ */
+@RestController
+@RequestMapping("/api/v1/instrument-source-plans")
+public class GetInstrumentSourcePlanController {
+
+    /* Сервис get-use case. */
+    private final GetInstrumentSourcePlanService getInstrumentSourcePlanService;
+
+    public GetInstrumentSourcePlanController(GetInstrumentSourcePlanService getInstrumentSourcePlanService) {
+        this.getInstrumentSourcePlanService = Objects.requireNonNull(
+                getInstrumentSourcePlanService,
+                "getInstrumentSourcePlanService must not be null"
+        );
+    }
+
+    /**
+     * Возвращает план источников для заданного инструмента.
+     */
+    @GetMapping("/{instrumentCode}")
+    public ResponseEntity<InstrumentSourcePlanResponse> get(@PathVariable String instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        InstrumentSourcePlan plan = getInstrumentSourcePlanService.get(new InstrumentCode(instrumentCode));
+        return ResponseEntity.ok(toResponse(plan));
+    }
+
+    /* Маппинг доменного плана в HTTP-ответ. */
+    private InstrumentSourcePlanResponse toResponse(InstrumentSourcePlan plan) {
+        List<MarketDataSourceResponse> sources = plan.sources().stream()
+                .map(this::toSourceResponse)
+                .toList();
+
+        return new InstrumentSourcePlanResponse(plan.instrumentCode().value(), sources);
+    }
+
+    /* Маппинг доменного источника в HTTP-модель источника. */
+    private MarketDataSourceResponse toSourceResponse(MarketDataSource source) {
+        return new MarketDataSourceResponse(
+                source.providerCode().value(),
+                source.active(),
+                source.priority()
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/dto/InstrumentSourcePlanResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/dto/InstrumentSourcePlanResponse.java
@@ -1,0 +1,12 @@
+package com.alligator.market.backend.sourcing.plan.api.query.get.dto;
+
+import java.util.List;
+
+/**
+ * DTO ответа с планом источников по инструменту.
+ */
+public record InstrumentSourcePlanResponse(
+        String instrumentCode,
+        List<MarketDataSourceResponse> sources
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/dto/MarketDataSourceResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/dto/MarketDataSourceResponse.java
@@ -1,0 +1,11 @@
+package com.alligator.market.backend.sourcing.plan.api.query.get.dto;
+
+/**
+ * DTO источника рыночных данных в ответе плана инструмента.
+ */
+public record MarketDataSourceResponse(
+        String providerCode,
+        boolean active,
+        int priority
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/get/GetInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/get/GetInstrumentSourcePlanService.java
@@ -1,0 +1,34 @@
+package com.alligator.market.backend.sourcing.plan.application.query.get;
+
+import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentSourcePlanNotFoundException;
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+
+import java.util.Objects;
+
+/**
+ * Сервис чтения плана источников рыночных данных для инструмента.
+ */
+public final class GetInstrumentSourcePlanService {
+
+    /* Репозиторий планов источников. */
+    private final InstrumentSourcePlanRepository instrumentSourcePlanRepository;
+
+    public GetInstrumentSourcePlanService(InstrumentSourcePlanRepository instrumentSourcePlanRepository) {
+        this.instrumentSourcePlanRepository = Objects.requireNonNull(
+                instrumentSourcePlanRepository,
+                "instrumentSourcePlanRepository must not be null"
+        );
+    }
+
+    /**
+     * Возвращает план источников для инструмента.
+     */
+    public InstrumentSourcePlan get(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        return instrumentSourcePlanRepository.findByInstrumentCode(instrumentCode)
+                .orElseThrow(() -> new InstrumentSourcePlanNotFoundException(instrumentCode));
+    }
+}


### PR DESCRIPTION
### Motivation
- Реализовать полный vertical slice чтения одного плана источников по коду инструмента и вернуть его через REST API. 
- Использовать существующий `InstrumentSourcePlanRepository` без новых портов и обеспечить единое поведение обработки ошибок (404) на уровне feature.

### Description
- Добавлен `GetInstrumentSourcePlanService` (`backend/.../application/query/get/GetInstrumentSourcePlanService.java`), который принимает `InstrumentCode`, читает план через `InstrumentSourcePlanRepository` и кидает `InstrumentSourcePlanNotFoundException`, если план отсутствует.  
- Добавлен wiring-конфиг `GetInstrumentSourcePlanServiceWiringConfig` (`backend/.../application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java`) с `@Import(InstrumentSourcePlanRepositoryWiringConfig.class)` и константой `BEAN_GET_INSTRUMENT_SOURCE_PLAN_SERVICE`.  
- Добавлен REST-контроллер `GetInstrumentSourcePlanController` (`backend/.../api/query/get/controller/GetInstrumentSourcePlanController.java`) с endpoint `GET /api/v1/instrument-source-plans/{instrumentCode}`, который вызывает сервис и маппит доменную модель в DTO.  
- Добавлены response DTO `InstrumentSourcePlanResponse` и `MarketDataSourceResponse` (`backend/.../api/query/get/dto/InstrumentSourcePlanResponse.java`, `backend/.../api/query/get/dto/MarketDataSourceResponse.java`), и обновлён feature-level exception handler `InstrumentSourcePlanRestExceptionHandler` чтобы включать `GetInstrumentSourcePlanController` в `assignableTypes` (404 обрабатывается этим handler).  
- Ничего лишнего не добавлено: нет списка всех планов, нет update/replace; порядок `sources` сохраняется как возвращает репозиторий (по `priority`).

### Testing
- Попытка сборки проекта: выполнена команда `mvn -f backend/pom.xml -DskipTests compile`, но сборка не прошла из-за внешней ошибки загрузки зависимости (HTTP `403` при скачивании `org.springframework.boot:spring-boot-starter-parent:4.0.5`) в текущем окружении.  
- Автоматических тестов нового кода не добавлялось и не запускалось, из‑за невозможности завершить сборку в текущем окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d664c952e0832d98334fcf2f6fc11d)