### PR TITLE
Добавить адаптер `FxSpotCurrencyUsageCheckAdapter`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/adapter/FxSpotCurrencyUsageCheckAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/adapter/FxSpotCurrencyUsageCheckAdapter.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.adapter;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.CurrencyUsageCheckPort;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.vo.CurrencyCode;
+import com.alligator.market.domain.instrument.asset.forex.spot.repository.FxSpotRepository;
+
+import java.util.Objects;
+
+/**
+ * Адаптер порта проверки использования валюты в FX Spot инструментах.
+ */
+public final class FxSpotCurrencyUsageCheckAdapter implements CurrencyUsageCheckPort {
+
+    /* Репозиторий FX Spot для проверки использования валюты. */
+    private final FxSpotRepository fxSpotRepository;
+
+    public FxSpotCurrencyUsageCheckAdapter(FxSpotRepository fxSpotRepository) {
+        this.fxSpotRepository = Objects.requireNonNull(fxSpotRepository, "fxSpotRepository must not be null");
+    }
+
+    @Override
+    public boolean isUsed(CurrencyCode currencyCode) {
+        // Проверяем обязательный входной аргумент.
+        Objects.requireNonNull(currencyCode, "currencyCode must not be null");
+
+        return fxSpotRepository.existsByCurrencyCode(currencyCode);
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить реализацию application-port для проверки, используется ли валюта в FX Spot инструментах, чтобы отделить логику проверки использования валюты от доменных/инфраструктурных слоев.

### Description
- Добавлен `final` класс `FxSpotCurrencyUsageCheckAdapter` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.adapter`.
- Класс реализует интерфейс `CurrencyUsageCheckPort` и принимает в конструкторе `FxSpotRepository` с `Objects.requireNonNull(...)` для защиты от `null`.
- Метод `isUsed(CurrencyCode currencyCode)` выполняет проверку входного аргумента на `null` и делегирует вызов в `fxSpotRepository.existsByCurrencyCode(currencyCode)`; никаких Spring-стереотипов и wiring не добавлено.
- Изменён только один новый файл: `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/adapter/FxSpotCurrencyUsageCheckAdapter.java`.

### Testing
- Попытка собрать модуль бекенда командой `./mvnw -pl backend -DskipTests compile` была выполнена автоматически, но сборка не завершилась из-за ошибки загрузки Maven дистрибутива в окружении (`Failed to fetch apache-maven-3.9.9-bin.zip`).
- Автоматические тесты не запускались и сборка не прошла, поэтому интеграционная проверка невозможна в текущем окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da53bd5794832d84201a13c146ab4c)