### PR TITLE
Привести структуру `sourcing/config/plan` в соответствие с `sourcing/plan`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/create/CreateInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/create/CreateInstrumentSourcePlanServiceWiringConfig.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.sourcing.config.plan.application.command.create;
 
-import com.alligator.market.backend.sourcing.config.plan.application.port.InstrumentCodeExistencePortWiringConfig;
-import com.alligator.market.backend.sourcing.config.plan.application.port.ProviderCodeExistencePortWiringConfig;
-import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.InstrumentCodeExistencePortWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.ProviderCodeExistencePortWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.command.create.CreateInstrumentSourcePlanService;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/delete/DeleteInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/delete/DeleteInstrumentSourcePlanServiceWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.sourcing.config.plan.application.command.delete;
 
-import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.command.delete.DeleteInstrumentSourcePlanService;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.sourcing.config.plan.application.command.replace;
 
-import com.alligator.market.backend.sourcing.config.plan.application.port.InstrumentCodeExistencePortWiringConfig;
-import com.alligator.market.backend.sourcing.config.plan.application.port.ProviderCodeExistencePortWiringConfig;
-import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.InstrumentCodeExistencePortWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.ProviderCodeExistencePortWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/port/adapter/InstrumentCodeExistencePortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/port/adapter/InstrumentCodeExistencePortWiringConfig.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.sourcing.config.plan.application.port;
+package com.alligator.market.backend.sourcing.config.plan.application.port.adapter;
 
 import com.alligator.market.backend.sourcing.plan.application.port.adapter.JooqInstrumentCodeExistenceAdapter;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/port/adapter/ProviderCodeExistencePortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/port/adapter/ProviderCodeExistencePortWiringConfig.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.sourcing.config.plan.application.port;
+package com.alligator.market.backend.sourcing.config.plan.application.port.adapter;
 
 import com.alligator.market.backend.sourcing.plan.application.port.adapter.JooqProviderCodeExistenceAdapter;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.sourcing.config.plan.application.query.get;
 
-import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.query.get.GetInstrumentSourcePlanService;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.sourcing.config.plan.application.query.list;
 
-import com.alligator.market.backend.sourcing.config.plan.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.query.list.ListInstrumentSourcePlansService;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/options/adapter/InstrumentSourcePlanOptionsQueryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/options/adapter/InstrumentSourcePlanOptionsQueryWiringConfig.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.sourcing.config.plan.application.query.options;
+package com.alligator.market.backend.sourcing.config.plan.application.query.options.adapter;
 
 import com.alligator.market.backend.sourcing.plan.application.query.options.adapter.JooqInstrumentOptionsQueryAdapter;
 import com.alligator.market.backend.sourcing.plan.application.query.options.adapter.JooqProviderOptionsQueryAdapter;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/repository/adapter/InstrumentSourcePlanRepositoryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/repository/adapter/InstrumentSourcePlanRepositoryWiringConfig.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.sourcing.config.plan.repository;
+package com.alligator.market.backend.sourcing.config.plan.repository.adapter;
 
 import com.alligator.market.backend.sourcing.plan.repository.adapter.JooqInstrumentSourcePlanRepository;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;


### PR DESCRIPTION
### Motivation
- Упорядочить расположение wiring-конфигураций так, чтобы `config/plan` отражал модульную архитектуру `plan` и отделял адаптеры в соответствующие пакеты.
- Обеспечить единый контракт и предсказуемые импорты для wiring-слоя, уменьшив рассинхрон между путями пакетов и фактической архитектурой.

### Description
- Перемещены конфигурации адаптеров портов в `backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/port/adapter` и обновлены их `package`-объявления (файлы `InstrumentCodeExistencePortWiringConfig` и `ProviderCodeExistencePortWiringConfig`).
- Перемещён query-options wiring в `backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/options/adapter` и обновлён `package` в `InstrumentSourcePlanOptionsQueryWiringConfig`.
- Перемещён репозиторный wiring в `backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/repository/adapter` и обновлён `package` в `InstrumentSourcePlanRepositoryWiringConfig`.
- Обновлены импорты во всех сервисных wiring-конфигах (`application/command/*`, `application/query/*`) чтобы ссылаться на новые пакеты адаптеров.

### Testing
- Выполнена проверка структуры директорий через `find backend/src/main/java/com/alligator/market/backend/sourcing/config/plan -type d` и подтверждена новая иерархия (успех). 
- Проверено приведение импортов с помощью поиска по паттерну (`rg ...`) и обновлено там, где это было необходимо (успех).
- Попытка собрать модуль командой `./mvnw -pl backend -DskipTests compile` не удалась в окружении из-за ошибки загрузки дистрибутива Maven (`wget: Failed to fetch https://repo.maven.apache.org/...`), поэтому полная компиляция не была подтверждена (ошибка).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d960c16718832db4036b9c688eb8ac)