### PR TITLE
docs: унифицировать javadoc для wiring-конфигураций

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/infra/time/config/TimeWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/infra/time/config/TimeWiringConfig.java
@@ -8,7 +8,9 @@ import org.springframework.context.annotation.Configuration;
 import java.time.Clock;
 import java.time.ZoneId;
 
-/* Spring wiring для времени приложения. */
+/**
+ * Wiring-конфигурация {@link AppTimeProperties}.
+ */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AppTimeProperties.class)
 public class TimeWiringConfig {

--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/config/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Wiring-конфигурация startup-runner для проекции паспортов провайдеров.
+ * Wiring-конфигурация {@link ProviderPassportProjectionStartupRunner}.
  */
 @Configuration(proxyBeanMethods = false)
 @Import({

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/get/GetInstrumentSourcePlanServiceWiringConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Конфигурация wiring {@link GetInstrumentSourcePlanService}.
+ * Wiring-конфигурация {@link GetInstrumentSourcePlanService}.
  */
 @Configuration(proxyBeanMethods = false)
 @Import({

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/list/ListInstrumentSourcePlansServiceWiringConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Конфигурация wiring {@link ListInstrumentSourcePlansService}.
+ * Wiring-конфигурация {@link ListInstrumentSourcePlansService}.
  */
 @Configuration(proxyBeanMethods = false)
 @Import({

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/options/adapter/InstrumentSourcePlanOptionsQueryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/options/adapter/InstrumentSourcePlanOptionsQueryWiringConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Конфигурация wiring query-портов получения options для UI.
+ * Wiring-конфигурация {@link JooqInstrumentOptionsQueryAdapter}.
  */
 @Configuration(proxyBeanMethods = false)
 public class InstrumentSourcePlanOptionsQueryWiringConfig {

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/persistence/jooq/repository/InstrumentSourcePlanRepositoryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/persistence/jooq/repository/InstrumentSourcePlanRepositoryWiringConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Конфигурация wiring репозитория планов источников инструмента.
+ * Wiring-конфигурация {@link InstrumentSourcePlanRepository}.
  */
 @Configuration(proxyBeanMethods = false)
 public class InstrumentSourcePlanRepositoryWiringConfig {


### PR DESCRIPTION
### Motivation
- Привести Javadoc-описания для всех wiring-конфигураций к единому формату `Wiring-конфигурация {@link ...}` для улучшения читаемости и навигации по коду.

### Description
- Обновлены Javadoc в 6 файлах: `TimeWiringConfig`, `ProviderPassportProjectionStartupRunnerWiringConfig`, `GetInstrumentSourcePlanServiceWiringConfig`, `ListInstrumentSourcePlansServiceWiringConfig`, `InstrumentSourcePlanOptionsQueryWiringConfig`, `InstrumentSourcePlanRepositoryWiringConfig`.

### Testing
- Выполнена проверка шаблона наличия `Wiring-конфигурация {@link ...}` командой `for f in $(rg --files backend/src/main/java | rg 'WiringConfig\\.java$'); do rg -n "Wiring-конфигурация \{@link" "$f" > /dev/null || echo "missing in $f"; done && echo "ok"`, которая вернула `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe73c41b0832d91c287c1c2ddcb68)