### PR TITLE
Выделен `ReplaceInstrumentSourcePlanMapper` для маппинга `toPlan`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/controller/ReplaceInstrumentSourcePlanController.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/controller/ReplaceInstrumentSourcePlanController.java
@@ -1,17 +1,12 @@
 package com.alligator.market.backend.sourcing.plan.api.command.replace.controller;
 
-import com.alligator.market.backend.sourcing.plan.api.common.dto.MarketDataSourceRequest;
 import com.alligator.market.backend.sourcing.plan.api.command.replace.dto.ReplaceInstrumentSourcePlanRequest;
+import com.alligator.market.backend.sourcing.plan.api.command.replace.mapper.ReplaceInstrumentSourcePlanMapper;
 import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;
-import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
-import com.alligator.market.domain.provider.model.vo.ProviderCode;
-import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -22,13 +17,19 @@ import java.util.Objects;
 public class ReplaceInstrumentSourcePlanController {
 
     private final ReplaceInstrumentSourcePlanService replaceInstrumentSourcePlanService;
+    private final ReplaceInstrumentSourcePlanMapper replaceInstrumentSourcePlanMapper;
 
     public ReplaceInstrumentSourcePlanController(
-            ReplaceInstrumentSourcePlanService replaceInstrumentSourcePlanService
+            ReplaceInstrumentSourcePlanService replaceInstrumentSourcePlanService,
+            ReplaceInstrumentSourcePlanMapper replaceInstrumentSourcePlanMapper
     ) {
         this.replaceInstrumentSourcePlanService = Objects.requireNonNull(
                 replaceInstrumentSourcePlanService,
                 "replaceInstrumentSourcePlanService must not be null"
+        );
+        this.replaceInstrumentSourcePlanMapper = Objects.requireNonNull(
+                replaceInstrumentSourcePlanMapper,
+                "replaceInstrumentSourcePlanMapper must not be null"
         );
     }
 
@@ -40,32 +41,7 @@ public class ReplaceInstrumentSourcePlanController {
             @PathVariable String instrumentCode,
             @Valid @RequestBody ReplaceInstrumentSourcePlanRequest request
     ) {
-        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-
-        replaceInstrumentSourcePlanService.replace(toPlan(instrumentCode, request));
+        replaceInstrumentSourcePlanService.replace(replaceInstrumentSourcePlanMapper.toPlan(instrumentCode, request));
         return ResponseEntity.noContent().build();
-    }
-
-    /* Маппинг HTTP-запроса в доменный план. */
-    private InstrumentSourcePlan toPlan(String instrumentCode, ReplaceInstrumentSourcePlanRequest request) {
-        List<MarketDataSource> sources = request.sources().stream()
-                .map(this::toSource)
-                .toList();
-
-        return new InstrumentSourcePlan(
-                new InstrumentCode(instrumentCode),
-                sources
-        );
-    }
-
-    /* Маппинг HTTP-модели источника в доменный источник. */
-    private MarketDataSource toSource(
-            MarketDataSourceRequest request
-    ) {
-        return new MarketDataSource(
-                new ProviderCode(request.providerCode()),
-                request.active(),
-                request.priority()
-        );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/mapper/ReplaceInstrumentSourcePlanMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/mapper/ReplaceInstrumentSourcePlanMapper.java
@@ -1,0 +1,45 @@
+package com.alligator.market.backend.sourcing.plan.api.command.replace.mapper;
+
+import com.alligator.market.backend.sourcing.plan.api.command.replace.dto.ReplaceInstrumentSourcePlanRequest;
+import com.alligator.market.backend.sourcing.plan.api.common.mapper.MarketDataSourceRequestMapper;
+import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Маппер для {@link ReplaceInstrumentSourcePlanRequest}.
+ */
+@Component
+public class ReplaceInstrumentSourcePlanMapper {
+
+    private final MarketDataSourceRequestMapper marketDataSourceRequestMapper;
+
+    public ReplaceInstrumentSourcePlanMapper(
+            MarketDataSourceRequestMapper marketDataSourceRequestMapper
+    ) {
+        this.marketDataSourceRequestMapper = Objects.requireNonNull(
+                marketDataSourceRequestMapper,
+                "marketDataSourceRequestMapper must not be null"
+        );
+    }
+
+    /**
+     * Преобразует запрос замены плана в доменную модель {@link InstrumentSourcePlan}.
+     */
+    public InstrumentSourcePlan toPlan(String instrumentCode, ReplaceInstrumentSourcePlanRequest request) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        List<MarketDataSource> sources = request.sources().stream()
+                .map(marketDataSourceRequestMapper::toDomain)
+                .toList();
+
+        return new InstrumentSourcePlan(
+                new InstrumentCode(instrumentCode),
+                sources
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Вынести логику маппинга `toPlan` из контроллера, чтобы контроллер отвечал только за адаптацию HTTP и делегирование.
- Переиспользовать общий `MarketDataSourceRequestMapper` для преобразования `MarketDataSourceRequest` в доменную модель.
- Повысить читабельность и тестируемость за счёт разделения ответственности между контроллером и маппером.

### Description
- Добавлен компонент `ReplaceInstrumentSourcePlanMapper` в `backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/mapper/ReplaceInstrumentSourcePlanMapper.java`.
- Метод `ReplaceInstrumentSourcePlanMapper#toPlan` преобразует `ReplaceInstrumentSourcePlanRequest` в `InstrumentSourcePlan`, используя `MarketDataSourceRequestMapper::toDomain`.
- Упрощён `ReplaceInstrumentSourcePlanController`: удалены приватные методы маппинга и добавлена зависимость на `ReplaceInstrumentSourcePlanMapper` для делегирования преобразования.
- Изменения коснулись файлов `ReplaceInstrumentSourcePlanController.java` и нового `ReplaceInstrumentSourcePlanMapper.java`.

### Testing
- Запущена компиляция `mvn -pl backend -DskipTests compile`, которая завершилась с ошибкой из-за недоступности родительского POM в Maven Central (HTTP 403), поэтому локальная компиляция неуспешна.
- Других автоматических тестов в текущем окружении не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4d696c58832db38e2f5ac5750529)