### PR TITLE
Добавить порт `CurrencyUsageContributor` для проверки использования валют

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/CurrencyUsageContributor.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/CurrencyUsageContributor.java
@@ -1,0 +1,10 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port;
+
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.vo.CurrencyCode;
+
+/* Локальный вклад feature/aggregate в общую проверку использования валюты. */
+public interface CurrencyUsageContributor {
+
+    /* Проверяет, используется ли валюта в рамках конкретного contributor. */
+    boolean isUsed(CurrencyCode currencyCode);
+}


### PR DESCRIPTION
### Motivation
- Ввести contributor-based схему проверки использования валюты, чтобы разные feature/aggregate (например, FxSpot, FxForward) могли вносить локальную логику проверки.

### Description
- Добавлен интерфейс `CurrencyUsageContributor` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port` с методом `boolean isUsed(CurrencyCode currencyCode);` и краткими комментариями на русском, без использования Spring-аннотаций.

### Testing
- Автоматизированные тесты не запускались; изменение ограничено добавлением интерфейса `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/CurrencyUsageContributor.java` и не затрагивает существующую логику.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db743bacc8832da5e4ddcd78bf735d)