### PR TITLE
Добавлен list endpoint для планов источников инструмента

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
@@ -1,0 +1,32 @@
+package com.alligator.market.backend.sourcing.config.plan.application.query.list;
+
+import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.plan.application.query.list.ListInstrumentSourcePlansService;
+import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Конфигурация wiring {@link ListInstrumentSourcePlansService}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        InstrumentSourcePlanRepositoryWiringConfig.class
+})
+public class ListInstrumentSourcePlansServiceWiringConfig {
+
+    public static final String BEAN_LIST_INSTRUMENT_SOURCE_PLANS_SERVICE = "listInstrumentSourcePlansService";
+
+    /**
+     * Сервис чтения планов источников рыночных данных.
+     */
+    @Bean(BEAN_LIST_INSTRUMENT_SOURCE_PLANS_SERVICE)
+    public ListInstrumentSourcePlansService listInstrumentSourcePlansService(
+            @Qualifier(InstrumentSourcePlanRepositoryWiringConfig.BEAN_INSTRUMENT_SOURCE_PLAN_REPOSITORY)
+            InstrumentSourcePlanRepository instrumentSourcePlanRepository
+    ) {
+        return new ListInstrumentSourcePlansService(instrumentSourcePlanRepository);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/controller/ListInstrumentSourcePlansController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/controller/ListInstrumentSourcePlansController.java
@@ -1,0 +1,63 @@
+package com.alligator.market.backend.sourcing.plan.api.query.list.controller;
+
+import com.alligator.market.backend.sourcing.plan.api.query.get.dto.InstrumentSourcePlanResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.get.dto.MarketDataSourceResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.list.dto.InstrumentSourcePlanListResponse;
+import com.alligator.market.backend.sourcing.plan.application.query.list.ListInstrumentSourcePlansService;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * REST-адаптер чтения списка планов источников инструментов.
+ */
+@RestController
+@RequestMapping("/api/v1/instrument-source-plans")
+public class ListInstrumentSourcePlansController {
+
+    /* Сервис list-use case. */
+    private final ListInstrumentSourcePlansService listInstrumentSourcePlansService;
+
+    public ListInstrumentSourcePlansController(ListInstrumentSourcePlansService listInstrumentSourcePlansService) {
+        this.listInstrumentSourcePlansService = Objects.requireNonNull(
+                listInstrumentSourcePlansService,
+                "listInstrumentSourcePlansService must not be null"
+        );
+    }
+
+    /**
+     * Возвращает планы источников для всех инструментов.
+     */
+    @GetMapping
+    public ResponseEntity<InstrumentSourcePlanListResponse> list() {
+        List<InstrumentSourcePlanResponse> plans = listInstrumentSourcePlansService.list().stream()
+                .map(this::toPlanResponse)
+                .toList();
+
+        return ResponseEntity.ok(new InstrumentSourcePlanListResponse(plans));
+    }
+
+    /* Маппинг доменного плана в HTTP-модель плана. */
+    private InstrumentSourcePlanResponse toPlanResponse(InstrumentSourcePlan plan) {
+        List<MarketDataSourceResponse> sources = plan.sources().stream()
+                .map(this::toSourceResponse)
+                .toList();
+
+        return new InstrumentSourcePlanResponse(plan.instrumentCode().value(), sources);
+    }
+
+    /* Маппинг доменного источника в HTTP-модель источника. */
+    private MarketDataSourceResponse toSourceResponse(MarketDataSource source) {
+        return new MarketDataSourceResponse(
+                source.providerCode().value(),
+                source.active(),
+                source.priority()
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/dto/InstrumentSourcePlanListResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/dto/InstrumentSourcePlanListResponse.java
@@ -1,0 +1,13 @@
+package com.alligator.market.backend.sourcing.plan.api.query.list.dto;
+
+import com.alligator.market.backend.sourcing.plan.api.query.get.dto.InstrumentSourcePlanResponse;
+
+import java.util.List;
+
+/**
+ * DTO ответа со списком планов источников по инструментам.
+ */
+public record InstrumentSourcePlanListResponse(
+        List<InstrumentSourcePlanResponse> plans
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/list/ListInstrumentSourcePlansService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/list/ListInstrumentSourcePlansService.java
@@ -1,0 +1,30 @@
+package com.alligator.market.backend.sourcing.plan.application.query.list;
+
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Сервис чтения всех планов источников рыночных данных.
+ */
+public final class ListInstrumentSourcePlansService {
+
+    /* Репозиторий планов источников. */
+    private final InstrumentSourcePlanRepository instrumentSourcePlanRepository;
+
+    public ListInstrumentSourcePlansService(InstrumentSourcePlanRepository instrumentSourcePlanRepository) {
+        this.instrumentSourcePlanRepository = Objects.requireNonNull(
+                instrumentSourcePlanRepository,
+                "instrumentSourcePlanRepository must not be null"
+        );
+    }
+
+    /**
+     * Возвращает планы источников для всех инструментов.
+     */
+    public List<InstrumentSourcePlan> list() {
+        return instrumentSourcePlanRepository.findAll();
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить вертикальный slice для получения списка всех планов источников, чтобы предоставить данные для UI-экрана управления планами.
- Переиспользовать уже существующие DTO `InstrumentSourcePlanResponse` и `MarketDataSourceResponse`, чтобы избежать дублирования моделей в API.

### Description
- Добавлен query-usecase `ListInstrumentSourcePlansService` в `backend/src/main/java/.../application/query/list/ListInstrumentSourcePlansService.java`, который без аргументов вызывает `instrumentSourcePlanRepository.findAll()` и возвращает `List<InstrumentSourcePlan>`.
- Добавлена wiring-конфигурация `ListInstrumentSourcePlansServiceWiringConfig` в `backend/src/main/java/.../config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java` для регистрации bean `listInstrumentSourcePlansService` в Spring с подключением репозитория.
- Добавлен REST-контроллер `ListInstrumentSourcePlansController` в `backend/src/main/java/.../plan/api/query/list/controller/ListInstrumentSourcePlansController.java` с endpoint `GET /api/v1/instrument-source-plans`, который маппит доменные планы в `InstrumentSourcePlanResponse` и источники в `MarketDataSourceResponse` и возвращает контейнер `plans`.
- Добавлен DTO-контейнер `InstrumentSourcePlanListResponse` в `backend/src/main/java/.../plan/api/query/list/dto/InstrumentSourcePlanListResponse.java` с единственным полем `plans` и без дублирования внутренних DTO.

### Testing
- Выполнен командой `mvn -pl backend -DskipTests compile`, сборка не завершилась успешно из-за недоступности артефактов в окружении (Maven Central вернул `403 Forbidden` при загрузке parent POM), поэтому компиляция/тесты в CI не были подтверждены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6695a86e0832d8a70ba411d68f8c4)