### PR TITLE
Добавить HTTP-валидацию для CreateCurrencyRequest

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
@@ -6,6 +6,7 @@ import com.alligator.market.backend.instrument.asset.forex.reference.currency.ap
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create.CreateCurrencyService;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +31,7 @@ public class CreateCurrencyController {
      * Создать валюту.
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<String>> create(@RequestBody CreateCurrencyRequest request) {
+    public ResponseEntity<ApiResponse<String>> create(@Valid @RequestBody CreateCurrencyRequest request) {
         // Собираем доменную модель из create-request
         Currency currency = new Currency(
                 CurrencyCode.of(request.code()),

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/dto/CreateCurrencyRequest.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/dto/CreateCurrencyRequest.java
@@ -1,12 +1,26 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 /**
  * DTO запроса на создание валюты.
  */
 public record CreateCurrencyRequest(
+        @NotBlank(message = "code must not be blank")
         String code,
+
+        @NotBlank(message = "name must not be blank")
         String name,
+
+        @NotBlank(message = "country must not be blank")
         String country,
+
+        @NotNull(message = "fractionDigits must not be null")
+        @Min(value = 0, message = "fractionDigits must be greater than or equal to 0")
+        @Max(value = 10, message = "fractionDigits must be less than or equal to 10")
         Integer fractionDigits
 ) {
 }


### PR DESCRIPTION
### Motivation
- Ввести простые HTTP-валидации на уровне DTO для защиты от пустых и некорректных полей при создании валюты без изменения доменной логики.
- Оставить формат/нормализацию `code` в доменном `CurrencyCode` и не добавлять `@Pattern` на уровне DTO согласно требованиям.

### Description
- В файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/dto/CreateCurrencyRequest.java` добавлены импорты `jakarta.validation.constraints.*` и аннотации: `@NotBlank` для полей `code`, `name`, `country` и `@NotNull`, `@Min(0)`, `@Max(10)` для `fractionDigits`.
- В контроллер `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java` добавлен импорт `jakarta.validation.Valid` и параметр метода `create` помечен как `@Valid @RequestBody CreateCurrencyRequest request`.
- URL-контракт и response-контракт не изменялись, бизнес-логика контроллера и доменная модель `Currency`/`CurrencyCode` не затронуты.

### Testing
- Выполнена попытка компиляции с помощью `./mvnw -pl backend -DskipTests compile`, которая завершилась неудачей из-за ошибки загрузки дистрибутива Maven в окружении (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).
- Никакие автоматизированные юнит- или интеграционные тесты в этом окружении не запускались из-за ограничений загрузки зависимостей.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5ccc6278832dae61ce6a3c4a4097)