### PR TITLE
Добавить FxSpotCurrencyUsageContributor

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/contributor/fxspot/FxSpotCurrencyUsageContributor.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/contributor/fxspot/FxSpotCurrencyUsageContributor.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.contributor.fxspot;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.contributor.CurrencyUsageContributor;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.model.vo.CurrencyCode;
+import com.alligator.market.domain.instrument.asset.forex.spot.repository.FxSpotRepository;
+
+import java.util.Objects;
+
+/**
+ * Contributor проверки использования валюты в инструментах FxSpot.
+ */
+public final class FxSpotCurrencyUsageContributor implements CurrencyUsageContributor {
+
+    /* Репозиторий FxSpot для проверки использования валюты. */
+    private final FxSpotRepository fxSpotRepository;
+
+    public FxSpotCurrencyUsageContributor(FxSpotRepository fxSpotRepository) {
+        this.fxSpotRepository = Objects.requireNonNull(fxSpotRepository, "fxSpotRepository must not be null");
+    }
+
+    @Override
+    public boolean isUsed(CurrencyCode currencyCode) {
+        // Проверяем обязательный входной аргумент.
+        Objects.requireNonNull(currencyCode, "currencyCode must not be null");
+
+        return fxSpotRepository.existsByCurrencyCode(currencyCode);
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить проверку использования валюты для инструментов FX Spot через репозиторий `FxSpotRepository` и обеспечить вклад в общую проверку использования валюты.

### Description
- Добавлен `final` класс `FxSpotCurrencyUsageContributor` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.application.contributor.fxspot`, реализующий `CurrencyUsageContributor`.
- Класс содержит поле `private final FxSpotRepository fxSpotRepository` и проверяет зависимость в конструкторе с помощью `Objects.requireNonNull`.
- Метод `isUsed(CurrencyCode currencyCode)` проверяет аргумент на `null` и делегирует проверку вызовом `fxSpotRepository.existsByCurrencyCode(currencyCode)`; в коде добавлены краткие русские комментарии.

### Testing
- Автоматизированные unit/integration тесты не запускались; изменения ограничены созданием нового класса `FxSpotCurrencyUsageContributor`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db84ba32ec832d8c4def92999aab99)