### PR TITLE
Добавить порт CurrencyUsageCheckPort

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/CurrencyUsageCheckPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/CurrencyUsageCheckPort.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port;
+
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.vo.CurrencyCode;
+
+/**
+ * Порт проверки использования валюты во внешних агрегатах и инструментах.
+ */
+public interface CurrencyUsageCheckPort {
+
+    /**
+     * Проверяет, используется ли валюта хотя бы в одном внешнем агрегате или инструменте.
+     */
+    boolean isUsed(CurrencyCode currencyCode);
+}


### PR DESCRIPTION
### Motivation
- Добавить абстрактный порт для проверки использования валюты в внешних агрегатах/инструментах без зависимостей от Spring/JPA/FxSpot, чтобы отделить контракт от реализации.

### Description
- Добавлен файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/CurrencyUsageCheckPort.java` с интерфейсом `CurrencyUsageCheckPort` и методом `boolean isUsed(CurrencyCode currencyCode);` и краткими комментариями на русском.

### Testing
- Выполнены автоматизированные проверки репозитория: `git status --short` и просмотр содержимого файла через `nl -ba backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/CurrencyUsageCheckPort.java`, обе команды выполнились успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da522dbb1c832d93cf1ef5d2918e17)