### PR TITLE
Add FxSpotCurrencyUsageContributor

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/contributor/FxSpotCurrencyUsageContributor.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/port/contributor/FxSpotCurrencyUsageContributor.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.contributor;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.CurrencyUsageContributor;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.vo.CurrencyCode;
+import com.alligator.market.domain.instrument.asset.forex.spot.repository.FxSpotRepository;
+
+import java.util.Objects;
+
+/**
+ * Contributor проверки использования валюты в инструментах FX Spot.
+ */
+public final class FxSpotCurrencyUsageContributor implements CurrencyUsageContributor {
+
+    /* Репозиторий FX Spot для проверки использования валюты. */
+    private final FxSpotRepository fxSpotRepository;
+
+    public FxSpotCurrencyUsageContributor(FxSpotRepository fxSpotRepository) {
+        this.fxSpotRepository = Objects.requireNonNull(fxSpotRepository, "fxSpotRepository must not be null");
+    }
+
+    @Override
+    public boolean isUsed(CurrencyCode currencyCode) {
+        // Проверяем обязательный входной аргумент.
+        Objects.requireNonNull(currencyCode, "currencyCode must not be null");
+
+        return fxSpotRepository.existsByCurrencyCode(currencyCode);
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить локальный contributor для проверки использования валюты в инструментах FX Spot, чтобы интегрировать проверку в общий механизм определения использования валюты.

### Description
- Добавлен final класс `FxSpotCurrencyUsageContributor` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.contributor`, реализующий `CurrencyUsageContributor`, принимающий в конструкторе `FxSpotRepository` и реализующий метод `isUsed` с проверкой на `null` и вызовом `fxSpotRepository.existsByCurrencyCode(currencyCode)`, при этом Spring-аннотаций не используется и добавлены краткие комментарии на русском.

### Testing
- Попытка сборки с помощью `./mvnw -pl backend -DskipTests compile` не прошла из-за ошибки загрузки Maven дистрибутива в окружении, других автоматических тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db765f3688832d90e63750724e526f)