### PR TITLE
Улучшение визуальной верстки страницы планов источников инструментов

### DIFF
--- a/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.html
+++ b/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.html
@@ -10,103 +10,109 @@
     <mat-card-content>
       <form [formGroup]="form" class="editor-form">
 
-        <div class="section-label">Select instrument</div>
-        <mat-form-field appearance="outline" class="instrument-field">
-          <mat-select formControlName="instrumentCode">
-            <mat-option *ngFor="let instrument of instruments" [value]="instrument.code">
-              {{ instrument.code }}
-            </mat-option>
-          </mat-select>
-          <mat-error *ngIf="form.controls['instrumentCode'].hasError('required')">
-            Is required
-          </mat-error>
-        </mat-form-field>
+        <section class="form-section">
+          <div class="section-label">Select instrument</div>
+          <mat-form-field appearance="outline" class="instrument-field">
+            <mat-select formControlName="instrumentCode">
+              <mat-option *ngFor="let instrument of instruments" [value]="instrument.code">
+                {{ instrument.code }}
+              </mat-option>
+            </mat-select>
+            <mat-error *ngIf="form.controls['instrumentCode'].hasError('required')">
+              Is required
+            </mat-error>
+          </mat-form-field>
+        </section>
 
-        <div class="sources-header-row">
-          <div class="section-label">Sources</div>
-          <button mat-stroked-button type="button" (click)="onAddSourceRow()">
-            Add source
-          </button>
-        </div>
-
-        <div formArrayName="sources" class="sources-grid">
-          <div
-            class="source-row"
-            *ngFor="let control of sourceControls; let i = index"
-            [formGroupName]="i"
-          >
-            <mat-form-field appearance="outline">
-              <mat-label>Provider</mat-label>
-              <mat-select formControlName="providerCode">
-                <mat-option *ngFor="let provider of providers" [value]="provider.code">
-                  {{ provider.code }}
-                </mat-option>
-              </mat-select>
-              <mat-error *ngIf="control.get('providerCode')?.hasError('required')">
-                Is required
-              </mat-error>
-            </mat-form-field>
-
-            <mat-checkbox formControlName="active">Active</mat-checkbox>
-
-            <mat-form-field appearance="outline">
-              <mat-label>Priority</mat-label>
-              <input matInput type="number" formControlName="priority" />
-              <mat-error *ngIf="control.get('priority')?.hasError('required')">
-                Is required
-              </mat-error>
-              <mat-error *ngIf="control.get('priority')?.hasError('min')">
-                Must be >= 0
-              </mat-error>
-            </mat-form-field>
-
-            <button
-              mat-icon-button
-              color="warn"
-              type="button"
-              (click)="onRemoveSourceRow(i)"
-              [disabled]="sources.length <= 1"
-            >
-              <mat-icon>delete</mat-icon>
+        <section class="form-section form-section--sources">
+          <div class="sources-header-row">
+            <div class="section-label">Sources</div>
+            <button mat-stroked-button type="button" (click)="onAddSourceRow()">
+              Add source
             </button>
           </div>
-        </div>
 
-        <div class="validation-row" *ngIf="hasDuplicateProviders || hasDuplicatePriorities">
-          <span *ngIf="hasDuplicateProviders">Duplicate providerCode is not allowed.</span>
-          <span *ngIf="hasDuplicatePriorities">Duplicate priority is not allowed.</span>
-        </div>
+          <div formArrayName="sources" class="sources-grid">
+            <div
+              class="source-row"
+              *ngFor="let control of sourceControls; let i = index"
+              [formGroupName]="i"
+            >
+              <mat-form-field appearance="outline">
+                <mat-label>Provider</mat-label>
+                <mat-select formControlName="providerCode">
+                  <mat-option *ngFor="let provider of providers" [value]="provider.code">
+                    {{ provider.code }}
+                  </mat-option>
+                </mat-select>
+                <mat-error *ngIf="control.get('providerCode')?.hasError('required')">
+                  Is required
+                </mat-error>
+              </mat-form-field>
 
-        <div class="action-row" *ngIf="!editing; else editModeButtons">
-          <button
-            mat-raised-button
-            color="primary"
-            type="button"
-            (click)="onCreate()"
-            [disabled]="hasPlanValidationError || locked"
-          >
-            Create plan
-          </button>
-          <button mat-raised-button type="button" (click)="onReset()">Reset</button>
-        </div>
+              <mat-checkbox formControlName="active">Active</mat-checkbox>
 
-        <ng-template #editModeButtons>
-          <div class="action-row">
+              <mat-form-field appearance="outline">
+                <mat-label>Priority</mat-label>
+                <input matInput type="number" formControlName="priority" />
+                <mat-error *ngIf="control.get('priority')?.hasError('required')">
+                  Is required
+                </mat-error>
+                <mat-error *ngIf="control.get('priority')?.hasError('min')">
+                  Must be >= 0
+                </mat-error>
+              </mat-form-field>
+
+              <button
+                mat-icon-button
+                color="warn"
+                type="button"
+                (click)="onRemoveSourceRow(i)"
+                [disabled]="sources.length <= 1"
+              >
+                <mat-icon>delete</mat-icon>
+              </button>
+            </div>
+          </div>
+
+          <div class="validation-row" *ngIf="hasDuplicateProviders || hasDuplicatePriorities">
+            <span *ngIf="hasDuplicateProviders">Duplicate providerCode is not allowed.</span>
+            <span *ngIf="hasDuplicatePriorities">Duplicate priority is not allowed.</span>
+          </div>
+        </section>
+
+        <section class="form-section form-section--actions">
+          <div class="action-row" *ngIf="!editing; else editModeButtons">
             <button
               mat-raised-button
               color="primary"
               type="button"
-              (click)="onSave()"
+              (click)="onCreate()"
               [disabled]="hasPlanValidationError || locked"
             >
-              Save changes
+              Create plan
             </button>
-            <button mat-raised-button type="button" (click)="cancelEdit()">Cancel edit</button>
-            <button mat-raised-button color="warn" type="button" (click)="onDeleteSelected()">
-              Delete plan
-            </button>
+            <button mat-raised-button type="button" (click)="onReset()">Reset</button>
           </div>
-        </ng-template>
+
+          <ng-template #editModeButtons>
+            <div class="action-row">
+              <button
+                mat-raised-button
+                color="primary"
+                type="button"
+                (click)="onSave()"
+                [disabled]="hasPlanValidationError || locked"
+              >
+                Save changes
+              </button>
+              <button mat-raised-button type="button" (click)="cancelEdit()">Cancel edit</button>
+              <button mat-raised-button color="warn" type="button" (click)="onDeleteSelected()">
+                Delete plan
+              </button>
+            </div>
+          </ng-template>
+        </section>
       </form>
     </mat-card-content>
   </mat-card>
@@ -116,8 +122,8 @@
     <mat-card-header>
       <mat-card-title>Source Plans</mat-card-title>
     </mat-card-header>
-    <mat-card-content>
-      <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
+    <mat-card-content class="table-content">
+      <table mat-table [dataSource]="dataSource" class="plans-table mat-elevation-z2">
 
         <ng-container matColumnDef="instrumentCode">
           <th mat-header-cell *matHeaderCellDef>Instrument</th>

--- a/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.scss
+++ b/frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.scss
@@ -1,69 +1,171 @@
+/* Контейнер страницы с ограничением ширины и единым вертикальным ритмом. */
 .center-box {
-  max-width: 1160px;
-  margin: 32px auto;
+  max-width: 1200px;
+  margin: 24px auto 40px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  padding: 0 16px;
+  gap: 24px;
+  padding: 0 20px;
 }
 
+/* Верхняя панель всегда остается доступной при прокрутке таблицы. */
 .toolbar-card {
   position: sticky;
-  top: 0;
+  top: 12px;
   z-index: 10;
   background: #fff;
+  border-radius: 14px;
 }
 
+/* Основная форма редактирования плана. */
 .editor-form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
 }
 
+/* Логически обособленные секции формы. */
+.form-section {
+  padding: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+/* Секция источников имеет более плотный ритм для повторяющихся строк. */
+.form-section--sources {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Блок с действиями отделяем от контента и выравниваем по правому краю. */
+.form-section--actions {
+  background: #fff;
+}
+
+/* Поле выбора инструмента с ограничением читаемой ширины. */
 .instrument-field {
-  max-width: 340px;
+  max-width: 360px;
+  width: 100%;
 }
 
+/* Унифицированный заголовок секции. */
 .section-label {
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
+  letter-spacing: 0.2px;
   color: rgba(0, 0, 0, 0.72);
 }
 
+/* Заголовок секции sources с action-кнопкой. */
 .sources-header-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
+/* Сетка строк источников. */
 .sources-grid {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
+/* Одна строка источника в виде карты. */
 .source-row {
   display: grid;
   grid-template-columns: minmax(220px, 1fr) 120px 140px 56px;
   gap: 12px;
   align-items: center;
+  padding: 12px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
 }
 
+/* Ошибки валидации плана. */
 .validation-row {
   color: #b3261e;
   display: flex;
   flex-direction: column;
   gap: 4px;
+  margin-top: 4px;
 }
 
+/* Ряд с действиями формы. */
 .action-row {
   display: flex;
   gap: 12px;
   align-items: center;
   flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
+/* Ячейка с action-кнопками в таблице. */
 .actions-cell {
   display: flex;
   gap: 8px;
+  justify-content: flex-end;
+}
+
+/* Контент карточки таблицы без лишних внутренних отступов. */
+.table-content {
+  padding-top: 8px;
+}
+
+/* Таблица планов с аккуратным скроллом на узких экранах. */
+.plans-table {
+  width: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+/* Адаптив для планшетов и мобильных экранов. */
+@media (max-width: 960px) {
+  .source-row {
+    grid-template-columns: 1fr 1fr auto;
+    grid-template-areas:
+      'provider provider remove'
+      'active priority remove';
+    row-gap: 8px;
+  }
+
+  .source-row mat-form-field:first-child {
+    grid-area: provider;
+  }
+
+  .source-row mat-checkbox {
+    grid-area: active;
+  }
+
+  .source-row mat-form-field:nth-of-type(2) {
+    grid-area: priority;
+  }
+
+  .source-row button {
+    grid-area: remove;
+    justify-self: end;
+  }
+}
+
+@media (max-width: 600px) {
+  .center-box {
+    margin-top: 16px;
+    padding: 0 12px;
+  }
+
+  .form-section {
+    padding: 12px;
+  }
+
+  .action-row {
+    justify-content: stretch;
+  }
+
+  .action-row > button {
+    flex: 1 1 100%;
+  }
 }


### PR DESCRIPTION
### Motivation
- Сделать форму и таблицу на странице `instrument-source-plans` более читаемыми и логично сгруппированными, не трогая бизнес-логику и биндинги.

### Description
- Разметка админ-страницы была реструктурирована в логические секции через `<section>`: `Select instrument`, `Sources`, `Actions`, при этом все исходные привязки и события сохранены (файл `frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.html`).
- Добавлены служебные классы для карточки/таблицы (`table-content`, `plans-table`) и мелкие правки в шаблоне для более аккуратного DOM и семантики.
- Обновлён SCSS для единого визуального ритма и иерархии: параметры `center-box`, улучшенная `toolbar-card`, карточные секции формы (`.form-section`), стили для `.source-row` и выравнивание `.action-row`, а также адаптивные правила для планшетов/мобил и небольшие изменения ширин/отступов (файл `frontend/src/app/features/instrument_source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.scss`).
- Визуальные изменения не затрагивают логику: все `formControlName`, `*ngFor`, методы (`onAddSourceRow`, `onRemoveSourceRow`, `onCreate`, `onSave`, `onLoadPlan`, `onDeleteFromList` и т.д.) и валидация оставлены без изменений.

### Testing
- Выполнена сборка фронтенда командой `cd frontend && npm run -s build` и сборка завершилась успешно, артефакты сгенерированы в `frontend/dist/frontend`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d976314fb4832da0cf3e94ba17ba01)