### PR TITLE
Рефакторинг маппинга создания плана источников инструмента

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/controller/CreateInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/controller/CreateInstrumentSourcePlanController.java
@@ -1,18 +1,13 @@
 package com.alligator.market.backend.sourcing.plan.api.command.create.controller;
 
-import com.alligator.market.backend.sourcing.plan.api.common.dto.MarketDataSourceRequest;
 import com.alligator.market.backend.sourcing.plan.api.command.create.dto.CreateInstrumentSourcePlanRequest;
+import com.alligator.market.backend.sourcing.plan.api.command.create.mapper.CreateInstrumentSourcePlanMapper;
 import com.alligator.market.backend.sourcing.plan.application.command.create.CreateInstrumentSourcePlanService;
-import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
-import com.alligator.market.domain.provider.model.vo.ProviderCode;
-import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -44,30 +39,7 @@ public class CreateInstrumentSourcePlanController {
      */
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody CreateInstrumentSourcePlanRequest request) {
-        createInstrumentSourcePlanService.create(toPlan(request));
+        createInstrumentSourcePlanService.create(createInstrumentSourcePlanMapper.toDomain(request));
         return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
-
-    /* Маппинг HTTP-запроса в доменный план. */
-    private InstrumentSourcePlan toPlan(CreateInstrumentSourcePlanRequest request) {
-        List<MarketDataSource> sources = request.sources().stream()
-                .map(this::toSource)
-                .toList();
-
-        return new InstrumentSourcePlan(
-                new InstrumentCode(request.instrumentCode()),
-                sources
-        );
-    }
-
-    /* Маппинг HTTP-модели источника в доменный источник. */
-    private MarketDataSource toSource(
-            MarketDataSourceRequest request
-    ) {
-        return new MarketDataSource(
-                new ProviderCode(request.providerCode()),
-                request.active(),
-                request.priority()
-        );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/mapper/CreateInstrumentSourcePlanMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/mapper/CreateInstrumentSourcePlanMapper.java
@@ -1,25 +1,38 @@
 package com.alligator.market.backend.sourcing.plan.api.command.create.mapper;
 
 import com.alligator.market.backend.sourcing.plan.api.command.create.dto.CreateInstrumentSourcePlanRequest;
-import com.alligator.market.backend.sourcing.plan.api.common.dto.MarketDataSourceRequest;
+import com.alligator.market.backend.sourcing.plan.api.common.mapper.MarketDataSourceRequestMapper;
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
-import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Маппер создания плана источников инструмента.
  */
+@Component
 public class CreateInstrumentSourcePlanMapper {
+
+    private final MarketDataSourceRequestMapper marketDataSourceRequestMapper;
+
+    public CreateInstrumentSourcePlanMapper(
+            MarketDataSourceRequestMapper marketDataSourceRequestMapper
+    ) {
+        this.marketDataSourceRequestMapper = Objects.requireNonNull(
+                marketDataSourceRequestMapper,
+                "marketDataSourceRequestMapper must not be null"
+        );
+    }
 
     /**
      * Преобразует тело HTTP-запроса в доменную модель плана.
      */
-    public InstrumentSourcePlan toPlan(CreateInstrumentSourcePlanRequest request) {
+    public InstrumentSourcePlan toDomain(CreateInstrumentSourcePlanRequest request) {
         List<MarketDataSource> sources = request.sources().stream()
-                .map(this::toSource)
+                .map(marketDataSourceRequestMapper::toDomain)
                 .toList();
 
         return new InstrumentSourcePlan(


### PR DESCRIPTION
### Motivation
- Устранить дублирование маппинга источников и стандартизировать преобразование входной HTTP-модели в доменную, переиспользовав уже существующий `MarketDataSourceRequestMapper`.

### Description
- `CreateInstrumentSourcePlanMapper` сделан Spring-бином (`@Component`) и теперь получает `MarketDataSourceRequestMapper` через конструктор с `Objects.requireNonNull` проверкой зависимости.
- Метод маппера переименован в `toDomain` и делегирует преобразование элементов `sources` вызову `marketDataSourceRequestMapper::toDomain` вместо локального ручного маппинга.
- `CreateInstrumentSourcePlanController` упрощён: он теперь использует `CreateInstrumentSourcePlanMapper.toDomain(request)` и удалены внутренние методы маппинга тела запроса и источников.
- Обновлены соответствующие импорты и удалён неиспользуемый код в контроллере для повышения читаемости и централизации логики маппинга.

### Testing
- Запущена команда `./mvnw -pl backend test -Dtest=InstrumentSourcePlanCommandControllersTest`, но в текущем окружении тест не выполнился из-за ошибки скачивания дистрибутива Maven (`Failed to fetch ... repo.maven.apache.org`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd47c90fd0832d84711ba84797da88)