### PR TITLE
Перевести dev-only тесты в тег `manual` и исключить их из Surefire

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -153,6 +153,16 @@
                 </dependencies>
             </plugin>
 
+
+            <!-- Управление запуском тестов по тегам (manual-тесты исключены по умолчанию). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludedTags>manual</excludedTags>
+                </configuration>
+            </plugin>
+
             <!-- Annotation processors -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/backend/src/test/java/com/alligator/market/backend/common/persistence/jpa/constraint/DbErrorsTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/common/persistence/jpa/constraint/DbErrorsTest.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.common.persistence.jpa.constraint;
 
 import org.hibernate.exception.ConstraintViolationException;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Тесты класса {@link DbErrors} для проверки распознавания нарушений ограничений БД.
  */
-@Disabled("Tests passed and disabled to speed up the build process")
+@Tag("manual")
 class DbErrorsTest {
 
     /**

--- a/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/provider/adapter/moex/iss/handler/forex/spot/MoexIssFxSpotHandlerQuoteLiveTest.java
@@ -7,7 +7,6 @@ import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.
 import com.alligator.market.domain.instrument.asset.forex.spot.model.FxSpot;
 import com.alligator.market.domain.instrument.asset.forex.spot.model.FxSpotTenor;
 import com.alligator.market.domain.marketdata.tick.model.QuoteTick;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -22,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Интеграционный тест {@link MoexIssFxSpotHandler} с реальным запросом котировки.
  */
-@Disabled("Manual run only: long integration scenario")
+@Tag("manual")
 class MoexIssFxSpotHandlerQuoteLiveTest {
 
     @Test

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/command/InstrumentSourcePlanCommandControllersTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/command/InstrumentSourcePlanCommandControllersTest.java
@@ -11,8 +11,8 @@ import com.alligator.market.backend.sourcing.plan.application.exception.Instrume
 import com.alligator.market.backend.sourcing.plan.application.exception.ProviderCodesNotFoundException;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /*
  * Интеграционный web-layer тест command-контроллеров плана источников.
  */
-@Disabled("Manual run only: long integration scenario")
+@Tag("manual")
 @WebMvcTest(controllers = {
         CreateInstrumentSourcePlanController.class,
         ReplaceInstrumentSourcePlanController.class,

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/query/InstrumentSourcePlanQueryControllersTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/query/InstrumentSourcePlanQueryControllersTest.java
@@ -13,8 +13,8 @@ import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /*
  * Интеграционный web-layer тест query-контроллеров плана источников.
  */
-@Disabled("Manual run only: long integration scenario")
+@Tag("manual")
 @WebMvcTest(controllers = {
         GetInstrumentSourcePlanController.class,
         ListInstrumentSourcePlansController.class,


### PR DESCRIPTION
### Motivation
- Текущие тесты, помеченные `@Disabled`, нарочно пропускаются на этапе разработки, но в отчётах показываются как `SKIPPED`, что создаёт шум и может скрывать реальные проблемы.
- Нужно сохранить тесты в кодовой базе для ручного/разового прогона (длинные или внешние интеграции), но не показывать их в обычном `mvn test` прогоне.

### Description
- Заменены аннотации `@Disabled(...)` на `@Tag("manual")` в тестах `DbErrorsTest`, `InstrumentSourcePlanQueryControllersTest`, `InstrumentSourcePlanCommandControllersTest` и `MoexIssFxSpotHandlerQuoteLiveTest` и добавлен импорт `org.junit.jupiter.api.Tag` там, где нужно.
- В `backend/pom.xml` добавлена конфигурация плагина `maven-surefire-plugin` с `excludedTags` установленным в `manual`, чтобы тесты с этим тегом по умолчанию не запускались/не отмечались как пропущенные.
- Существующие дополнительные теги (`external`, `slow`) в live-тесте сохранены, чтобы можно было гибко фильтровать нужные категории тестов.

### Testing
- Попытка запустить автоматические тесты командой `./mvnw -pl backend test -DskipITs` завершилась неудачей из-за того, что Maven Wrapper не смог скачать дистрибутив (`Failed to fetch ... apache-maven-3.9.9-bin.zip`), поэтому тесты фактически не выполнялись.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e798a644832dbd84ab2ae38eb607)