### PR TITLE
Вынесён валидатор существования инструмента и провайдеров для планов источников

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/create/CreateInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/create/CreateInstrumentSourcePlanServiceWiringConfig.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.sourcing.config.plan.application.command.cr
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.InstrumentCodeExistencePortWiringConfig;
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.ProviderCodeExistencePortWiringConfig;
 import com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.plan.application.command.common.InstrumentSourcePlanExistenceValidator;
 import com.alligator.market.backend.sourcing.plan.application.command.create.CreateInstrumentSourcePlanService;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
@@ -39,8 +40,10 @@ public class CreateInstrumentSourcePlanServiceWiringConfig {
     ) {
         return new CreateInstrumentSourcePlanService(
                 instrumentSourcePlanRepository,
-                instrumentCodeExistencePort,
-                providerCodeExistencePort
+                new InstrumentSourcePlanExistenceValidator(
+                        instrumentCodeExistencePort,
+                        providerCodeExistencePort
+                )
         );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/command/replace/ReplaceInstrumentSourcePlanServiceWiringConfig.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.sourcing.config.plan.application.command.re
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.InstrumentCodeExistencePortWiringConfig;
 import com.alligator.market.backend.sourcing.config.plan.application.port.adapter.ProviderCodeExistencePortWiringConfig;
 import com.alligator.market.backend.sourcing.config.plan.persistence.jooq.repository.InstrumentSourcePlanRepositoryWiringConfig;
+import com.alligator.market.backend.sourcing.plan.application.command.common.InstrumentSourcePlanExistenceValidator;
 import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
 import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;
@@ -39,8 +40,10 @@ public class ReplaceInstrumentSourcePlanServiceWiringConfig {
     ) {
         return new ReplaceInstrumentSourcePlanService(
                 instrumentSourcePlanRepository,
-                instrumentCodeExistencePort,
-                providerCodeExistencePort
+                new InstrumentSourcePlanExistenceValidator(
+                        instrumentCodeExistencePort,
+                        providerCodeExistencePort
+                )
         );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/common/InstrumentSourcePlanExistenceValidator.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/common/InstrumentSourcePlanExistenceValidator.java
@@ -1,0 +1,64 @@
+package com.alligator.market.backend.sourcing.plan.application.command.common;
+
+import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentCodeNotFoundException;
+import com.alligator.market.backend.sourcing.plan.application.exception.ProviderCodesNotFoundException;
+import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
+import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Валидатор существования связанных сущностей для плана источников.
+ */
+public final class InstrumentSourcePlanExistenceValidator {
+
+    /* Порт проверки существования инструмента по коду. */
+    private final InstrumentCodeExistencePort instrumentCodeExistencePort;
+
+    /* Порт проверки существования провайдера по коду. */
+    private final ProviderCodeExistencePort providerCodeExistencePort;
+
+    public InstrumentSourcePlanExistenceValidator(
+            InstrumentCodeExistencePort instrumentCodeExistencePort,
+            ProviderCodeExistencePort providerCodeExistencePort
+    ) {
+        this.instrumentCodeExistencePort = Objects.requireNonNull(
+                instrumentCodeExistencePort,
+                "instrumentCodeExistencePort must not be null"
+        );
+        this.providerCodeExistencePort = Objects.requireNonNull(
+                providerCodeExistencePort,
+                "providerCodeExistencePort must not be null"
+        );
+    }
+
+    /**
+     * Проверяет существование инструмента.
+     */
+    public void ensureInstrumentExists(InstrumentSourcePlan plan) {
+        if (!instrumentCodeExistencePort.existsByCode(plan.instrumentCode())) {
+            throw new InstrumentCodeNotFoundException(plan.instrumentCode());
+        }
+    }
+
+    /**
+     * Проверяет существование всех провайдеров, указанных в плане.
+     */
+    public void ensureProvidersExist(InstrumentSourcePlan plan) {
+        Set<String> missingProviderCodes = new LinkedHashSet<>();
+
+        for (MarketDataSource source : plan.sources()) {
+            if (!providerCodeExistencePort.existsByCode(source.providerCode())) {
+                missingProviderCodes.add(source.providerCode().value());
+            }
+        }
+
+        if (!missingProviderCodes.isEmpty()) {
+            throw new ProviderCodesNotFoundException(missingProviderCodes);
+        }
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/create/CreateInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/create/CreateInstrumentSourcePlanService.java
@@ -1,18 +1,12 @@
 package com.alligator.market.backend.sourcing.plan.application.command.create;
 
-import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentCodeNotFoundException;
 import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentSourcePlanAlreadyExistsException;
-import com.alligator.market.backend.sourcing.plan.application.exception.ProviderCodesNotFoundException;
-import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
-import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
+import com.alligator.market.backend.sourcing.plan.application.command.common.InstrumentSourcePlanExistenceValidator;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Сервис создания плана источников рыночных данных для инструмента.
@@ -26,28 +20,20 @@ public final class CreateInstrumentSourcePlanService {
     /* Репозиторий планов источников. */
     private final InstrumentSourcePlanRepository instrumentSourcePlanRepository;
 
-    /* Порт проверки существования инструмента по коду. */
-    private final InstrumentCodeExistencePort instrumentCodeExistencePort;
-
-    /* Порт проверки существования провайдера по коду. */
-    private final ProviderCodeExistencePort providerCodeExistencePort;
+    /* Валидатор существования инструмента и провайдеров из плана. */
+    private final InstrumentSourcePlanExistenceValidator existenceValidator;
 
     public CreateInstrumentSourcePlanService(
             InstrumentSourcePlanRepository instrumentSourcePlanRepository,
-            InstrumentCodeExistencePort instrumentCodeExistencePort,
-            ProviderCodeExistencePort providerCodeExistencePort
+            InstrumentSourcePlanExistenceValidator existenceValidator
     ) {
         this.instrumentSourcePlanRepository = Objects.requireNonNull(
                 instrumentSourcePlanRepository,
                 "instrumentSourcePlanRepository must not be null"
         );
-        this.instrumentCodeExistencePort = Objects.requireNonNull(
-                instrumentCodeExistencePort,
-                "instrumentCodeExistencePort must not be null"
-        );
-        this.providerCodeExistencePort = Objects.requireNonNull(
-                providerCodeExistencePort,
-                "providerCodeExistencePort must not be null"
+        this.existenceValidator = Objects.requireNonNull(
+                existenceValidator,
+                "existenceValidator must not be null"
         );
     }
 
@@ -58,10 +44,10 @@ public final class CreateInstrumentSourcePlanService {
         Objects.requireNonNull(plan, "plan must not be null");
 
         // Проверяем, что инструмент реально существует
-        ensureInstrumentExists(plan);
+        existenceValidator.ensureInstrumentExists(plan);
 
         // Проверяем, что все коды провайдеров из плана существуют
-        ensureProvidersExist(plan);
+        existenceValidator.ensureProvidersExist(plan);
 
         // Атомарно создаём план, если он ещё не существует
         if (!instrumentSourcePlanRepository.createIfAbsent(plan)) {
@@ -70,31 +56,5 @@ public final class CreateInstrumentSourcePlanService {
         }
 
         log.info("Instrument source plan created: instrumentCode={}, sourceCount={}", plan.instrumentCode().value(), plan.sources().size());
-    }
-
-    /**
-     * Проверяет существование инструмента.
-     */
-    private void ensureInstrumentExists(InstrumentSourcePlan plan) {
-        if (!instrumentCodeExistencePort.existsByCode(plan.instrumentCode())) {
-            throw new InstrumentCodeNotFoundException(plan.instrumentCode());
-        }
-    }
-
-    /**
-     * Проверяет существование всех провайдеров, указанных в плане.
-     */
-    private void ensureProvidersExist(InstrumentSourcePlan plan) {
-        Set<String> missingProviderCodes = new LinkedHashSet<>();
-
-        for (MarketDataSource source : plan.sources()) {
-            if (!providerCodeExistencePort.existsByCode(source.providerCode())) {
-                missingProviderCodes.add(source.providerCode().value());
-            }
-        }
-
-        if (!missingProviderCodes.isEmpty()) {
-            throw new ProviderCodesNotFoundException(missingProviderCodes);
-        }
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/replace/ReplaceInstrumentSourcePlanService.java
@@ -1,18 +1,12 @@
 package com.alligator.market.backend.sourcing.plan.application.command.replace;
 
-import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentCodeNotFoundException;
-import com.alligator.market.backend.sourcing.plan.application.exception.ProviderCodesNotFoundException;
-import com.alligator.market.backend.sourcing.plan.application.port.InstrumentCodeExistencePort;
-import com.alligator.market.backend.sourcing.plan.application.port.ProviderCodeExistencePort;
+import com.alligator.market.backend.sourcing.plan.application.command.common.InstrumentSourcePlanExistenceValidator;
 import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentSourcePlanNotFoundException;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Сервис полной замены плана источников рыночных данных для инструмента.
@@ -23,28 +17,20 @@ public final class ReplaceInstrumentSourcePlanService {
     /* Репозиторий планов источников. */
     private final InstrumentSourcePlanRepository instrumentSourcePlanRepository;
 
-    /* Порт проверки существования инструмента по коду. */
-    private final InstrumentCodeExistencePort instrumentCodeExistencePort;
-
-    /* Порт проверки существования провайдера по коду. */
-    private final ProviderCodeExistencePort providerCodeExistencePort;
+    /* Валидатор существования инструмента и провайдеров из плана. */
+    private final InstrumentSourcePlanExistenceValidator existenceValidator;
 
     public ReplaceInstrumentSourcePlanService(
             InstrumentSourcePlanRepository instrumentSourcePlanRepository,
-            InstrumentCodeExistencePort instrumentCodeExistencePort,
-            ProviderCodeExistencePort providerCodeExistencePort
+            InstrumentSourcePlanExistenceValidator existenceValidator
     ) {
         this.instrumentSourcePlanRepository = Objects.requireNonNull(
                 instrumentSourcePlanRepository,
                 "instrumentSourcePlanRepository must not be null"
         );
-        this.instrumentCodeExistencePort = Objects.requireNonNull(
-                instrumentCodeExistencePort,
-                "instrumentCodeExistencePort must not be null"
-        );
-        this.providerCodeExistencePort = Objects.requireNonNull(
-                providerCodeExistencePort,
-                "providerCodeExistencePort must not be null"
+        this.existenceValidator = Objects.requireNonNull(
+                existenceValidator,
+                "existenceValidator must not be null"
         );
     }
 
@@ -55,10 +41,10 @@ public final class ReplaceInstrumentSourcePlanService {
         Objects.requireNonNull(plan, "plan must not be null");
 
         // Проверяем, что инструмент реально существует
-        ensureInstrumentExists(plan);
+        existenceValidator.ensureInstrumentExists(plan);
 
         // Проверяем, что все коды провайдеров из плана существуют
-        ensureProvidersExist(plan);
+        existenceValidator.ensureProvidersExist(plan);
 
         // Условно заменяем содержимое root-plan и сигнализируем, если плана не было
         boolean replaced = instrumentSourcePlanRepository.replaceIfExists(plan);
@@ -68,31 +54,5 @@ public final class ReplaceInstrumentSourcePlanService {
         }
 
         log.info("Instrument source plan replaced: instrumentCode={}, sourceCount={}", plan.instrumentCode().value(), plan.sources().size());
-    }
-
-    /**
-     * Проверяет существование инструмента.
-     */
-    private void ensureInstrumentExists(InstrumentSourcePlan plan) {
-        if (!instrumentCodeExistencePort.existsByCode(plan.instrumentCode())) {
-            throw new InstrumentCodeNotFoundException(plan.instrumentCode());
-        }
-    }
-
-    /**
-     * Проверяет существование всех провайдеров, указанных в плане.
-     */
-    private void ensureProvidersExist(InstrumentSourcePlan plan) {
-        Set<String> missingProviderCodes = new LinkedHashSet<>();
-
-        for (MarketDataSource source : plan.sources()) {
-            if (!providerCodeExistencePort.existsByCode(source.providerCode())) {
-                missingProviderCodes.add(source.providerCode().value());
-            }
-        }
-
-        if (!missingProviderCodes.isEmpty()) {
-            throw new ProviderCodesNotFoundException(missingProviderCodes);
-        }
     }
 }


### PR DESCRIPTION
### Motivation
- Убрать дублирование проверок существования инструмента и провайдеров, которое присутствовало в `CreateInstrumentSourcePlanService` и `ReplaceInstrumentSourcePlanService`, и централизовать эту логику для простоты и поддержки единообразного поведения.

### Description
- Добавлен новый класс `InstrumentSourcePlanExistenceValidator` в `backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/command/common` для проверки существования инструмента и провайдеров из плана.
- Обновлены `CreateInstrumentSourcePlanService` и `ReplaceInstrumentSourcePlanService` для делегирования проверок в `existenceValidator` вместо локальных дублирующихся методов.
- Скорректированы wiring-конфигурации `CreateInstrumentSourcePlanServiceWiringConfig` и `ReplaceInstrumentSourcePlanServiceWiringConfig` для создания и передачи `InstrumentSourcePlanExistenceValidator` с зависимостями `InstrumentCodeExistencePort` и `ProviderCodeExistencePort`.
- Удалены приватные методы `ensureInstrumentExists` и `ensureProvidersExist` из сервисов, так как логика теперь централизована.

### Testing
- Попытка скомпилировать модуль бекенда командой `./mvnw -pl backend -DskipTests compile` была выполнена, но не завершилась успешно из-за невозможности скачать дистрибутив Maven в этом окружении (`wget: Failed to fetch ...`).
- Автоматические юнит- или интеграционные тесты не запускались из-за ошибки с окружением; кодовые изменения проверены статическим просмотром и сборкой зависимостей в конфигурациях.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf8480490832dbb670c768ecf6f89)