### PR TITLE
Выделен CreateCurrencyController для операции создания валюты

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java
@@ -6,13 +6,10 @@ import com.alligator.market.backend.instrument.asset.forex.reference.currency.ap
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.common.CurrencyDto;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.in.CurrencyUpdateDto;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.mapper.CurrencyDtoMapper;
-import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.net.URI;
 import java.util.List;
 
 /**
@@ -24,21 +21,6 @@ import java.util.List;
 public class CurrencyController {
 
     private final CurrencyCatalogService service;
-
-    /**
-     * Создать валюту.
-     */
-    @PostMapping
-    public ResponseEntity<ApiResponse<String>> create(@RequestBody CurrencyDto dto) {
-
-        Currency created = service.create(CurrencyDtoMapper.toDomain(dto));
-        URI location = ServletUriComponentsBuilder
-                .fromCurrentRequest()
-                .path("/{code}")
-                .buildAndExpand(created.code().value())
-                .toUri();
-        return ResponseEntityFactory.created(location, created.code().value());
-    }
 
     /**
      * Обновить валюту.

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
@@ -1,0 +1,44 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.controller;
+
+import com.alligator.market.backend.common.web.response.ApiResponse;
+import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.common.CurrencyDto;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.mapper.CurrencyDtoMapper;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create.CreateCurrencyService;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+/**
+ * REST-контроллер для create use case валюты.
+ */
+@RestController
+@RequestMapping("/api/v1/currencies")
+@RequiredArgsConstructor
+public class CreateCurrencyController {
+
+    private final CreateCurrencyService createCurrencyService;
+
+    /**
+     * Создать валюту.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> create(@RequestBody CurrencyDto dto) {
+
+        Currency created = createCurrencyService.create(CurrencyDtoMapper.toDomain(dto));
+        // Формируем location для созданного ресурса по его коду.
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{code}")
+                .buildAndExpand(created.code().value())
+                .toUri();
+        return ResponseEntityFactory.created(location, created.code().value());
+    }
+}


### PR DESCRIPTION
### Motivation
- Разделить API по use-case: вынести операцию создания валюты в отдельный контроллер, сохранив прежний контракт и не трогая слой application.

### Description
- Добавлен `CreateCurrencyController` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.controller` с аннотациями `@RestController`, `@RequestMapping("/api/v1/currencies")` и `@RequiredArgsConstructor` и внедрением `CreateCurrencyService`.
- Реализован метод `@PostMapping public ResponseEntity<ApiResponse<String>> create(@RequestBody CurrencyDto dto)` который вызывает `createCurrencyService.create(CurrencyDtoMapper.toDomain(dto))`, формирует `Location` через `ServletUriComponentsBuilder.fromCurrentRequest().path("/{code}")` и возвращает `ResponseEntityFactory.created(location, created.code().value())`.
- Из `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java` удалён метод создания и связанные неиспользуемые импорты; оставлены только методы `update` и `getAll` без изменения их URL- и response-контрактов.
- Добавлены краткие комментарии на русском над классом и внутри метода в соответствии со стилем проекта.

### Testing
- Попытка запустить Gradle сборку через `./gradlew :backend:compile` не выполнилась в окружении из-за отсутствия wrapper; команда не найдена.
- Попытка запустить Maven-wrapper `./mvnw -pl backend -DskipTests compile` завершилась неудачей из-за ошибки скачивания дистрибутива Maven (`Failed to fetch ... apache-maven-3.9.9-bin.zip`).
- Команда `git commit` выполнена локально успешно и зафиксировала изменения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0cf112b0832d9cd7cbfbcdabf933)