### PR TITLE
Рефакторинг delete/replace для instrument_source_plan — условные операции на root-row

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/delete/DeleteInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/delete/DeleteInstrumentSourcePlanService.java
@@ -29,17 +29,9 @@ public final class DeleteInstrumentSourcePlanService {
     public void delete(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
-        // Проверяем, что удаляемый план существует
-        ensurePlanExists(instrumentCode);
-
-        instrumentSourcePlanRepository.deleteByInstrumentCode(instrumentCode);
-    }
-
-    /**
-     * Проверяет существование плана перед удалением.
-     */
-    private void ensurePlanExists(InstrumentCode instrumentCode) {
-        if (instrumentSourcePlanRepository.findByInstrumentCode(instrumentCode).isEmpty()) {
+        // Условно удаляем root-plan и сигнализируем, если его не было
+        boolean deleted = instrumentSourcePlanRepository.deleteIfExistsByInstrumentCode(instrumentCode);
+        if (!deleted) {
             throw new InstrumentSourcePlanNotFoundException(instrumentCode);
         }
     }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
@@ -58,11 +58,11 @@ public final class ReplaceInstrumentSourcePlanService {
         // Проверяем, что все коды провайдеров из плана существуют
         ensureProvidersExist(plan);
 
-        // Проверяем, что заменяемый план уже существует
-        ensurePlanExists(plan);
-
-        // Атомарно заменяем весь состав источников в репозитории
-        instrumentSourcePlanRepository.replace(plan);
+        // Условно заменяем содержимое root-plan и сигнализируем, если плана не было
+        boolean replaced = instrumentSourcePlanRepository.replaceIfExists(plan);
+        if (!replaced) {
+            throw new InstrumentSourcePlanNotFoundException(plan.instrumentCode());
+        }
     }
 
     /**
@@ -91,12 +91,4 @@ public final class ReplaceInstrumentSourcePlanService {
         }
     }
 
-    /**
-     * Проверяет существование плана перед заменой.
-     */
-    private void ensurePlanExists(InstrumentSourcePlan plan) {
-        if (instrumentSourcePlanRepository.findByInstrumentCode(plan.instrumentCode()).isEmpty()) {
-            throw new InstrumentSourcePlanNotFoundException(plan.instrumentCode());
-        }
-    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/repository/adapter/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/repository/adapter/JooqInstrumentSourcePlanRepository.java
@@ -117,11 +117,22 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
 
 
     @Override
-    public void replace(InstrumentSourcePlan plan) {
+    public boolean replaceIfExists(InstrumentSourcePlan plan) {
         Objects.requireNonNull(plan, "plan must not be null");
 
-        dsl.transaction(configuration -> {
+        return dsl.transactionResult(configuration -> {
             DSLContext tx = configuration.dsl();
+
+            boolean planExists = tx.selectOne()
+                    .from(INSTRUMENT_SOURCE_PLAN)
+                    .where(INSTRUMENT_SOURCE_PLAN.INSTRUMENT_CODE.eq(plan.instrumentCode().value()))
+                    .forUpdate()
+                    .fetchOptional()
+                    .isPresent();
+
+            if (!planExists) {
+                return false;
+            }
 
             tx.deleteFrom(INSTRUMENT_MARKET_DATA_SOURCE)
                     .where(INSTRUMENT_MARKET_DATA_SOURCE.INSTRUMENT_CODE.eq(plan.instrumentCode().value()))
@@ -130,11 +141,13 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
             for (MarketDataSource source : plan.sources()) {
                 insertSource(tx, plan.instrumentCode(), source);
             }
+
+            return true;
         });
     }
 
     @Override
-    public boolean deleteByInstrumentCode(InstrumentCode instrumentCode) {
+    public boolean deleteIfExistsByInstrumentCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         int deletedRows = dsl.deleteFrom(INSTRUMENT_SOURCE_PLAN)

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/InstrumentSourcePlanReplaceApiIntegrationTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/InstrumentSourcePlanReplaceApiIntegrationTest.java
@@ -257,12 +257,16 @@ class InstrumentSourcePlanReplaceApiIntegrationTest {
         }
 
         @Override
-        public void replace(InstrumentSourcePlan plan) {
+        public boolean replaceIfExists(InstrumentSourcePlan plan) {
+            if (!plans.containsKey(plan.instrumentCode())) {
+                return false;
+            }
             plans.put(plan.instrumentCode(), plan);
+            return true;
         }
 
         @Override
-        public boolean deleteByInstrumentCode(InstrumentCode instrumentCode) {
+        public boolean deleteIfExistsByInstrumentCode(InstrumentCode instrumentCode) {
             return plans.remove(instrumentCode) != null;
         }
 

--- a/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/sourcing/plan/repository/InstrumentSourcePlanRepository.java
@@ -22,18 +22,24 @@ public interface InstrumentSourcePlanRepository {
     List<InstrumentSourcePlan> findAll();
 
     /**
-     * Создаёт план источников, если план не существует.
+     * Создаёт root-plan, если он ещё не существует.
+     *
+     * @return true, если root-plan создан; false, если план уже существует
      */
     boolean createIfAbsent(InstrumentSourcePlan plan);
 
 
     /**
-     * Заменяет существующий план источников на новый.
+     * Условно заменяет содержимое существующего root-plan.
+     *
+     * @return true, если root-plan существовал и был обновлён; false, если план отсутствует
      */
-    void replace(InstrumentSourcePlan plan);
+    boolean replaceIfExists(InstrumentSourcePlan plan);
 
     /**
-     * Удаляет план источников для заданного инструмента.
+     * Условно удаляет существующий root-plan инструмента.
+     *
+     * @return true, если root-plan существовал и был удалён; false, если плана не было
      */
-    boolean deleteByInstrumentCode(InstrumentCode instrumentCode);
+    boolean deleteIfExistsByInstrumentCode(InstrumentCode instrumentCode);
 }


### PR DESCRIPTION
### Motivation
- Привести `delete` и `replace` к той же надёжной модели, что уже используется в `createIfAbsent(...)`, где root-row в `instrument_source_plan` является единственным маркером существования плана.
- Убрать read-before-delete/replace в сервисах и переложить условную атомарную логику на репозиторий, который возвращает `boolean` для дальнейшего маппинга в доменные исключения.
- Обеспечить транзакционную замену child-строк только при наличии root-row и полагаться на FK `ON DELETE CASCADE` при удалении root-row.

### Description
- Обновлён контракт репозитория `InstrumentSourcePlanRepository`: сохранён `createIfAbsent`, добавлены `boolean replaceIfExists(InstrumentSourcePlan plan)` и `boolean deleteIfExistsByInstrumentCode(InstrumentCode instrumentCode)` с соответствующим Javadoc и семантикой.
- В `JooqInstrumentSourcePlanRepository` реализовано `replaceIfExists(...)` через `dsl.transactionResult(...)` с existence-check внутри транзакции (`SELECT ... FOR UPDATE`), удалением и вставкой child-строк только если root-row существует, и возвратом `boolean`; `deleteIfExistsByInstrumentCode(...)` удаляет только root-row из `INSTRUMENT_SOURCE_PLAN` и возвращает `deletedRows > 0` (без ручного удаления child-строк).
- Сервисы изменены: `DeleteInstrumentSourcePlanService` убран pre-check и теперь вызывает `deleteIfExistsByInstrumentCode(...)`, бросая `InstrumentSourcePlanNotFoundException` при `false`; `ReplaceInstrumentSourcePlanService` оставляет проверки инструмента и провайдеров, убирает pre-check плана и использует `replaceIfExists(...)`, бросая `InstrumentSourcePlanNotFoundException` при `false`.
- Обновлена in-memory реализация в тесте `InstrumentSourcePlanReplaceApiIntegrationTest` под новые сигнатуры и булевую семантику (`replaceIfExists` / `deleteIfExistsByInstrumentCode`).

### Testing
- Зафиксированы изменения в репозитории (`git commit`) успешно выполнен.
- Пытался собрать проект автоматическими командами: `./mvnw -DskipTests compile` не прошёл из-за проблем с скачиванием Maven, а `mvn -DskipTests compile` завершился ошибкой разрешения родительского POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5` с `403 Forbidden`), поэтому компиляция не удалась.
- `./gradlew` в репозитории отсутствует, поэтому Gradle-сборка не запускалась; из-за неуспешной компиляции автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b8414128832db854cc657c740f75)