### PR TITLE
Вынес create use case валюты в отдельный command service

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/CurrencyCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/CurrencyCatalogServiceImpl.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.application;
 
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.exception.CurrencyNotFoundException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create.CreateCurrencyService;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.delete.DeleteCurrencyService;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
@@ -22,17 +23,14 @@ import java.util.Objects;
 public class CurrencyCatalogServiceImpl implements CurrencyCatalogService {
 
     private final CurrencyRepository currencyRepository;
+    private final CreateCurrencyService createCurrencyService;
     private final DeleteCurrencyService deleteCurrencyService;
 
     @Override
     @Transactional
     public Currency create(Currency currency) {
-        Objects.requireNonNull(currency, "currency must not be null");
-
-        // Без пред‑проверок на уникальность (устраняем TOCTOU) – уникальность проверяет адаптер репозитория
-        Currency created = currencyRepository.create(currency);
-        log.info("Currency {} created", created.code().value());
-        return created;
+        // Делегируем create use case в выделенный command service.
+        return createCurrencyService.create(currency);
     }
 
     @Override

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/create/CreateCurrencyService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/create/CreateCurrencyService.java
@@ -1,0 +1,31 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create;
+
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+
+/**
+ * Command service для сценария создания валюты.
+ */
+@Slf4j
+public final class CreateCurrencyService {
+
+    private final CurrencyRepository currencyRepository;
+
+    public CreateCurrencyService(CurrencyRepository currencyRepository) {
+        // Проверяем обязательную зависимость.
+        this.currencyRepository = Objects.requireNonNull(currencyRepository, "currencyRepository must not be null");
+    }
+
+    public Currency create(Currency currency) {
+        // Проверяем входные данные.
+        Objects.requireNonNull(currency, "currency must not be null");
+
+        // Делегируем создание в репозиторий.
+        Currency created = currencyRepository.create(currency);
+        log.info("Currency {} created", created.code().value());
+        return created;
+    }
+}


### PR DESCRIPTION
### Motivation

- Упростить `CurrencyCatalogServiceImpl` и выделить сценарий создания валюты в отдельный command service для лучшей разделённости ответственности и тестируемости.

### Description

- Добавлен `final` класс `CreateCurrencyService` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create` без Spring-аннотаций и с аннотацией `@Slf4j`, реализующий метод `public Currency create(Currency currency)` с `Objects.requireNonNull` и вызовом `currencyRepository.create(...)` и логированием.`
- Внедрена зависимость `private final CreateCurrencyService createCurrencyService;` в `CurrencyCatalogServiceImpl` и метод `create(Currency currency)` заменён на делегирование `return createCurrencyService.create(currency);`.
- Интерфейсы, контроллеры, иflows `update`/`findAll` не изменялись согласно требованиям.
- Новый файл: `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/create/CreateCurrencyService.java`, модифицирован: `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/CurrencyCatalogServiceImpl.java`.

### Testing

- Попытка запустить сборку `./mvnw -pl backend -DskipTests compile` завершилась ошибкой в среде из-за проблем с загрузкой дистрибутива Maven (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0b1d7f40832d8e4a340c546bd70d)