### PR TITLE
Сортировка FX Spot инструментов по символу в админке

### DIFF
--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -225,7 +225,7 @@ export class FxSpotAdminComponent implements OnInit {
   private refresh(): void {
     this.service.list().subscribe({
       next: list => {
-        this.dataSource.data = list;
+        this.dataSource.data = [...list].sort((left, right) => left.symbol.localeCompare(right.symbol));
       },
       error: err => {
         this.snack.open(err.message ?? 'Load failed', 'Close');


### PR DESCRIPTION
### Motivation
- Обеспечить отображение таблицы FX Spot Instruments в фронтенде в алфавитном порядке по полю `symbol` для удобства поиска и читабельности.

### Description
- В `frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts` изменён метод `refresh()`: данные теперь присваиваются как `this.dataSource.data = [...list].sort((left, right) => left.symbol.localeCompare(right.symbol));` чтобы сортировать инструменты по `symbol` перед привязкой к `MatTableDataSource`.

### Testing
- Запущена сборка фронтенда командой `npm run build` в каталоге `frontend`, сборка завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96b3a6540832d93a7212fa3ebc859)