### PR TITLE
Выделен отдельный create-controller request DTO для Currency

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
@@ -2,10 +2,10 @@ package com.alligator.market.backend.instrument.asset.forex.reference.currency.a
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.common.CurrencyDto;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.mapper.CurrencyDtoMapper;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.dto.CreateCurrencyRequest;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create.CreateCurrencyService;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,9 +30,17 @@ public class CreateCurrencyController {
      * Создать валюту.
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<String>> create(@RequestBody CurrencyDto dto) {
-        // Делегируем удаление application-service
-        Currency created = createCurrencyService.create(CurrencyDtoMapper.toDomain(dto));
+    public ResponseEntity<ApiResponse<String>> create(@RequestBody CreateCurrencyRequest request) {
+        // Собираем доменную модель из create-request
+        Currency currency = new Currency(
+                CurrencyCode.of(request.code()),
+                request.name(),
+                request.country(),
+                request.fractionDigits()
+        );
+
+        // Делегируем создание валюты application-service
+        Currency created = createCurrencyService.create(currency);
 
         // Формируем location для созданного ресурса по его коду
         URI location = ServletUriComponentsBuilder

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/dto/CreateCurrencyRequest.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/dto/CreateCurrencyRequest.java
@@ -1,0 +1,12 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.dto;
+
+/**
+ * DTO запроса на создание валюты.
+ */
+public record CreateCurrencyRequest(
+        String code,
+        String name,
+        String country,
+        Integer fractionDigits
+) {
+}


### PR DESCRIPTION
### Motivation
- Упростить и изолировать входной контракт для операции создания валюты, разместив DTO рядом с create-контроллером и устранив зависимость create-slice от общего `CurrencyDto`/`CurrencyDtoMapper`.

### Description
- Добавлен новый request DTO `CreateCurrencyRequest` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.dto` как `record` с полями `code`, `name`, `country`, `fractionDigits` и комментарием на русском.
- Обновлён `CreateCurrencyController` в пакете `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.controller` для приёма `CreateCurrencyRequest`, сборки доменной модели через `new Currency(CurrencyCode.of(request.code()), ...)` и делегирования в `CreateCurrencyService`.
- Формирование `location` выполняется через `ServletUriComponentsBuilder.fromCurrentRequest().path("/{code}")`, ответ формируется через `ResponseEntityFactory.created(location, created.code().value())`.
- Для create-slice больше не используются `CurrencyDto` и `CurrencyDtoMapper`, при этом `CurrencyController` и существующие DTO/обновления/листинг не тронуты.

### Testing
- Попытка компиляции модуля `backend` через `./mvnw -pl backend -DskipTests compile` была выполнена автоматически, но завершилась неуспехом из-за недоступности загрузки Maven дистрибутива (`Failed to fetch apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc11b90b20832d8ebc841207cce607)