### PR TITLE
refactor: вынести маппинг CreateCurrencyRequest в локальный CreateCurrencyRequestMapper

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
@@ -3,9 +3,9 @@ package com.alligator.market.backend.instrument.asset.forex.reference.currency.a
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.dto.CreateCurrencyRequest;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.mapper.CreateCurrencyRequestMapper;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create.CreateCurrencyService;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
-import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,15 +32,9 @@ public class CreateCurrencyController {
      */
     @PostMapping
     public ResponseEntity<ApiResponse<String>> create(@Valid @RequestBody CreateCurrencyRequest request) {
-        // Собираем доменную модель из create-request
-        Currency currency = new Currency(
-                CurrencyCode.of(request.code()),
-                request.name(),
-                request.country(),
-                request.fractionDigits()
+        Currency created = createCurrencyService.create(
+                CreateCurrencyRequestMapper.toDomain(request)
         );
-
-        Currency created = createCurrencyService.create(currency);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/mapper/CreateCurrencyRequestMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/mapper/CreateCurrencyRequestMapper.java
@@ -1,0 +1,34 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.mapper;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.dto.CreateCurrencyRequest;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+
+import java.util.Objects;
+
+/**
+ * Локальный маппер create-slice для преобразования transport-request в доменную модель.
+ */
+public final class CreateCurrencyRequestMapper {
+
+    /**
+     * Приватный конструктор (запрещает создание экземпляров).
+     */
+    private CreateCurrencyRequestMapper() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Create-request --> доменная модель валюты.
+     */
+    public static Currency toDomain(CreateCurrencyRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        return new Currency(
+                CurrencyCode.of(request.code()),
+                request.name(),
+                request.country(),
+                request.fractionDigits()
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Убрать inline‑mapping из `CreateCurrencyController`, чтобы контроллер остался transport‑only и mapping был локальным для create‑slice.

### Description
- Добавлен `CreateCurrencyRequestMapper` в `backend/src/main/java/.../command/create/mapper` с методом `toDomain(CreateCurrencyRequest)` для преобразования request в доменную `Currency`, и `CreateCurrencyController` заменён на вызов `CreateCurrencyRequestMapper.toDomain(request)` вместо ручной сборки модели.

### Testing
- Выполнена попытка собрать модуль командой `./mvnw -pl backend -DskipTests compile`, сборка не завершилась из‑за ошибки загрузки Maven дистрибутива с `repo.maven.apache.org` (сборка в окружении не выполнена).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6186c560832d81026a014951fba9)