### PR TITLE
Выделить delete use case в отдельный command service

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/CurrencyCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/CurrencyCatalogServiceImpl.java
@@ -1,11 +1,10 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.application;
 
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.exception.CurrencyNotFoundException;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyInUseException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.delete.DeleteCurrencyService;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.CurrencyUsageCheckPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,7 +22,7 @@ import java.util.Objects;
 public class CurrencyCatalogServiceImpl implements CurrencyCatalogService {
 
     private final CurrencyRepository currencyRepository;
-    private final CurrencyUsageCheckPort currencyUsageCheckPort;
+    private final DeleteCurrencyService deleteCurrencyService;
 
     @Override
     @Transactional
@@ -59,16 +58,8 @@ public class CurrencyCatalogServiceImpl implements CurrencyCatalogService {
     @Override
     @Transactional
     public void delete(CurrencyCode code) {
-        Objects.requireNonNull(code, "code must not be null");
-
-        // Бизнес‑правило: валюта не должна использоваться внешними фичами/агрегатами
-        if (currencyUsageCheckPort.isUsed(code)) {
-            throw new CurrencyInUseException(code);
-        }
-
-        // Случай отсутствия инструмента и прочие сбои БД определит адаптер репозитория
-        currencyRepository.deleteByCode(code);
-        log.info("Currency {} deleted", code.value());
+        // Делегируем delete use case в выделенный command service.
+        deleteCurrencyService.delete(code);
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/delete/DeleteCurrencyService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/delete/DeleteCurrencyService.java
@@ -1,0 +1,38 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.delete;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyInUseException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.port.CurrencyUsageCheckPort;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+
+/* Use case сервис удаления валюты из каталога. */
+@Slf4j
+public final class DeleteCurrencyService {
+
+    private final CurrencyRepository currencyRepository;
+    private final CurrencyUsageCheckPort currencyUsageCheckPort;
+
+    public DeleteCurrencyService(
+            CurrencyRepository currencyRepository,
+            CurrencyUsageCheckPort currencyUsageCheckPort
+    ) {
+        this.currencyRepository = Objects.requireNonNull(currencyRepository, "currencyRepository must not be null");
+        this.currencyUsageCheckPort = Objects.requireNonNull(currencyUsageCheckPort, "currencyUsageCheckPort must not be null");
+    }
+
+    public void delete(CurrencyCode code) {
+        Objects.requireNonNull(code, "code must not be null");
+
+        // Бизнес‑правило: удаление запрещено, пока валюта используется в других фичах.
+        if (currencyUsageCheckPort.isUsed(code)) {
+            throw new CurrencyInUseException(code);
+        }
+
+        // Удаляем валюту через repository, детали ошибок делегированы адаптеру.
+        currencyRepository.deleteByCode(code);
+        log.info("Currency {} deleted", code.value());
+    }
+}


### PR DESCRIPTION
### Motivation
- Разделить логику удаления валюты на отдельный use case сервис для улучшения ответственности и читаемости кода.

### Description
- Добавлен `final` класс `DeleteCurrencyService` в пакет `application.command.delete` без Spring-стереотипов, с аннотацией `@Slf4j` и краткими комментариями на русском.
- В `DeleteCurrencyService` реализован метод `public void delete(CurrencyCode code)` с `Objects.requireNonNull(code, "code must not be null")`, проверкой `currencyUsageCheckPort.isUsed(code)` и выбросом `CurrencyInUseException`, вызовом `currencyRepository.deleteByCode(code)` и логом `Currency {} deleted`.
- В `CurrencyCatalogServiceImpl` удалено поле `CurrencyUsageCheckPort`, добавлено поле `DeleteCurrencyService` и метод `delete(CurrencyCode code)` заменён на делегирование в `deleteCurrencyService.delete(code)`, при этом логика `create/update/findAll` не изменилась.
- Не менялись интерфейс `CurrencyCatalogService`, контроллеры и wiring/конфигурация.

### Testing
- Выполнен запуск сборки `./mvnw -pl backend -DskipTests compile`, который не завершился успешно из-за ошибки скачивания Maven дистрибутива в окружении (wget failed), поэтому сборка/компиляция не были подтверждены; автоматических тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc06658bcc832db1e8d50def53585d)