### PR TITLE
Поправить WebMvcTest для Spring Boot 4 (backend)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -79,6 +79,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Тестовый стек для Spring MVC (WebMvcTest, MockMvc) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Тестирование реактивного кода -->
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/query/InstrumentSourcePlanQueryControllersTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/query/InstrumentSourcePlanQueryControllersTest.java
@@ -16,7 +16,7 @@ import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;


### PR DESCRIPTION
### Motivation
- Исправить проблему с резолвом `WebMvcTest` и привести тестовый стек web-layer к консистентному состоянию под Spring Boot 4.0.5 без изменения production-кода.

### Description
- Добавлен тестовый артефакт `spring-boot-starter-webmvc-test` в `backend/pom.xml` с `test` scope для явного подключения web MVC тест-слайса; импорт `@WebMvcTest` в `InstrumentSourcePlanQueryControllersTest` заменён на `org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest` чтобы соответствовать Boot 4 пакету.

### Testing
- Выполнена проверка использования аннотации `WebMvcTest` и новых зависимостей через `rg` (поиск по `backend/src/test/java` и `backend/pom.xml`) и подтверждена консистентность импортов; команда прошла успешно.
- Попытка собрать тестовые исходники `mvn -pl backend -DskipTests test-compile` не завершилась из-за проблем с разрешением родительского POM в этом окружении (Maven Central вернул `403`), поэтому полная компиляционная верификация не была выполнена здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c0cdb530832d83e64536ab1ce842)