### PR TITLE
feat(frontend): добавить Instrument Source Plans whole-plan admin

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -4,6 +4,7 @@
   <button mat-button routerLink="/currencies">Currencies</button>
   <button mat-button routerLink="/fx-spot">FX Spot</button>
   <button mat-button routerLink="/provider-passports">Providers</button>
+  <button mat-button routerLink="/instrument-source-plans">Source Plans</button>
 </mat-toolbar>
 
 <router-outlet></router-outlet>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -18,6 +18,12 @@ export const routes: Routes = [
         .then(m => m.ProviderPassportModule)
   },
   {
+    path: 'instrument-source-plans',
+    loadChildren: () =>
+      import('./features/instrument_source_plan/instrument-source-plan.module')
+        .then(m => m.InstrumentSourcePlanModule)
+  },
+  {
     path: '',
     loadComponent: () =>
       import('./home/home.component').then(c => c.HomeComponent)

--- a/frontend/src/app/features/instrument_source_plan/instrument-source-plan-routing.module.ts
+++ b/frontend/src/app/features/instrument_source_plan/instrument-source-plan-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/instrument-source-plan-admin/instrument-source-plan-admin.component')
+        .then(c => c.InstrumentSourcePlanAdminComponent)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class InstrumentSourcePlanRoutingModule {}

--- a/frontend/src/app/features/instrument_source_plan/instrument-source-plan.module.ts
+++ b/frontend/src/app/features/instrument_source_plan/instrument-source-plan.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { InstrumentSourcePlanRoutingModule } from './instrument-source-plan-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, InstrumentSourcePlanRoutingModule]
+})
+export class InstrumentSourcePlanModule {}

--- a/frontend/src/app/features/instrument_source_plan/models/create-instrument-source-plan.model.ts
+++ b/frontend/src/app/features/instrument_source_plan/models/create-instrument-source-plan.model.ts
@@ -1,0 +1,10 @@
+export interface MarketDataSourceRequestDto {
+  providerCode: string;
+  active: boolean;
+  priority: number;
+}
+
+export interface CreateInstrumentSourcePlanDto {
+  instrumentCode: string;
+  sources: MarketDataSourceRequestDto[];
+}

--- a/frontend/src/app/features/instrument_source_plan/models/instrument-source-plan-options.model.ts
+++ b/frontend/src/app/features/instrument_source_plan/models/instrument-source-plan-options.model.ts
@@ -1,0 +1,12 @@
+export interface InstrumentOptionDto {
+  code: string;
+}
+
+export interface ProviderOptionDto {
+  code: string;
+}
+
+export interface InstrumentSourcePlanOptionsResponseDto {
+  instruments: InstrumentOptionDto[];
+  providers: ProviderOptionDto[];
+}

--- a/frontend/src/app/features/instrument_source_plan/models/instrument-source-plan.model.ts
+++ b/frontend/src/app/features/instrument_source_plan/models/instrument-source-plan.model.ts
@@ -1,0 +1,14 @@
+export interface MarketDataSourceResponseDto {
+  providerCode: string;
+  active: boolean;
+  priority: number;
+}
+
+export interface InstrumentSourcePlanResponseDto {
+  instrumentCode: string;
+  sources: MarketDataSourceResponseDto[];
+}
+
+export interface InstrumentSourcePlanListResponseDto {
+  plans: InstrumentSourcePlanResponseDto[];
+}

--- a/frontend/src/app/features/instrument_source_plan/models/replace-instrument-source-plan.model.ts
+++ b/frontend/src/app/features/instrument_source_plan/models/replace-instrument-source-plan.model.ts
@@ -1,0 +1,5 @@
+import { MarketDataSourceRequestDto } from './create-instrument-source-plan.model';
+
+export interface ReplaceInstrumentSourcePlanDto {
+  sources: MarketDataSourceRequestDto[];
+}

--- a/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.html
+++ b/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.html
@@ -1,0 +1,153 @@
+<div class="center-box">
+
+  <h1 class="mat-headline-4">Instrument Source Plans Administration</h1>
+
+  <!-- Верхняя карточка: whole-plan editor и toolbar действий -->
+  <mat-card class="toolbar-card">
+    <mat-card-header>
+      <mat-card-title>Source Plan Editor</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <form [formGroup]="form" class="editor-form">
+
+        <mat-form-field appearance="outline" class="instrument-field">
+          <mat-label>Instrument</mat-label>
+          <mat-select formControlName="instrumentCode">
+            <mat-option *ngFor="let instrument of instruments" [value]="instrument.code">
+              {{ instrument.code }}
+            </mat-option>
+          </mat-select>
+          <mat-error *ngIf="form.controls['instrumentCode'].hasError('required')">
+            Is required
+          </mat-error>
+        </mat-form-field>
+
+        <div class="sources-header-row">
+          <h3>Sources</h3>
+          <button mat-stroked-button type="button" (click)="onAddSourceRow()">
+            Add source row
+          </button>
+        </div>
+
+        <div formArrayName="sources" class="sources-grid">
+          <div
+            class="source-row"
+            *ngFor="let control of sourceControls; let i = index"
+            [formGroupName]="i"
+          >
+            <mat-form-field appearance="outline">
+              <mat-label>Provider</mat-label>
+              <mat-select formControlName="providerCode">
+                <mat-option *ngFor="let provider of providers" [value]="provider.code">
+                  {{ provider.code }}
+                </mat-option>
+              </mat-select>
+              <mat-error *ngIf="control.get('providerCode')?.hasError('required')">
+                Is required
+              </mat-error>
+            </mat-form-field>
+
+            <mat-checkbox formControlName="active">Active</mat-checkbox>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Priority</mat-label>
+              <input matInput type="number" formControlName="priority" />
+              <mat-error *ngIf="control.get('priority')?.hasError('required')">
+                Is required
+              </mat-error>
+              <mat-error *ngIf="control.get('priority')?.hasError('min')">
+                Must be >= 0
+              </mat-error>
+            </mat-form-field>
+
+            <button
+              mat-icon-button
+              color="warn"
+              type="button"
+              (click)="onRemoveSourceRow(i)"
+              [disabled]="sources.length <= 1"
+            >
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
+        </div>
+
+        <div class="validation-row" *ngIf="hasDuplicateProviders || hasDuplicatePriorities">
+          <span *ngIf="hasDuplicateProviders">Duplicate providerCode is not allowed.</span>
+          <span *ngIf="hasDuplicatePriorities">Duplicate priority is not allowed.</span>
+        </div>
+
+        <div class="action-row" *ngIf="!editing; else editModeButtons">
+          <button
+            mat-raised-button
+            color="primary"
+            type="button"
+            (click)="onCreate()"
+            [disabled]="hasPlanValidationError || locked"
+          >
+            Create plan
+          </button>
+          <button mat-raised-button type="button" (click)="onReset()">Reset</button>
+        </div>
+
+        <ng-template #editModeButtons>
+          <div class="action-row">
+            <button
+              mat-raised-button
+              color="primary"
+              type="button"
+              (click)="onSave()"
+              [disabled]="hasPlanValidationError || locked"
+            >
+              Save changes
+            </button>
+            <button mat-raised-button type="button" (click)="cancelEdit()">Cancel edit</button>
+            <button mat-raised-button color="warn" type="button" (click)="onDeleteSelected()">
+              Delete plan
+            </button>
+          </div>
+        </ng-template>
+      </form>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Нижняя карточка: обзор существующих plans -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Existing Source Plans</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
+
+        <ng-container matColumnDef="instrumentCode">
+          <th mat-header-cell *matHeaderCellDef>Instrument</th>
+          <td mat-cell *matCellDef="let plan">{{ plan.instrumentCode }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="sourceCount">
+          <th mat-header-cell *matHeaderCellDef>Sources</th>
+          <td mat-cell *matCellDef="let plan">{{ plan.sources.length }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="firstProvider">
+          <th mat-header-cell *matHeaderCellDef>First Provider</th>
+          <td mat-cell *matCellDef="let plan">{{ firstProvider(plan) }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let plan" class="actions-cell">
+            <button mat-stroked-button color="primary" (click)="onLoadPlan(plan)">Load</button>
+            <button mat-stroked-button color="warn" (click)="onDeleteFromList(plan.instrumentCode)">
+              Delete
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayed"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayed;"></tr>
+      </table>
+    </mat-card-content>
+  </mat-card>
+
+</div>

--- a/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.scss
+++ b/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.scss
@@ -1,0 +1,63 @@
+.center-box {
+  max-width: 1160px;
+  margin: 32px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 0 16px;
+}
+
+.toolbar-card {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #fff;
+}
+
+.editor-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.instrument-field {
+  max-width: 340px;
+}
+
+.sources-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sources-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.source-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 120px 140px 56px;
+  gap: 12px;
+  align-items: center;
+}
+
+.validation-row {
+  color: #b3261e;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.action-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.actions-cell {
+  display: flex;
+  gap: 8px;
+}

--- a/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.ts
+++ b/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.ts
@@ -1,0 +1,316 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  AbstractControl,
+  FormArray,
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatCardModule } from '@angular/material/card';
+
+import {
+  InstrumentSourcePlanResponseDto,
+  MarketDataSourceResponseDto
+} from '../../models/instrument-source-plan.model';
+import {
+  InstrumentOptionDto,
+  ProviderOptionDto
+} from '../../models/instrument-source-plan-options.model';
+import { MarketDataSourceRequestDto } from '../../models/create-instrument-source-plan.model';
+import { InstrumentSourcePlanService } from '../../services/instrument-source-plan.service';
+
+/* Админ-страница управления whole-plan sourcing планами по инструментам. */
+@Component({
+  selector: 'app-instrument-source-plan-admin',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatCheckboxModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    MatCardModule
+  ],
+  templateUrl: './instrument-source-plan-admin.component.html',
+  styleUrl: './instrument-source-plan-admin.component.scss'
+})
+export class InstrumentSourcePlanAdminComponent implements OnInit {
+
+  /* Колонки таблицы с существующими планами. */
+  displayed: string[] = ['instrumentCode', 'sourceCount', 'firstProvider', 'actions'];
+  dataSource = new MatTableDataSource<InstrumentSourcePlanResponseDto>([]);
+
+  /* Опции для селектов формы. */
+  instruments: InstrumentOptionDto[] = [];
+  providers: ProviderOptionDto[] = [];
+
+  /* Флаг блокировки кнопок при запросе. */
+  locked = false;
+  /* Режим редактора: create/edit. */
+  editing = false;
+  /* Текущий выбранный план в режиме редактирования. */
+  selectedInstrumentCode: string | null = null;
+
+  /* Главная форма whole-plan редактора. */
+  form: FormGroup;
+
+  constructor(
+    private readonly service: InstrumentSourcePlanService,
+    private readonly fb: FormBuilder,
+    private readonly snack: MatSnackBar
+  ) {
+    this.form = this.fb.group({
+      instrumentCode: ['', [Validators.required]],
+      sources: this.fb.array([])
+    });
+  }
+
+  /* Загрузка данных при открытии страницы. */
+  ngOnInit(): void {
+    this.refreshList();
+    this.loadOptions();
+    this.onAddSourceRow();
+  }
+
+  /* Удобный доступ к FormArray sources. */
+  get sources(): FormArray {
+    return this.form.controls['sources'] as FormArray;
+  }
+
+  /* Быстрый список source-контролов для шаблона. */
+  get sourceControls(): AbstractControl[] {
+    return this.sources.controls;
+  }
+
+  /* Есть ли дубликаты провайдеров в редакторе. */
+  get hasDuplicateProviders(): boolean {
+    const values = this.sourceControls
+      .map(c => c.get('providerCode')?.value)
+      .filter(v => !!v);
+
+    return new Set(values).size !== values.length;
+  }
+
+  /* Есть ли дубликаты priority в редакторе. */
+  get hasDuplicatePriorities(): boolean {
+    const values = this.sourceControls
+      .map(c => c.get('priority')?.value)
+      .filter(v => v !== null && v !== undefined && v !== '');
+
+    return new Set(values).size !== values.length;
+  }
+
+  /* Признак невалидного состояния, блокирующий сохранение. */
+  get hasPlanValidationError(): boolean {
+    return this.form.invalid
+      || this.sources.length === 0
+      || this.hasDuplicateProviders
+      || this.hasDuplicatePriorities;
+  }
+
+  /* Перезагрузить список существующих plans. */
+  refreshList(): void {
+    this.service.list().subscribe({
+      next: plans => {
+        this.dataSource.data = plans;
+      },
+      error: () => {
+        this.snack.open('Load source plans failed', 'Close');
+      }
+    });
+  }
+
+  /* Загрузить опции для селектов editor-а. */
+  loadOptions(): void {
+    this.service.getOptions().subscribe({
+      next: options => {
+        this.instruments = options.instruments;
+        this.providers = options.providers;
+      },
+      error: () => {
+        this.snack.open('Load options failed', 'Close');
+      }
+    });
+  }
+
+  /* Добавить новую строку source в FormArray. */
+  onAddSourceRow(source?: MarketDataSourceResponseDto): void {
+    this.sources.push(this.fb.group({
+      providerCode: [source?.providerCode ?? '', [Validators.required]],
+      active: [source?.active ?? true],
+      priority: [source?.priority ?? 0, [Validators.required, Validators.min(0)]]
+    }));
+  }
+
+  /* Удалить строку source по индексу. */
+  onRemoveSourceRow(index: number): void {
+    if (this.sources.length <= 1) {
+      return;
+    }
+
+    this.sources.removeAt(index);
+  }
+
+  /* Загрузить план в editor и перейти в edit mode. */
+  onLoadPlan(plan: InstrumentSourcePlanResponseDto): void {
+    this.service.get(plan.instrumentCode).subscribe({
+      next: fullPlan => {
+        this.editing = true;
+        this.selectedInstrumentCode = fullPlan.instrumentCode;
+
+        this.form.controls['instrumentCode'].setValue(fullPlan.instrumentCode);
+        this.form.controls['instrumentCode'].disable();
+
+        this.sources.clear();
+        fullPlan.sources.forEach(source => this.onAddSourceRow(source));
+
+        if (this.sources.length === 0) {
+          this.onAddSourceRow();
+        }
+      },
+      error: err => {
+        this.snack.open(err.error?.message ?? err.message ?? 'Load plan failed', 'Close');
+      }
+    });
+  }
+
+  /* Создать новый whole-plan из формы. */
+  onCreate(): void {
+    if (this.hasPlanValidationError || this.locked) {
+      return;
+    }
+
+    this.locked = true;
+
+    const instrumentCode = this.form.controls['instrumentCode'].value;
+    const sources = this.collectSortedSources();
+
+    this.service.create({ instrumentCode, sources }).subscribe({
+      next: () => {
+        this.snack.open(`Plan for '${instrumentCode}' created`, 'OK', { duration: 2500 });
+        this.refreshList();
+        this.onReset();
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Create failed';
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => {
+          this.locked = false;
+        });
+      }
+    });
+  }
+
+  /* Сохранить изменения whole-plan в edit mode. */
+  onSave(): void {
+    if (this.hasPlanValidationError || this.locked || !this.selectedInstrumentCode) {
+      return;
+    }
+
+    this.locked = true;
+    const instrumentCode = this.selectedInstrumentCode;
+    const sources = this.collectSortedSources();
+
+    this.service.replace(instrumentCode, { sources }).subscribe({
+      next: () => {
+        this.snack.open(`Plan for '${instrumentCode}' replaced`, 'OK', { duration: 2500 });
+        this.refreshList();
+        this.locked = false;
+      },
+      error: err => {
+        const msg = err.error?.message ?? err.message ?? 'Replace failed';
+        const ref = this.snack.open(msg, 'Close', { duration: 0 });
+        ref.afterDismissed().subscribe(() => {
+          this.locked = false;
+        });
+      }
+    });
+  }
+
+  /* Удалить выбранный план из editor-а. */
+  onDeleteSelected(): void {
+    if (!this.selectedInstrumentCode || this.locked) {
+      return;
+    }
+
+    this.deletePlan(this.selectedInstrumentCode, true);
+  }
+
+  /* Удалить план из нижнего списка. */
+  onDeleteFromList(instrumentCode: string): void {
+    const isCurrentPlan = this.selectedInstrumentCode === instrumentCode;
+    this.deletePlan(instrumentCode, isCurrentPlan);
+  }
+
+  /* Сбросить форму и вернуться в create mode. */
+  onReset(): void {
+    this.editing = false;
+    this.selectedInstrumentCode = null;
+    this.locked = false;
+
+    this.form.reset({ instrumentCode: '' });
+    this.form.controls['instrumentCode'].enable();
+
+    this.sources.clear();
+    this.onAddSourceRow();
+  }
+
+  /* Отменить режим редактирования. */
+  cancelEdit(): void {
+    this.onReset();
+  }
+
+  /* Получить first provider для обзорной таблицы. */
+  firstProvider(plan: InstrumentSourcePlanResponseDto): string {
+    if (!plan.sources.length) {
+      return '—';
+    }
+
+    const sorted = [...plan.sources].sort((a, b) => a.priority - b.priority);
+    return sorted[0].providerCode;
+  }
+
+  /* Привести source-строки к DTO и отсортировать по priority перед отправкой. */
+  private collectSortedSources(): MarketDataSourceRequestDto[] {
+    return this.sources.getRawValue()
+      .map((row: { providerCode: string; active: boolean; priority: number }) => ({
+        providerCode: row.providerCode,
+        active: row.active,
+        priority: Number(row.priority)
+      }))
+      .sort((a, b) => a.priority - b.priority);
+  }
+
+  /* Унифицированное удаление плана (из editor или из списка). */
+  private deletePlan(instrumentCode: string, resetEditor: boolean): void {
+    this.service.delete(instrumentCode).subscribe({
+      next: () => {
+        this.snack.open(`Plan for '${instrumentCode}' deleted`, 'OK', { duration: 2500 });
+        this.refreshList();
+
+        if (resetEditor) {
+          this.onReset();
+        }
+      },
+      error: err => {
+        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close');
+      }
+    });
+  }
+}

--- a/frontend/src/app/features/instrument_source_plan/services/instrument-source-plan.service.ts
+++ b/frontend/src/app/features/instrument_source_plan/services/instrument-source-plan.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+
+import { ApiResponse } from '../../../shared/api/api-response.model';
+import {
+  InstrumentSourcePlanListResponseDto,
+  InstrumentSourcePlanResponseDto
+} from '../models/instrument-source-plan.model';
+import { InstrumentSourcePlanOptionsResponseDto } from '../models/instrument-source-plan-options.model';
+import { CreateInstrumentSourcePlanDto } from '../models/create-instrument-source-plan.model';
+import { ReplaceInstrumentSourcePlanDto } from '../models/replace-instrument-source-plan.model';
+
+/* Сервис для управления whole-plan sourcing планами инструмента. */
+@Injectable({
+  providedIn: 'root'
+})
+export class InstrumentSourcePlanService {
+
+  constructor(private readonly http: HttpClient) {}
+
+  /* Базовый URL (через proxy уйдёт на Spring). */
+  private readonly baseUrl = '/api/v1/instrument-source-plans';
+
+  /* Получить все sourcing plans. */
+  list(): Observable<InstrumentSourcePlanResponseDto[]> {
+    return this.http
+      .get<ApiResponse<InstrumentSourcePlanListResponseDto>>(this.baseUrl)
+      .pipe(map(res => res.data?.plans ?? []));
+  }
+
+  /* Получить whole-plan по instrumentCode. */
+  get(instrumentCode: string): Observable<InstrumentSourcePlanResponseDto> {
+    return this.http
+      .get<ApiResponse<InstrumentSourcePlanResponseDto>>(`${this.baseUrl}/${instrumentCode}`)
+      .pipe(map(res => res.data as InstrumentSourcePlanResponseDto));
+  }
+
+  /* Получить опции инструментов и провайдеров для формы. */
+  getOptions(): Observable<InstrumentSourcePlanOptionsResponseDto> {
+    return this.http
+      .get<ApiResponse<InstrumentSourcePlanOptionsResponseDto>>(`${this.baseUrl}/options`)
+      .pipe(
+        map(res => res.data ?? { instruments: [], providers: [] })
+      );
+  }
+
+  /* Создать новый whole-plan. */
+  create(dto: CreateInstrumentSourcePlanDto): Observable<void> {
+    return this.http
+      .post<void>(this.baseUrl, dto)
+      .pipe(map(() => undefined));
+  }
+
+  /* Полностью заменить whole-plan по instrumentCode. */
+  replace(instrumentCode: string, dto: ReplaceInstrumentSourcePlanDto): Observable<void> {
+    return this.http
+      .put<void>(`${this.baseUrl}/${instrumentCode}`, dto)
+      .pipe(map(() => undefined));
+  }
+
+  /* Удалить whole-plan по instrumentCode. */
+  delete(instrumentCode: string): Observable<void> {
+    return this.http
+      .delete<void>(`${this.baseUrl}/${instrumentCode}`)
+      .pipe(map(() => undefined));
+  }
+}


### PR DESCRIPTION
### Motivation
- Добавить frontend-фичу для управления whole-plan `InstrumentSourcePlan`, чтобы пользователь мог работать с одним планом целиком (create / replace / delete / edit sources) без изменения backend и доменной модели.
- Сделать экран в стиле существующих Angular features проекта (как `currency` и `provider_passport`), единый одностраничный admin с редактором и обзором существующих plans.

### Description
- Добавлен лениво загружаемый feature-модуль `frontend/src/app/features/instrument_source_plan` с `instrument-source-plan.module.ts` и `instrument-source-plan-routing.module.ts` и подключён route `path: 'instrument-source-plans'` в `frontend/src/app/app.routes.ts` и кнопка в toolbar `frontend/src/app/app.component.html`.
- Созданы DTO-модели по контракту backend в `models/` (`instrument-source-plan.model.ts`, `instrument-source-plan-options.model.ts`, `create-instrument-source-plan.model.ts`, `replace-instrument-source-plan.model.ts`).
- Реализован `InstrumentSourcePlanService` (`services/instrument-source-plan.service.ts`) на `HttpClient` с методами `list/get/getOptions/create/replace/delete` и базовым URL `/api/v1/instrument-source-plans`.
- Добавлена standalone admin-страница `InstrumentSourcePlanAdminComponent` (`pages/instrument-source-plan-admin/*`) с двукарточным layout: верхний editor (instrument `mat-select`, `FormArray` rows для sources с `providerCode/active/priority`, валидация, проверки duplicate, сортировка по `priority`) и нижняя обзорная `mat-table` (колонки `instrumentCode`, `sourceCount`, `firstProvider`, `actions`), а также snackbar-сообщения для успехов/ошибок.

### Testing
- Запущена сборка фронтенда командой `cd frontend && npm run build`, сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d968dd06ec832dbeb1a56d70031a85)