### PR TITLE
refactor: move source plan repository to persistence/jooq structure

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/create/CreateInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/create/CreateInstrumentSourcePlanServiceWiringConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.sourcing.config.plan.application.command.cr
 
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.InstrumentCodeExistencePortWiringConfig;
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.ProviderCodeExistencePortWiringConfig;
-import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.command.create.CreateInstrumentSourcePlanService;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/delete/DeleteInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/delete/DeleteInstrumentSourcePlanServiceWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.sourcing.config.plan.application.command.delete;
 
-import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.command.delete.DeleteInstrumentSourcePlanService;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.sourcing.config.plan.application.command.re
 
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.InstrumentCodeExistencePortWiringConfig;
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.ProviderCodeExistencePortWiringConfig;
-import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.sourcing.config.plan.application.query.get;
 
-import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.query.get.GetInstrumentSourcePlanService;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.sourcing.config.plan.application.query.list;
 
-import com.alligator.market.backend.sourcing.config.plan.repository.adapter.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository.InstrumentSourcePlanRepositoryWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.query.list.ListInstrumentSourcePlansService;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/persistence/jooq/repository/InstrumentSourcePlanRepositoryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/persistence/jooq/repository/InstrumentSourcePlanRepositoryWiringConfig.java
@@ -1,6 +1,6 @@
-package com.alligator.market.backend.sourcing.config.plan.repository.adapter;
+package com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository;
 
-import com.alligator.market.backend.sourcing.plan.repository.adapter.JooqInstrumentSourcePlanRepository;
+import com.alligator.market.backend.sourcing.plan.persistence.jooq.repository.JooqInstrumentSourcePlanRepository;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepository.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.sourcing.plan.repository.adapter;
+package com.alligator.market.backend.sourcing.plan.persistence.jooq.repository;
 
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.provider.model.vo.ProviderCode;


### PR DESCRIPTION
### Motivation

- Упростить и прояснить архитектурную структуру, разделив оси «роль слоя» и «конкретная технология» в путях пакетов. 
- Заменить общий ярлык `adapter` на более конкретный `persistence/jooq/repository` для лучшей читаемости и масштабируемости кода.

### Description

- Перенёс `JooqInstrumentSourcePlanRepository` в пакет `com.alligator.market.backend.sourcing.plan.persistence.jooq.repository` и обновил соответствующий `package` в файле. 
- Перенёс `InstrumentSourcePlanRepositoryWiringConfig` в пакет `com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository` и обновил импорт реализации на новый путь. 
- Обновил импорты во всех связанных wiring-конфигах сервисов (`create`, `delete`, `replace`, `get`, `list`) чтобы они импортировали новую конфигурацию репозитория из `config.plan.persistence.jooq.repository`. 
- Изменения носят рефакторинг пакетов и не изменяют поведение самой реализации репозитория.

### Testing

- Выполнена попытка сборки команды `mvn -pl backend -DskipTests compile`, которая не прошла из-за невозможности разрешить parent POM `org.springframework.boot:spring-boot-starter-parent:4.0.5` (ошибка при загрузке из Maven Central: `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db879eea84832db4b11c735dc9ddc7)