### PR TITLE
Симметричный read-side для instrument-source-plans

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
@@ -6,6 +6,7 @@ import com.alligator.market.backend.sourcing.plan.api.command.create.controller.
 import com.alligator.market.backend.sourcing.plan.api.command.delete.controller.DeleteInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.replace.controller.ReplaceInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.query.get.controller.GetInstrumentSourcePlanController;
+import com.alligator.market.backend.sourcing.plan.api.query.list.controller.ListInstrumentSourcePlansController;
 import com.alligator.market.backend.sourcing.plan.api.query.options.controller.InstrumentSourcePlanOptionsQueryController;
 import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentCodeNotFoundException;
 import com.alligator.market.backend.sourcing.plan.application.exception.ProviderCodesNotFoundException;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
         DeleteInstrumentSourcePlanController.class,
         ReplaceInstrumentSourcePlanController.class,
         GetInstrumentSourcePlanController.class,
+        ListInstrumentSourcePlansController.class,
         InstrumentSourcePlanOptionsQueryController.class
 })
 public class InstrumentSourcePlanRestExceptionHandler {

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/mapper/InstrumentSourcePlanResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/mapper/InstrumentSourcePlanResponseMapper.java
@@ -1,0 +1,36 @@
+package com.alligator.market.backend.sourcing.plan.api.query.common.mapper;
+
+import com.alligator.market.backend.sourcing.plan.api.query.get.dto.InstrumentSourcePlanResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.get.dto.MarketDataSourceResponse;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Единый mapper доменной модели плана в read-side HTTP DTO.
+ */
+@Component
+public class InstrumentSourcePlanResponseMapper {
+
+    /**
+     * Конвертирует доменный план в DTO ответа.
+     */
+    public InstrumentSourcePlanResponse toPlanResponse(InstrumentSourcePlan plan) {
+        List<MarketDataSourceResponse> sources = plan.sources().stream()
+                .map(this::toSourceResponse)
+                .toList();
+
+        return new InstrumentSourcePlanResponse(plan.instrumentCode().value(), sources);
+    }
+
+    /* Конвертация доменного источника в DTO источника. */
+    private MarketDataSourceResponse toSourceResponse(MarketDataSource source) {
+        return new MarketDataSourceResponse(
+                source.providerCode().value(),
+                source.active(),
+                source.priority()
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/controller/GetInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/get/controller/GetInstrumentSourcePlanController.java
@@ -1,18 +1,16 @@
 package com.alligator.market.backend.sourcing.plan.api.query.get.controller;
 
 import com.alligator.market.backend.sourcing.plan.api.query.get.dto.InstrumentSourcePlanResponse;
-import com.alligator.market.backend.sourcing.plan.api.query.get.dto.MarketDataSourceResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.common.mapper.InstrumentSourcePlanResponseMapper;
 import com.alligator.market.backend.sourcing.plan.application.query.get.GetInstrumentSourcePlanService;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -24,12 +22,18 @@ public class GetInstrumentSourcePlanController {
 
     /* Сервис get-use case. */
     private final GetInstrumentSourcePlanService getInstrumentSourcePlanService;
+    /* Единый mapper read-side DTO. */
+    private final InstrumentSourcePlanResponseMapper responseMapper;
 
-    public GetInstrumentSourcePlanController(GetInstrumentSourcePlanService getInstrumentSourcePlanService) {
+    public GetInstrumentSourcePlanController(
+            GetInstrumentSourcePlanService getInstrumentSourcePlanService,
+            InstrumentSourcePlanResponseMapper responseMapper
+    ) {
         this.getInstrumentSourcePlanService = Objects.requireNonNull(
                 getInstrumentSourcePlanService,
                 "getInstrumentSourcePlanService must not be null"
         );
+        this.responseMapper = Objects.requireNonNull(responseMapper, "responseMapper must not be null");
     }
 
     /**
@@ -40,24 +44,6 @@ public class GetInstrumentSourcePlanController {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         InstrumentSourcePlan plan = getInstrumentSourcePlanService.get(new InstrumentCode(instrumentCode));
-        return ResponseEntity.ok(toResponse(plan));
-    }
-
-    /* Маппинг доменного плана в HTTP-ответ. */
-    private InstrumentSourcePlanResponse toResponse(InstrumentSourcePlan plan) {
-        List<MarketDataSourceResponse> sources = plan.sources().stream()
-                .map(this::toSourceResponse)
-                .toList();
-
-        return new InstrumentSourcePlanResponse(plan.instrumentCode().value(), sources);
-    }
-
-    /* Маппинг доменного источника в HTTP-модель источника. */
-    private MarketDataSourceResponse toSourceResponse(MarketDataSource source) {
-        return new MarketDataSourceResponse(
-                source.providerCode().value(),
-                source.active(),
-                source.priority()
-        );
+        return ResponseEntity.ok(responseMapper.toPlanResponse(plan));
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/controller/ListInstrumentSourcePlansController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/list/controller/ListInstrumentSourcePlansController.java
@@ -1,11 +1,9 @@
 package com.alligator.market.backend.sourcing.plan.api.query.list.controller;
 
 import com.alligator.market.backend.sourcing.plan.api.query.get.dto.InstrumentSourcePlanResponse;
-import com.alligator.market.backend.sourcing.plan.api.query.get.dto.MarketDataSourceResponse;
+import com.alligator.market.backend.sourcing.plan.api.query.common.mapper.InstrumentSourcePlanResponseMapper;
 import com.alligator.market.backend.sourcing.plan.api.query.list.dto.InstrumentSourcePlanListResponse;
 import com.alligator.market.backend.sourcing.plan.application.query.list.ListInstrumentSourcePlansService;
-import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,12 +21,18 @@ public class ListInstrumentSourcePlansController {
 
     /* Сервис list-use case. */
     private final ListInstrumentSourcePlansService listInstrumentSourcePlansService;
+    /* Единый mapper read-side DTO. */
+    private final InstrumentSourcePlanResponseMapper responseMapper;
 
-    public ListInstrumentSourcePlansController(ListInstrumentSourcePlansService listInstrumentSourcePlansService) {
+    public ListInstrumentSourcePlansController(
+            ListInstrumentSourcePlansService listInstrumentSourcePlansService,
+            InstrumentSourcePlanResponseMapper responseMapper
+    ) {
         this.listInstrumentSourcePlansService = Objects.requireNonNull(
                 listInstrumentSourcePlansService,
                 "listInstrumentSourcePlansService must not be null"
         );
+        this.responseMapper = Objects.requireNonNull(responseMapper, "responseMapper must not be null");
     }
 
     /**
@@ -37,27 +41,9 @@ public class ListInstrumentSourcePlansController {
     @GetMapping
     public ResponseEntity<InstrumentSourcePlanListResponse> list() {
         List<InstrumentSourcePlanResponse> plans = listInstrumentSourcePlansService.list().stream()
-                .map(this::toPlanResponse)
+                .map(responseMapper::toPlanResponse)
                 .toList();
 
         return ResponseEntity.ok(new InstrumentSourcePlanListResponse(plans));
-    }
-
-    /* Маппинг доменного плана в HTTP-модель плана. */
-    private InstrumentSourcePlanResponse toPlanResponse(InstrumentSourcePlan plan) {
-        List<MarketDataSourceResponse> sources = plan.sources().stream()
-                .map(this::toSourceResponse)
-                .toList();
-
-        return new InstrumentSourcePlanResponse(plan.instrumentCode().value(), sources);
-    }
-
-    /* Маппинг доменного источника в HTTP-модель источника. */
-    private MarketDataSourceResponse toSourceResponse(MarketDataSource source) {
-        return new MarketDataSourceResponse(
-                source.providerCode().value(),
-                source.active(),
-                source.priority()
-        );
     }
 }

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/InstrumentSourcePlanReplaceApiIntegrationTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/InstrumentSourcePlanReplaceApiIntegrationTest.java
@@ -3,7 +3,9 @@ package com.alligator.market.backend.sourcing.plan.api;
 import com.alligator.market.backend.sourcing.plan.api.advice.InstrumentSourcePlanRestExceptionHandler;
 import com.alligator.market.backend.sourcing.plan.api.command.create.controller.CreateInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.replace.controller.ReplaceInstrumentSourcePlanController;
+import com.alligator.market.backend.sourcing.plan.api.query.common.mapper.InstrumentSourcePlanResponseMapper;
 import com.alligator.market.backend.sourcing.plan.api.query.get.controller.GetInstrumentSourcePlanController;
+import com.alligator.market.backend.sourcing.plan.api.query.list.controller.ListInstrumentSourcePlansController;
 import com.alligator.market.backend.sourcing.plan.application.command.create.CreateInstrumentSourcePlanService;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
@@ -29,6 +31,7 @@ import java.util.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -38,7 +41,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = {
         CreateInstrumentSourcePlanController.class,
         ReplaceInstrumentSourcePlanController.class,
-        GetInstrumentSourcePlanController.class
+        GetInstrumentSourcePlanController.class,
+        ListInstrumentSourcePlansController.class
 })
 @Import({
         InstrumentSourcePlanRestExceptionHandler.class,
@@ -159,6 +163,33 @@ class InstrumentSourcePlanReplaceApiIntegrationTest {
                 .andExpect(jsonPath("$.sources[0].providerCode").value("REUTERS"));
     }
 
+    @Test
+    void listReturnsAllPlansUsingSharedResponseShape() throws Exception {
+        instrumentCatalog.add("EURUSD_TOM");
+        instrumentCatalog.add("USDJPY_TOM");
+        providerCatalog.addAll("MOEX", "BLOOMBERG", "REUTERS");
+
+        createInitialPlan();
+
+        mockMvc.perform(post("/api/v1/instrument-source-plans")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "instrumentCode": "USDJPY_TOM",
+                                  "sources": [
+                                    {"providerCode": "REUTERS", "active": true, "priority": 0}
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/instrument-source-plans"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.plans.length()").value(2))
+                .andExpect(jsonPath("$.plans[?(@.instrumentCode=='EURUSD_TOM')].sources[0].providerCode").value(hasItem("MOEX")))
+                .andExpect(jsonPath("$.plans[?(@.instrumentCode=='USDJPY_TOM')].sources[0].providerCode").value(hasItem("REUTERS")));
+    }
+
     /* Подготовка исходного плана для replace-сценариев. */
     private void createInitialPlan() throws Exception {
         mockMvc.perform(post("/api/v1/instrument-source-plans")
@@ -227,6 +258,11 @@ class InstrumentSourcePlanReplaceApiIntegrationTest {
         @Bean
         DeleteInstrumentSourcePlanService deleteInstrumentSourcePlanService(InstrumentSourcePlanRepository repository) {
             return new DeleteInstrumentSourcePlanService(repository);
+        }
+
+        @Bean
+        InstrumentSourcePlanResponseMapper instrumentSourcePlanResponseMapper() {
+            return new InstrumentSourcePlanResponseMapper();
         }
     }
 


### PR DESCRIPTION
### Motivation
- Сделать read-side для plans источников инструментов полностью симметричным и исключить дублирование маппинга между `GET /api/v1/instrument-source-plans/{instrumentCode}` и `GET /api/v1/instrument-source-plans`.
- Обеспечить единый контракт ответа и стабильность HTTP-моделей при расширении и тестировании API.
- Покрыть scope feature-specific `RestControllerAdvice` для всех read-контроллеров раздела.

### Description
- Добавлен компонент `InstrumentSourcePlanResponseMapper` для единой конвертации доменной модели `InstrumentSourcePlan` в read-side DTO `InstrumentSourcePlanResponse` и `MarketDataSourceResponse`.
- Рефакторинг контроллеров: `GetInstrumentSourcePlanController` и `ListInstrumentSourcePlansController` теперь используют общий `responseMapper` и убрали локальные дублирующие методы маппинга.
- `ListInstrumentSourcePlansController` добавлен в `InstrumentSourcePlanRestExceptionHandler` для симметричного покрытия обработчика исключений read-side.
- Расширен интеграционный тест `InstrumentSourcePlanReplaceApiIntegrationTest`: подключён list-контроллер в `@WebMvcTest`, добавлен тест `listReturnsAllPlansUsingSharedResponseShape` и зарегистрирован `InstrumentSourcePlanResponseMapper` в тестовой wiring-конфигурации.

### Testing
- Попытка запустить интеграционный тест через wrapper: `./mvnw -q -pl backend -Dtest=InstrumentSourcePlanReplaceApiIntegrationTest test` завершилась неудачей из-за ошибки загрузки Maven (`Failed to fetch apache-maven-3.9.9-bin.zip`).
- Попытка запустить тест через системный Maven: `mvn -q -pl backend -Dtest=InstrumentSourcePlanReplaceApiIntegrationTest test` завершилась неудачей из-за ошибки резолва parent POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5`) с `403 Forbidden`, поэтому автоматические тесты не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c0fae91c832da836852652cc7c84)