### PR TITLE
Вынести DELETE /api/v1/currencies/{code} в отдельный контроллер

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java
@@ -6,7 +6,6 @@ import com.alligator.market.backend.instrument.asset.forex.reference.currency.ap
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.common.CurrencyDto;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.in.CurrencyUpdateDto;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.mapper.CurrencyDtoMapper;
-import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -48,16 +47,6 @@ public class CurrencyController {
     public ResponseEntity<Void> update(@PathVariable String code, @RequestBody CurrencyUpdateDto dto) {
 
         service.update(CurrencyDtoMapper.toDomainUpdate(code, dto));
-        return ResponseEntityFactory.noContent();
-    }
-
-    /**
-     * Удалить валюту.
-     */
-    @DeleteMapping("/{code}")
-    public ResponseEntity<Void> delete(@PathVariable String code) {
-
-        service.delete(CurrencyCode.of(code));
         return ResponseEntityFactory.noContent();
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/delete/controller/DeleteCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/delete/controller/DeleteCurrencyController.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.delete.controller;
+
+import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.delete.DeleteCurrencyService;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/* REST-контроллер delete use case для валют. */
+@RestController
+@RequestMapping("/api/v1/currencies")
+@RequiredArgsConstructor
+public class DeleteCurrencyController {
+
+    private final DeleteCurrencyService deleteCurrencyService;
+
+    /* Удалить валюту по коду. */
+    @DeleteMapping("/{code}")
+    public ResponseEntity<Void> delete(@PathVariable String code) {
+
+        // Делегируем удаление в application-service.
+        deleteCurrencyService.delete(CurrencyCode.of(code));
+        return ResponseEntityFactory.noContent();
+    }
+}


### PR DESCRIPTION
### Motivation
- Разделить командный сценарий удаления валюты в отдельный API-контроллер, чтобы следовать разделению ответственности и избежать смешения команд и запросов, при этом оставить существующий URL- и response‑контракт без изменений.

### Description
- Добавлен `DeleteCurrencyController` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.delete.controller` с аннотациями `@RestController`, `@RequestMapping("/api/v1/currencies")`, `@RequiredArgsConstructor`, методом `delete(@PathVariable String code)` который вызывает `deleteCurrencyService.delete(CurrencyCode.of(code))` и возвращает `ResponseEntityFactory.noContent()`; удалён `delete`-метод из `CurrencyController` и убран неиспользуемый импорт `CurrencyCode`.

### Testing
- Выполнен запуск сборки `./mvnw -pl backend -DskipTests compile`, который не завершился успешно из‑за проблем окружения при загрузке Maven дистрибутива (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc08acff28832d8c9d175a14567cba)