### PR TITLE
Добавить wiring-конфигурацию для CurrencyUsageCheckPort

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/port/adapter/CurrencyUsageCheckPortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/port/adapter/CurrencyUsageCheckPortWiringConfig.java
@@ -1,0 +1,24 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.port.adapter;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.CurrencyUsageCheckPort;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.adapter.FxSpotCurrencyUsageCheckAdapter;
+import com.alligator.market.domain.instrument.asset.forex.spot.repository.FxSpotRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация wiring {@link CurrencyUsageCheckPort}.
+ */
+@Configuration(proxyBeanMethods = false)
+public class CurrencyUsageCheckPortWiringConfig {
+
+    public static final String BEAN_CURRENCY_USAGE_CHECK_PORT = "currencyUsageCheckPort";
+
+    /**
+     * Порт проверки использования валюты в FX Spot инструментах.
+     */
+    @Bean(BEAN_CURRENCY_USAGE_CHECK_PORT)
+    public CurrencyUsageCheckPort currencyUsageCheckPort(FxSpotRepository fxSpotRepository) {
+        return new FxSpotCurrencyUsageCheckAdapter(fxSpotRepository);
+    }
+}


### PR DESCRIPTION
### Motivation
- Необходимо явно зарегистрировать bean порта проверки использования валюты для явной сборки адаптера и избежания stereotype-аннотаций на адаптере.

### Description
- Добавлен новый файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/port/adapter/CurrencyUsageCheckPortWiringConfig.java` с аннотацией `@Configuration(proxyBeanMethods = false)`.
- В классе объявлена константа `public static final String BEAN_CURRENCY_USAGE_CHECK_PORT = "currencyUsageCheckPort"` для имени bean.
- Добавлен метод `@Bean(BEAN_CURRENCY_USAGE_CHECK_PORT) public CurrencyUsageCheckPort currencyUsageCheckPort(FxSpotRepository fxSpotRepository)`, возвращающий `new FxSpotCurrencyUsageCheckAdapter(fxSpotRepository)`.
- Добавлены краткие русскоязычные комментарии в стиле проекта и использованы интерфейсы/классы `CurrencyUsageCheckPort`, `FxSpotCurrencyUsageCheckAdapter` и `FxSpotRepository`.

### Testing
- Выполнена проверка стиля/диффа через `git diff --check`, ошибок не обнаружено (успешно).
- Попытка запустить компиляцию через `./gradlew :backend:compileJava` не выполнена из-за отсутствия `gradlew` в окружении (проверка недоступна).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db44fe5490832d86aec92f78cb69f2)