### PR TITLE
Вынес общий DTO MarketDataSourceRequest и обновил request DTO для create/replace

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/common/dto/MarketDataSourceRequest.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/common/dto/MarketDataSourceRequest.java
@@ -1,0 +1,25 @@
+package com.alligator.market.backend.sourcing.plan.api.command.common.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+/**
+ * DTO одного источника рыночных данных в составе плана источников инструмента.
+ */
+public record MarketDataSourceRequest(
+
+        /* Код провайдера рыночных данных. */
+        @NotBlank(message = "providerCode must not be blank")
+        String providerCode,
+
+        /* Признак того, что источник включён в план. */
+        @NotNull(message = "active must not be null")
+        Boolean active,
+
+        /* Приоритет источника: меньшее значение означает более высокий приоритет. */
+        @NotNull(message = "priority must not be null")
+        @PositiveOrZero(message = "priority must be greater than or equal to 0")
+        Integer priority
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/controller/CreateInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/controller/CreateInstrumentSourcePlanController.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.sourcing.plan.api.command.create.controller;
 
+import com.alligator.market.backend.sourcing.plan.api.command.common.dto.MarketDataSourceRequest;
 import com.alligator.market.backend.sourcing.plan.api.command.create.dto.CreateInstrumentSourcePlanRequest;
 import com.alligator.market.backend.sourcing.plan.application.command.create.CreateInstrumentSourcePlanService;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
@@ -56,7 +57,7 @@ public class CreateInstrumentSourcePlanController {
 
     /* Маппинг HTTP-модели источника в доменный источник. */
     private MarketDataSource toSource(
-            CreateInstrumentSourcePlanRequest.MarketDataSourceRequest request
+            MarketDataSourceRequest request
     ) {
         return new MarketDataSource(
                 new ProviderCode(request.providerCode()),

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/dto/CreateInstrumentSourcePlanRequest.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/dto/CreateInstrumentSourcePlanRequest.java
@@ -1,44 +1,23 @@
 package com.alligator.market.backend.sourcing.plan.api.command.create.dto;
 
+import com.alligator.market.backend.sourcing.plan.api.command.common.dto.MarketDataSourceRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 
 import java.util.List;
 
 /**
- * HTTP-запрос на создание плана источников инструмента.
+ * DTO тела HTTP-запроса на создание плана источников для инструмента.
  */
 public record CreateInstrumentSourcePlanRequest(
 
-        /* Код инструмента, для которого создаётся план. */
+        /* Код инструмента, для которого создаётся новый план источников. */
         @NotBlank(message = "instrumentCode must not be blank")
         String instrumentCode,
 
-        /* Источники рыночных данных для инструмента. */
+        /* Список источников, формирующих создаваемый план. */
         @NotEmpty(message = "sources must not be empty")
         List<@Valid MarketDataSourceRequest> sources
 ) {
-
-    /**
-     * HTTP-модель одного источника в составе плана.
-     */
-    public record MarketDataSourceRequest(
-
-            /* Код провайдера-источника. */
-            @NotBlank(message = "providerCode must not be blank")
-            String providerCode,
-
-            /* Признак активности источника. */
-            @NotNull(message = "active must not be null")
-            Boolean active,
-
-            /* Приоритет источника. */
-            @NotNull(message = "priority must not be null")
-            @PositiveOrZero(message = "priority must be greater than or equal to 0")
-            Integer priority
-    ) {
-    }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/controller/ReplaceInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/controller/ReplaceInstrumentSourcePlanController.java
@@ -1,5 +1,6 @@
 package com.alligator.market.backend.sourcing.plan.api.command.replace.controller;
 
+import com.alligator.market.backend.sourcing.plan.api.command.common.dto.MarketDataSourceRequest;
 import com.alligator.market.backend.sourcing.plan.api.command.replace.dto.ReplaceInstrumentSourcePlanRequest;
 import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
@@ -60,7 +61,7 @@ public class ReplaceInstrumentSourcePlanController {
 
     /* Маппинг HTTP-модели источника в доменный источник. */
     private MarketDataSource toSource(
-            ReplaceInstrumentSourcePlanRequest.MarketDataSourceRequest request
+            MarketDataSourceRequest request
     ) {
         return new MarketDataSource(
                 new ProviderCode(request.providerCode()),

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/dto/ReplaceInstrumentSourcePlanRequest.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/dto/ReplaceInstrumentSourcePlanRequest.java
@@ -1,40 +1,18 @@
 package com.alligator.market.backend.sourcing.plan.api.command.replace.dto;
 
+import com.alligator.market.backend.sourcing.plan.api.command.common.dto.MarketDataSourceRequest;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 
 import java.util.List;
 
 /**
- * HTTP-запрос на полную замену плана источников инструмента.
+ * DTO тела HTTP-запроса на полную замену состава источников в плане инструмента.
  */
 public record ReplaceInstrumentSourcePlanRequest(
 
-        /* Источники рыночных данных для инструмента. */
+        /* Новый полный состав источников, который должен заменить текущий план. */
         @NotEmpty(message = "sources must not be empty")
         List<@Valid MarketDataSourceRequest> sources
 ) {
-
-    /**
-     * HTTP-модель одного источника в составе плана.
-     */
-    public record MarketDataSourceRequest(
-
-            /* Код провайдера-источника. */
-            @NotBlank(message = "providerCode must not be blank")
-            String providerCode,
-
-            /* Признак активности источника. */
-            @NotNull(message = "active must not be null")
-            Boolean active,
-
-            /* Приоритет источника. */
-            @NotNull(message = "priority must not be null")
-            @PositiveOrZero(message = "priority must be greater than or equal to 0")
-            Integer priority
-    ) {
-    }
 }


### PR DESCRIPTION
### Motivation
- Убрать дублирование вложенной модели `MarketDataSourceRequest` в запросах создания и полной замены плана источников.
- Сделать повторяемый элемент `sources` явным общим API-DTO, чтобы согласовать HTTP-контракт и упростить повторное использование.
- Упростить маппинг в контроллерах и привести формулировки JavaDoc к семантике тела HTTP-запроса для операций create/replace.

### Description
- Добавлен `backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/common/dto/MarketDataSourceRequest.java` как общий DTO для элементов `sources`.
- Обновлены `CreateInstrumentSourcePlanRequest` и `ReplaceInstrumentSourcePlanRequest` для использования общего `MarketDataSourceRequest` и уточнены комментарии/JavaDoc в них.
- Обновлены `CreateInstrumentSourcePlanController` и `ReplaceInstrumentSourcePlanController` для импорта и использования нового DTO в методе `toSource` без изменения доменной логики преобразования в `MarketDataSource`.
- Удалены дублирующие вложенные записи `MarketDataSourceRequest` из старых request-файлов и приведена структура пакетов к `api/command/common/dto` для общего элемента.

### Testing
- Попытка сборки через `./mvnw -pl backend -DskipTests compile` завершилась неудачей из‑за ошибки при скачивании (Maven wrapper не смог загрузить дистрибутив, 403).
- Попытка сборки через `mvn -pl backend -DskipTests compile` также завершилась неудачей из‑за невозможности резолва зависимостей из Maven Central (403), поэтому автоматические тесты не запускались.
- Код статически проверялся визуальным ревью и изменение не должно влиять на доменную логику маппинга в контроллерах.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1618f228832d9166f0c011a5f13c)