### PR TITLE
refactor(sourcing): заменить ApiResponse на ProblemDetail в InstrumentSourcePlanRestExceptionHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.sourcing.plan.api.advice;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.sourcing.plan.api.command.create.controller.CreateInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.delete.controller.DeleteInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.replace.controller.ReplaceInstrumentSourcePlanController;
@@ -15,9 +13,17 @@ import com.alligator.market.backend.sourcing.plan.application.exception.Instrume
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Feature-specific обработчик ошибок API для сценариев InstrumentSourcePlan.
@@ -39,42 +45,114 @@ public class InstrumentSourcePlanRestExceptionHandler {
     private static final String PROVIDER_CODES_NOT_FOUND = "PROVIDER_CODES_NOT_FOUND";
     private static final String INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS = "INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS";
     private static final String INSTRUMENT_SOURCE_PLAN_NOT_FOUND = "INSTRUMENT_SOURCE_PLAN_NOT_FOUND";
+    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
+    private static final String MALFORMED_REQUEST = "MALFORMED_REQUEST";
 
     /**
      * Код инструмента отсутствует в registry --> 400.
      */
     @ExceptionHandler(InstrumentCodeNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInstrumentCodeNotFound(InstrumentCodeNotFoundException ex) {
+    public ProblemDetail handleInstrumentCodeNotFound(InstrumentCodeNotFoundException ex) {
         log.warn("Instrument code does not exist: {}", ex.getMessage());
-        return ResponseEntityFactory.badRequest(INSTRUMENT_CODE_NOT_FOUND, ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Instrument code not found",
+                ex.getMessage(),
+                INSTRUMENT_CODE_NOT_FOUND
+        );
     }
 
     /**
      * Один или несколько кодов провайдера отсутствуют в registry --> 400.
      */
     @ExceptionHandler(ProviderCodesNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleProviderCodesNotFound(ProviderCodesNotFoundException ex) {
+    public ProblemDetail handleProviderCodesNotFound(ProviderCodesNotFoundException ex) {
         log.warn("Provider codes do not exist: {}", ex.getMessage());
-        return ResponseEntityFactory.badRequest(PROVIDER_CODES_NOT_FOUND, ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Provider codes not found",
+                ex.getMessage(),
+                PROVIDER_CODES_NOT_FOUND
+        );
     }
 
     /**
      * План источников уже существует --> 409.
      */
     @ExceptionHandler(InstrumentSourcePlanAlreadyExistsException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInstrumentSourcePlanAlreadyExists(
+    public ProblemDetail handleInstrumentSourcePlanAlreadyExists(
             InstrumentSourcePlanAlreadyExistsException ex
     ) {
         log.warn("Instrument source plan already exists: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS, ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.CONFLICT,
+                "Instrument source plan already exists",
+                ex.getMessage(),
+                INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS
+        );
     }
 
     /**
      * План источников не найден --> 404.
      */
     @ExceptionHandler(InstrumentSourcePlanNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInstrumentSourcePlanNotFound(InstrumentSourcePlanNotFoundException ex) {
+    public ProblemDetail handleInstrumentSourcePlanNotFound(InstrumentSourcePlanNotFoundException ex) {
         log.warn("Instrument source plan not found: {}", ex.getMessage());
-        return ResponseEntityFactory.notFound(INSTRUMENT_SOURCE_PLAN_NOT_FOUND, ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.NOT_FOUND,
+                "Instrument source plan not found",
+                ex.getMessage(),
+                INSTRUMENT_SOURCE_PLAN_NOT_FOUND
+        );
+    }
+
+    /**
+     * Ошибки валидации входного DTO (@Valid) --> 400.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        log.warn("Request validation failed: {}", ex.getMessage());
+
+        ProblemDetail problemDetail = buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Validation failed",
+                "Request validation failed",
+                VALIDATION_ERROR
+        );
+
+        /* Поля с ошибками -> компактная карта field -> message. */
+        Map<String, String> fieldErrors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .collect(Collectors.toMap(
+                        FieldError::getField,
+                        fieldError -> Objects.requireNonNullElse(fieldError.getDefaultMessage(), "Invalid value"),
+                        (first, second) -> first
+                ));
+        problemDetail.setProperty("fieldErrors", fieldErrors);
+
+        return problemDetail;
+    }
+
+    /**
+     * Некорректное тело запроса (JSON parse / type mismatch) --> 400.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+        log.warn("Malformed request body: {}", ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Malformed request",
+                "Request body is malformed or unreadable",
+                MALFORMED_REQUEST
+        );
+    }
+
+    /* Общий builder ProblemDetail для единообразного контракта ошибок feature. */
+    private ProblemDetail buildProblemDetail(HttpStatus status, String title, String detail, String errorCode) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setTitle(title);
+        problemDetail.setProperty("errorCode", errorCode);
+        return problemDetail;
     }
 }


### PR DESCRIPTION
### Motivation
- Убрать использование кастомного `ApiResponse` / `ResponseEntityFactory` внутри фичи sourcing и перейти на стандартный Spring `ProblemDetail` для ошибок.
- Обеспечить, чтобы типовые ошибки валидации и некорректного JSON в контроллерах sourcing тоже возвращались в формате `ProblemDetail`, а не шли в глобальный обработчик с `ApiResponse`.
- Сохранить прежние HTTP статусы и контракт ошибок (status / detail / читабельный title) и добавить legacy `errorCode` в теле для совместимости.

### Description
- Изменён файл `backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java`, удалены импорты `ApiResponse` и `ResponseEntityFactory` и все обработчики переводятся на возврат `ProblemDetail`.
- Для доменных исключений сохранены HTTP статусы и добавлены понятные заголовки и свойство `errorCode`, причём `detail = ex.getMessage()` для всех: `InstrumentCodeNotFoundException` (400, `INSTRUMENT_CODE_NOT_FOUND`), `ProviderCodesNotFoundException` (400, `PROVIDER_CODES_NOT_FOUND`), `InstrumentSourcePlanAlreadyExistsException` (409, `INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS`) и `InstrumentSourcePlanNotFoundException` (404, `INSTRUMENT_SOURCE_PLAN_NOT_FOUND`).
- Добавлены feature-scoped обработчики типовых ошибок запроса: `MethodArgumentNotValidException` -> 400 `ProblemDetail` с `errorCode = VALIDATION_ERROR` и свойством `fieldErrors` (map field->message), и `HttpMessageNotReadableException` -> 400 `ProblemDetail` с `errorCode = MALFORMED_REQUEST`.
- Внутри handler добавлен приватный helper `buildProblemDetail(...)` для единого формирования `ProblemDetail`; контроллеры и успешные ответы не менялись.

### Testing
- Выполнен поиск по sourcing-коду на оставшиеся импорты кастомного ответа с помощью `rg "com\.alligator\.market\.backend\.common\.web\.response\.(ApiResponse|ResponseEntityFactory)" backend/src/main/java/com/alligator/market/backend/sourcing`, и совпадений не найдено (импорты удалены).
- Попытка собрать модуль бекенда командой `./mvnw -pl backend -DskipTests compile` в этом окружении завершилась неудачей из-за невозможности скачать Maven дистрибутив (сетевая ошибка), поэтому компиляция/CI-проверки не были успешно выполнены здесь.
- Автоматических тестов (unit/integration) дополнительно не запускал в этом окружении из-за отсутствия успешной сборки.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96f28ee5c832dafc53a6d5d928e4a)