### PR TITLE
Перевести тест старта приложения в smoke-категорию

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -159,7 +159,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <excludedGroups>dev</excludedGroups>
+                    <excludedGroups>dev,smoke</excludedGroups>
                 </configuration>
             </plugin>
 

--- a/backend/src/test/java/com/alligator/market/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/alligator/market/backend/BackendApplicationTests.java
@@ -1,11 +1,17 @@
 package com.alligator.market.backend;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+/* Smoke-тест: проверяет, что Spring context приложения поднимается в test-профиле. */
+@Tag("smoke")
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
+    /* Проверка проходит, если контекст приложения стартует без ошибок. */
     @Test
     void contextLoads() {
     }


### PR DESCRIPTION
### Motivation
- Тест `BackendApplicationTests` фактически проверяет запуск Spring context (smoke/startup), поэтому его не следует запускать в обязательном девелоперском прогоне.

### Description
- Пометил `BackendApplicationTests` `@Tag("smoke")` и добавил `@ActiveProfiles("test")`, сохранив пустое тело `contextLoads()` как корректную проверку старта контекста.
- Обновил конфигурацию `maven-surefire-plugin` в `backend/pom.xml`, добавив `smoke` в `excludedGroups` (`dev,smoke`) чтобы исключить эти тесты из стандартного `test` прогона.

### Testing
- Попытка запустить `./mvnw -pl backend test -DskipITs` в текущем окружении не завершилась из-за ошибки загрузки Maven (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`), поэтому автоматические тесты не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9604228d4832d83ccaaed10bbd86a)