### PR TITLE
fix(frontend): убрать ApiResponse и читать DTO напрямую в InstrumentSourcePlanService

### DIFF
--- a/frontend/src/app/features/instrument_source_plan/services/instrument-source-plan.service.ts
+++ b/frontend/src/app/features/instrument_source_plan/services/instrument-source-plan.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
 
-import { ApiResponse } from '../../../shared/api/api-response.model';
 import {
   InstrumentSourcePlanListResponseDto,
   InstrumentSourcePlanResponseDto
@@ -25,24 +24,18 @@ export class InstrumentSourcePlanService {
   /* Получить все sourcing plans. */
   list(): Observable<InstrumentSourcePlanResponseDto[]> {
     return this.http
-      .get<ApiResponse<InstrumentSourcePlanListResponseDto>>(this.baseUrl)
-      .pipe(map(res => res.data?.plans ?? []));
+      .get<InstrumentSourcePlanListResponseDto>(this.baseUrl)
+      .pipe(map(res => res.plans ?? []));
   }
 
   /* Получить whole-plan по instrumentCode. */
   get(instrumentCode: string): Observable<InstrumentSourcePlanResponseDto> {
-    return this.http
-      .get<ApiResponse<InstrumentSourcePlanResponseDto>>(`${this.baseUrl}/${instrumentCode}`)
-      .pipe(map(res => res.data as InstrumentSourcePlanResponseDto));
+    return this.http.get<InstrumentSourcePlanResponseDto>(`${this.baseUrl}/${instrumentCode}`);
   }
 
   /* Получить опции инструментов и провайдеров для формы. */
   getOptions(): Observable<InstrumentSourcePlanOptionsResponseDto> {
-    return this.http
-      .get<ApiResponse<InstrumentSourcePlanOptionsResponseDto>>(`${this.baseUrl}/options`)
-      .pipe(
-        map(res => res.data ?? { instruments: [], providers: [] })
-      );
+    return this.http.get<InstrumentSourcePlanOptionsResponseDto>(`${this.baseUrl}/options`);
   }
 
   /* Создать новый whole-plan. */


### PR DESCRIPTION
### Motivation
- Бэкенд-запросы для sourcing уже возвращают plain DTO без `ApiResponse`-envelope, а фронтенд всё ещё ожидал `ApiResponse<T>` и читал `res.data`, из‑за чего dropdowns и таблицы оставались пустыми.

### Description
- Удалён импорт `ApiResponse` из `frontend/src/app/features/instrument_source_plan/services/instrument-source-plan.service.ts`.
- Метод `list()` теперь использует `GET<InstrumentSourcePlanListResponseDto>` и мапит `res.plans ?? []` вместо `res.data?.plans`.
- Метод `get()` теперь использует `GET<InstrumentSourcePlanResponseDto>` и возвращает ответ напрямую вместо чтения `res.data`.
- Метод `getOptions()` теперь использует `GET<InstrumentSourcePlanOptionsResponseDto>` и возвращает ответ напрямую вместо чтения `res.data`.
- Методы `create`, `replace` и `delete` оставлены без изменений.

### Testing
- Выполнена сборка фронтенда командой `cd frontend && npm run -s build`, сборка прошла успешно.
- Нет дополнительных автоматизированных тестов для этого изменения; поведение проверено через успешную сборку и статическую проверку типов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d970a309c4832d88f826a05f37231f)