### PR TITLE
Добавить логирование в сервисы команд планов источников

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/create/CreateInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/create/CreateInstrumentSourcePlanService.java
@@ -8,6 +8,7 @@ import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeE
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -19,6 +20,7 @@ import java.util.Set;
  * <p>Назначение сервиса — выполнить внешние логические проверки перед созданием плана,
  * а затем делегировать сохранение в доменный репозиторий.</p>
  */
+@Slf4j
 public final class CreateInstrumentSourcePlanService {
 
     /* Репозиторий планов источников. */
@@ -63,8 +65,11 @@ public final class CreateInstrumentSourcePlanService {
 
         // Атомарно создаём план, если он ещё не существует
         if (!instrumentSourcePlanRepository.createIfAbsent(plan)) {
+            log.warn("Instrument source plan already exists and was not created: instrumentCode={}", plan.instrumentCode().value());
             throw new InstrumentSourcePlanAlreadyExistsException(plan.instrumentCode());
         }
+
+        log.info("Instrument source plan created: instrumentCode={}, sourceCount={}", plan.instrumentCode().value(), plan.sources().size());
     }
 
     /**

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/delete/DeleteInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/delete/DeleteInstrumentSourcePlanService.java
@@ -3,12 +3,14 @@ package com.alligator.market.backend.sourcing.plan.application.command.delete;
 import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentSourcePlanNotFoundException;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Objects;
 
 /**
  * Сервис удаления плана источников рыночных данных для инструмента.
  */
+@Slf4j
 public final class DeleteInstrumentSourcePlanService {
 
     /* Репозиторий планов источников. */
@@ -32,7 +34,10 @@ public final class DeleteInstrumentSourcePlanService {
         // Условно удаляем root-plan и сигнализируем, если его не было
         boolean deleted = instrumentSourcePlanRepository.deleteIfExistsByInstrumentCode(instrumentCode);
         if (!deleted) {
+            log.warn("Instrument source plan was not found and was not deleted: instrumentCode={}", instrumentCode.value());
             throw new InstrumentSourcePlanNotFoundException(instrumentCode);
         }
+
+        log.info("Instrument source plan deleted: instrumentCode={}", instrumentCode.value());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
@@ -8,6 +8,7 @@ import com.alligator.market.backend.sourcing.plan.application.exception.Instrume
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -16,6 +17,7 @@ import java.util.Set;
 /**
  * Сервис полной замены плана источников рыночных данных для инструмента.
  */
+@Slf4j
 public final class ReplaceInstrumentSourcePlanService {
 
     /* Репозиторий планов источников. */
@@ -61,8 +63,11 @@ public final class ReplaceInstrumentSourcePlanService {
         // Условно заменяем содержимое root-plan и сигнализируем, если плана не было
         boolean replaced = instrumentSourcePlanRepository.replaceIfExists(plan);
         if (!replaced) {
+            log.warn("Instrument source plan was not found and was not replaced: instrumentCode={}", plan.instrumentCode().value());
             throw new InstrumentSourcePlanNotFoundException(plan.instrumentCode());
         }
+
+        log.info("Instrument source plan replaced: instrumentCode={}, sourceCount={}", plan.instrumentCode().value(), plan.sources().size());
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Улучшить наблюдаемость операций создания, удаления и замены планов источников и упростить диагностику проблем в runtime.
- Логировать неудачные попытки (перед выбросом исключений) и успешные операции с ключевыми метриками (`instrumentCode`, `sourceCount`).

### Description
- Подключил `@Slf4j` и добавил логирование в `CreateInstrumentSourcePlanService` (`backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/create/CreateInstrumentSourcePlanService.java`) — `warn` перед `InstrumentSourcePlanAlreadyExistsException` и `info` при успешном создании с `instrumentCode` и `sourceCount`.
- Подключил `@Slf4j` и добавил логирование в `DeleteInstrumentSourcePlanService` (`backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/delete/DeleteInstrumentSourcePlanService.java`) — `warn` если план не найден перед выбросом `InstrumentSourcePlanNotFoundException` и `info` при успешном удалении с `instrumentCode`.
- Подключил `@Slf4j` и добавил логирование в `ReplaceInstrumentSourcePlanService` (`backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java`) — `warn` если план не найден перед выбросом `InstrumentSourcePlanNotFoundException` и `info` при успешной замене с `instrumentCode` и `sourceCount`.

### Testing
- Попытка собрать бэкенд командой `./mvnw -pl backend -DskipTests compile` завершилась неудачей из-за невозможности скачать дистрибутив Maven в этом окружении (`wget: Failed to fetch ...`), поэтому автоматическая сборка/тесты не были выполнены.
- Изменения проверены локально через просмотр diff и успешное сохранение (коммит) в репозитории.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97539c6d0832dbe2460edb0bf5e1b)