### PR TITLE
Вынес `MarketDataSourceResponseMapper` из `InstrumentSourcePlanResponseMapper`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/InstrumentSourcePlanResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/InstrumentSourcePlanResponseMapper.java
@@ -1,7 +1,6 @@
 package com.alligator.market.backend.sourcing.plan.api.query.common;
 
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -12,23 +11,20 @@ import java.util.List;
 @Component
 public class InstrumentSourcePlanResponseMapper {
 
+    private final MarketDataSourceResponseMapper marketDataSourceResponseMapper;
+
+    public InstrumentSourcePlanResponseMapper(MarketDataSourceResponseMapper marketDataSourceResponseMapper) {
+        this.marketDataSourceResponseMapper = marketDataSourceResponseMapper;
+    }
+
     /**
      * Конвертирует доменный {@link InstrumentSourcePlan} в DTO ответа {@link InstrumentSourcePlanResponse}.
      */
     public InstrumentSourcePlanResponse toPlanResponse(InstrumentSourcePlan plan) {
         List<MarketDataSourceResponse> sources = plan.sources().stream()
-                .map(this::toSourceResponse)
+                .map(marketDataSourceResponseMapper::toSourceResponse)
                 .toList();
 
         return new InstrumentSourcePlanResponse(plan.instrumentCode().value(), sources);
-    }
-
-    /* Конвертация доменного источника в DTO источника. */
-    private MarketDataSourceResponse toSourceResponse(MarketDataSource source) {
-        return new MarketDataSourceResponse(
-                source.providerCode().value(),
-                source.active(),
-                source.priority()
-        );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/MarketDataSourceResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/MarketDataSourceResponseMapper.java
@@ -1,0 +1,22 @@
+package com.alligator.market.backend.sourcing.plan.api.query.common;
+
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Маппер доменной модели {@link MarketDataSource} в DTO read-side ответов.
+ */
+@Component
+public class MarketDataSourceResponseMapper {
+
+    /**
+     * Конвертирует доменный {@link MarketDataSource} в DTO ответа {@link MarketDataSourceResponse}.
+     */
+    public MarketDataSourceResponse toSourceResponse(MarketDataSource source) {
+        return new MarketDataSourceResponse(
+                source.providerCode().value(),
+                source.active(),
+                source.priority()
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Разделить ответственность: вынести преобразование `MarketDataSource -> MarketDataSourceResponse` в отдельный компонент для упрощения, повторного использования и тестирования.

### Description
- Добавлен новый Spring-компонент `MarketDataSourceResponseMapper` с публичным методом `toSourceResponse(MarketDataSource)` для маппинга источника в DTO.
- Обновлён `InstrumentSourcePlanResponseMapper`: удалён приватный `toSourceResponse`, добавлена зависимость `MarketDataSourceResponseMapper` через конструктор и делегирование маппинга источников через `marketDataSourceResponseMapper::toSourceResponse`.

### Testing
- Выполнена попытка сборки `./mvnw -pl backend -DskipTests compile`, которая не прошла из-за ошибки окружения: Maven wrapper не смог скачать дистрибутив с `repo.maven.apache.org` (сборка не выполнена).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd54c90fd0832dbf9a1dd524ccb905)