### PR TITLE
Добавить replace-use case для InstrumentSourcePlan

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
@@ -1,0 +1,46 @@
+package com.alligator.market.backend.sourcing.config.plan.application.command.replace;
+
+import com.alligator.market.backend.sourcing.config.plan.application.command.create.port.InstrumentCodeExistencePortWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.command.create.port.ProviderCodeExistencePortWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.plan.application.command.create.port.InstrumentCodeExistencePort;
+import com.alligator.market.backend.sourcing.plan.application.command.create.port.ProviderCodeExistencePort;
+import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;
+import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Конфигурация wiring {@link ReplaceInstrumentSourcePlanService}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        InstrumentSourcePlanRepositoryWiringConfig.class,
+        InstrumentCodeExistencePortWiringConfig.class,
+        ProviderCodeExistencePortWiringConfig.class
+})
+public class ReplaceInstrumentSourcePlanServiceWiringConfig {
+
+    public static final String BEAN_REPLACE_INSTRUMENT_SOURCE_PLAN_SERVICE = "replaceInstrumentSourcePlanService";
+
+    /**
+     * Сервис полной замены плана источников рыночных данных для инструмента.
+     */
+    @Bean(BEAN_REPLACE_INSTRUMENT_SOURCE_PLAN_SERVICE)
+    public ReplaceInstrumentSourcePlanService replaceInstrumentSourcePlanService(
+            @Qualifier(InstrumentSourcePlanRepositoryWiringConfig.BEAN_INSTRUMENT_SOURCE_PLAN_REPOSITORY)
+            InstrumentSourcePlanRepository instrumentSourcePlanRepository,
+            @Qualifier(InstrumentCodeExistencePortWiringConfig.BEAN_INSTRUMENT_CODE_EXISTENCE_PORT)
+            InstrumentCodeExistencePort instrumentCodeExistencePort,
+            @Qualifier(ProviderCodeExistencePortWiringConfig.BEAN_PROVIDER_CODE_EXISTENCE_PORT)
+            ProviderCodeExistencePort providerCodeExistencePort
+    ) {
+        return new ReplaceInstrumentSourcePlanService(
+                instrumentSourcePlanRepository,
+                instrumentCodeExistencePort,
+                providerCodeExistencePort
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
@@ -4,6 +4,7 @@ import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.sourcing.plan.api.command.create.controller.CreateInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.delete.controller.DeleteInstrumentSourcePlanController;
+import com.alligator.market.backend.sourcing.plan.api.command.replace.controller.ReplaceInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.query.get.controller.GetInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.query.options.controller.InstrumentSourcePlanOptionsQueryController;
 import com.alligator.market.backend.sourcing.plan.application.command.create.exception.InstrumentCodeNotFoundException;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(assignableTypes = {
         CreateInstrumentSourcePlanController.class,
         DeleteInstrumentSourcePlanController.class,
+        ReplaceInstrumentSourcePlanController.class,
         GetInstrumentSourcePlanController.class,
         InstrumentSourcePlanOptionsQueryController.class
 })

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/controller/ReplaceInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/controller/ReplaceInstrumentSourcePlanController.java
@@ -1,0 +1,71 @@
+package com.alligator.market.backend.sourcing.plan.api.command.replace.controller;
+
+import com.alligator.market.backend.sourcing.plan.api.command.replace.dto.ReplaceInstrumentSourcePlanRequest;
+import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+import com.alligator.market.domain.provider.model.vo.ProviderCode;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * REST-адаптер полной замены плана источников инструмента.
+ */
+@RestController
+@RequestMapping("/api/v1/instrument-source-plans")
+public class ReplaceInstrumentSourcePlanController {
+
+    /* Сервис replace-use case. */
+    private final ReplaceInstrumentSourcePlanService replaceInstrumentSourcePlanService;
+
+    public ReplaceInstrumentSourcePlanController(
+            ReplaceInstrumentSourcePlanService replaceInstrumentSourcePlanService
+    ) {
+        this.replaceInstrumentSourcePlanService = Objects.requireNonNull(
+                replaceInstrumentSourcePlanService,
+                "replaceInstrumentSourcePlanService must not be null"
+        );
+    }
+
+    /**
+     * Полностью заменяет план источников для заданного инструмента.
+     */
+    @PutMapping("/{instrumentCode}")
+    public ResponseEntity<Void> replace(
+            @PathVariable String instrumentCode,
+            @Valid @RequestBody ReplaceInstrumentSourcePlanRequest request
+    ) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        replaceInstrumentSourcePlanService.replace(toPlan(instrumentCode, request));
+        return ResponseEntity.noContent().build();
+    }
+
+    /* Маппинг HTTP-запроса в доменный план. */
+    private InstrumentSourcePlan toPlan(String instrumentCode, ReplaceInstrumentSourcePlanRequest request) {
+        List<MarketDataSource> sources = request.sources().stream()
+                .map(this::toSource)
+                .toList();
+
+        return new InstrumentSourcePlan(
+                new InstrumentCode(instrumentCode),
+                sources
+        );
+    }
+
+    /* Маппинг HTTP-модели источника в доменный источник. */
+    private MarketDataSource toSource(
+            ReplaceInstrumentSourcePlanRequest.MarketDataSourceRequest request
+    ) {
+        return new MarketDataSource(
+                new ProviderCode(request.providerCode()),
+                request.active(),
+                request.priority()
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/dto/ReplaceInstrumentSourcePlanRequest.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/dto/ReplaceInstrumentSourcePlanRequest.java
@@ -1,0 +1,40 @@
+package com.alligator.market.backend.sourcing.plan.api.command.replace.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.util.List;
+
+/**
+ * HTTP-запрос на полную замену плана источников инструмента.
+ */
+public record ReplaceInstrumentSourcePlanRequest(
+
+        /* Источники рыночных данных для инструмента. */
+        @NotEmpty(message = "sources must not be empty")
+        List<@Valid MarketDataSourceRequest> sources
+) {
+
+    /**
+     * HTTP-модель одного источника в составе плана.
+     */
+    public record MarketDataSourceRequest(
+
+            /* Код провайдера-источника. */
+            @NotBlank(message = "providerCode must not be blank")
+            String providerCode,
+
+            /* Признак активности источника. */
+            @NotNull(message = "active must not be null")
+            Boolean active,
+
+            /* Приоритет источника. */
+            @NotNull(message = "priority must not be null")
+            @PositiveOrZero(message = "priority must be greater than or equal to 0")
+            Integer priority
+    ) {
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
@@ -1,0 +1,102 @@
+package com.alligator.market.backend.sourcing.plan.application.command.replace;
+
+import com.alligator.market.backend.sourcing.plan.application.command.create.exception.InstrumentCodeNotFoundException;
+import com.alligator.market.backend.sourcing.plan.application.command.create.exception.ProviderCodesNotFoundException;
+import com.alligator.market.backend.sourcing.plan.application.command.create.port.InstrumentCodeExistencePort;
+import com.alligator.market.backend.sourcing.plan.application.command.create.port.ProviderCodeExistencePort;
+import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentSourcePlanNotFoundException;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Сервис полной замены плана источников рыночных данных для инструмента.
+ */
+public final class ReplaceInstrumentSourcePlanService {
+
+    /* Репозиторий планов источников. */
+    private final InstrumentSourcePlanRepository instrumentSourcePlanRepository;
+
+    /* Порт проверки существования инструмента по коду. */
+    private final InstrumentCodeExistencePort instrumentCodeExistencePort;
+
+    /* Порт проверки существования провайдера по коду. */
+    private final ProviderCodeExistencePort providerCodeExistencePort;
+
+    public ReplaceInstrumentSourcePlanService(
+            InstrumentSourcePlanRepository instrumentSourcePlanRepository,
+            InstrumentCodeExistencePort instrumentCodeExistencePort,
+            ProviderCodeExistencePort providerCodeExistencePort
+    ) {
+        this.instrumentSourcePlanRepository = Objects.requireNonNull(
+                instrumentSourcePlanRepository,
+                "instrumentSourcePlanRepository must not be null"
+        );
+        this.instrumentCodeExistencePort = Objects.requireNonNull(
+                instrumentCodeExistencePort,
+                "instrumentCodeExistencePort must not be null"
+        );
+        this.providerCodeExistencePort = Objects.requireNonNull(
+                providerCodeExistencePort,
+                "providerCodeExistencePort must not be null"
+        );
+    }
+
+    /**
+     * Полностью заменяет содержимое существующего плана источников.
+     */
+    public void replace(InstrumentSourcePlan plan) {
+        Objects.requireNonNull(plan, "plan must not be null");
+
+        // Проверяем, что инструмент реально существует
+        ensureInstrumentExists(plan);
+
+        // Проверяем, что все коды провайдеров из плана существуют
+        ensureProvidersExist(plan);
+
+        // Проверяем, что заменяемый план уже существует
+        ensurePlanExists(plan);
+
+        // Атомарно заменяем весь состав источников в репозитории
+        instrumentSourcePlanRepository.replace(plan);
+    }
+
+    /**
+     * Проверяет существование инструмента.
+     */
+    private void ensureInstrumentExists(InstrumentSourcePlan plan) {
+        if (!instrumentCodeExistencePort.existsByCode(plan.instrumentCode())) {
+            throw new InstrumentCodeNotFoundException(plan.instrumentCode());
+        }
+    }
+
+    /**
+     * Проверяет существование всех провайдеров, указанных в плане.
+     */
+    private void ensureProvidersExist(InstrumentSourcePlan plan) {
+        Set<String> missingProviderCodes = new LinkedHashSet<>();
+
+        for (MarketDataSource source : plan.sources()) {
+            if (!providerCodeExistencePort.existsByCode(source.providerCode())) {
+                missingProviderCodes.add(source.providerCode().value());
+            }
+        }
+
+        if (!missingProviderCodes.isEmpty()) {
+            throw new ProviderCodesNotFoundException(missingProviderCodes);
+        }
+    }
+
+    /**
+     * Проверяет существование плана перед заменой.
+     */
+    private void ensurePlanExists(InstrumentSourcePlan plan) {
+        if (instrumentSourcePlanRepository.findByInstrumentCode(plan.instrumentCode()).isEmpty()) {
+            throw new InstrumentSourcePlanNotFoundException(plan.instrumentCode());
+        }
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/repository/adapter/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/repository/adapter/JooqInstrumentSourcePlanRepository.java
@@ -115,13 +115,33 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
         });
     }
 
+
     @Override
-    public void deleteByInstrumentCode(InstrumentCode instrumentCode) {
+    public void replace(InstrumentSourcePlan plan) {
+        Objects.requireNonNull(plan, "plan must not be null");
+
+        dsl.transaction(configuration -> {
+            DSLContext tx = configuration.dsl();
+
+            tx.deleteFrom(INSTRUMENT_MARKET_DATA_SOURCE)
+                    .where(INSTRUMENT_MARKET_DATA_SOURCE.INSTRUMENT_CODE.eq(plan.instrumentCode().value()))
+                    .execute();
+
+            for (MarketDataSource source : plan.sources()) {
+                insertSource(tx, plan.instrumentCode(), source);
+            }
+        });
+    }
+
+    @Override
+    public boolean deleteByInstrumentCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
-        dsl.deleteFrom(INSTRUMENT_SOURCE_PLAN)
+        int deletedRows = dsl.deleteFrom(INSTRUMENT_SOURCE_PLAN)
                 .where(INSTRUMENT_SOURCE_PLAN.INSTRUMENT_CODE.eq(instrumentCode.value()))
                 .execute();
+
+        return deletedRows > 0;
     }
 
     /* Вставляет один источник инструмента. */

--- a/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
@@ -29,6 +29,12 @@ public interface InstrumentSourcePlanRepository {
      */
     boolean createIfAbsent(InstrumentSourcePlan plan);
 
+
+    /**
+     * Полностью заменяет содержимое существующего плана источников.
+     */
+    void replace(InstrumentSourcePlan plan);
+
     /**
      * Удаляет план источников для заданного инструмента.
      *


### PR DESCRIPTION
### Motivation
- Нужно поддержать операцию полной атомарной замены содержимого агрегата плана источников, сохранив его identity (`instrumentCode`) и избегая размывания доменной семантики через два отдельных вызова `delete + create`.
- HTTP-контракт требует `PUT /api/v1/instrument-source-plans/{instrumentCode}` с телом, содержащим только `sources`.

### Description
- Добавлен сервис `ReplaceInstrumentSourcePlanService` с проверками: наличие инструмента, существование всех провайдеров и существование текущего плана, после чего вызывается `instrumentSourcePlanRepository.replace(plan)`; файл: `backend/.../application/command/replace/ReplaceInstrumentSourcePlanService.java`.
- Добавлена wiring-конфигурация `ReplaceInstrumentSourcePlanServiceWiringConfig`; файл: `backend/.../config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java`.
- Реализован REST-эндпоинт `PUT /api/v1/instrument-source-plans/{instrumentCode}` с DTO `ReplaceInstrumentSourcePlanRequest` и контроллером `ReplaceInstrumentSourcePlanController`, которые берут `instrumentCode` из path и возвращают `204 No Content`; файлы: `backend/.../api/command/replace/controller/ReplaceInstrumentSourcePlanController.java` и `backend/.../api/command/replace/dto/ReplaceInstrumentSourcePlanRequest.java`.
- Расширен доменный порт `InstrumentSourcePlanRepository` новым методом `void replace(InstrumentSourcePlan plan)`; файл: `domain/.../repository/InstrumentSourcePlanRepository.java`.
- В `JooqInstrumentSourcePlanRepository` добавлена реализация `replace` в одной транзакции: удаление текущих строк из `INSTRUMENT_MARKET_DATA_SOURCE` по `instrumentCode` и повторная вставка нового списка `sources`; также исправлен `deleteByInstrumentCode` на возвращаемый `boolean`; файл: `backend/.../repository/adapter/JooqInstrumentSourcePlanRepository.java`.
- Обновлён `InstrumentSourcePlanRestExceptionHandler`, добавлен `ReplaceInstrumentSourcePlanController` в `assignableTypes`, чтобы переиспользовать существующие обработчики ошибок (`INSTRUMENT_CODE_NOT_FOUND`, `PROVIDER_CODES_NOT_FOUND`, `INSTRUMENT_SOURCE_PLAN_NOT_FOUND`).

### Testing
- Попытка сборки через wrapper выполнена: `./mvnw -q -DskipTests compile`, но wrapper не смог скачать Maven (среда ограничивает загрузку), сборка не завершилась успешно.
- Локальная команда `mvn -q -DskipTests compile` была запущена и завершилась с ошибкой разрешения parent POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5`), от сервера Maven Central пришёл HTTP 403, поэтому полноценная компиляция/тесты в этом окружении не прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66dd5477c832dbfddec67573575ad)