### PR TITLE
refactor(backend): explicit wiring for sourcing/plan API mappers

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/api/mapper/InstrumentSourcePlanApiMapperWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/api/mapper/InstrumentSourcePlanApiMapperWiringConfig.java
@@ -1,0 +1,53 @@
+package com.alligator.market.backend.sourcing.config.plan.api.mapper;
+
+import com.alligator.market.backend.sourcing.plan.api.command.common.MarketDataSourceRequestMapper;
+import com.alligator.market.backend.sourcing.plan.api.command.create.mapper.CreateInstrumentSourcePlanMapper;
+import com.alligator.market.backend.sourcing.plan.api.command.replace.mapper.ReplaceInstrumentSourcePlanMapper;
+import com.alligator.market.backend.sourcing.plan.api.query.common.mapper.InstrumentSourcePlanResponseMapper;
+import com.alligator.market.backend.sourcing.plan.api.query.common.mapper.MarketDataSourceResponseMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring-конфигурация API mapper-ов фичи sourcing/plan.
+ */
+@Configuration(proxyBeanMethods = false)
+public class InstrumentSourcePlanApiMapperWiringConfig {
+
+    public static final String BEAN_MARKET_DATA_SOURCE_REQUEST_MAPPER = "marketDataSourceRequestMapper";
+    public static final String BEAN_CREATE_INSTRUMENT_SOURCE_PLAN_MAPPER = "createInstrumentSourcePlanMapper";
+    public static final String BEAN_REPLACE_INSTRUMENT_SOURCE_PLAN_MAPPER = "replaceInstrumentSourcePlanMapper";
+    public static final String BEAN_MARKET_DATA_SOURCE_RESPONSE_MAPPER = "marketDataSourceResponseMapper";
+    public static final String BEAN_INSTRUMENT_SOURCE_PLAN_RESPONSE_MAPPER = "instrumentSourcePlanResponseMapper";
+
+    @Bean(BEAN_MARKET_DATA_SOURCE_REQUEST_MAPPER)
+    public MarketDataSourceRequestMapper marketDataSourceRequestMapper() {
+        return new MarketDataSourceRequestMapper();
+    }
+
+    @Bean(BEAN_CREATE_INSTRUMENT_SOURCE_PLAN_MAPPER)
+    public CreateInstrumentSourcePlanMapper createInstrumentSourcePlanMapper(
+            MarketDataSourceRequestMapper marketDataSourceRequestMapper
+    ) {
+        return new CreateInstrumentSourcePlanMapper(marketDataSourceRequestMapper);
+    }
+
+    @Bean(BEAN_REPLACE_INSTRUMENT_SOURCE_PLAN_MAPPER)
+    public ReplaceInstrumentSourcePlanMapper replaceInstrumentSourcePlanMapper(
+            MarketDataSourceRequestMapper marketDataSourceRequestMapper
+    ) {
+        return new ReplaceInstrumentSourcePlanMapper(marketDataSourceRequestMapper);
+    }
+
+    @Bean(BEAN_MARKET_DATA_SOURCE_RESPONSE_MAPPER)
+    public MarketDataSourceResponseMapper marketDataSourceResponseMapper() {
+        return new MarketDataSourceResponseMapper();
+    }
+
+    @Bean(BEAN_INSTRUMENT_SOURCE_PLAN_RESPONSE_MAPPER)
+    public InstrumentSourcePlanResponseMapper instrumentSourcePlanResponseMapper(
+            MarketDataSourceResponseMapper marketDataSourceResponseMapper
+    ) {
+        return new InstrumentSourcePlanResponseMapper(marketDataSourceResponseMapper);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/common/MarketDataSourceRequestMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/common/MarketDataSourceRequestMapper.java
@@ -2,12 +2,10 @@ package com.alligator.market.backend.sourcing.plan.api.command.common;
 
 import com.alligator.market.domain.provider.model.vo.ProviderCode;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
-import org.springframework.stereotype.Component;
 
 /**
  * Маппер для {@link MarketDataSourceRequest}.
  */
-@Component
 public class MarketDataSourceRequestMapper {
 
     /**

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/mapper/CreateInstrumentSourcePlanMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/create/mapper/CreateInstrumentSourcePlanMapper.java
@@ -5,7 +5,6 @@ import com.alligator.market.backend.sourcing.plan.api.command.common.MarketDataS
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Objects;
@@ -13,7 +12,6 @@ import java.util.Objects;
 /**
  * Маппер для {@link CreateInstrumentSourcePlanRequest}.
  */
-@Component
 public class CreateInstrumentSourcePlanMapper {
 
     private final MarketDataSourceRequestMapper marketDataSourceRequestMapper;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/mapper/ReplaceInstrumentSourcePlanMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/command/replace/mapper/ReplaceInstrumentSourcePlanMapper.java
@@ -5,7 +5,6 @@ import com.alligator.market.backend.sourcing.plan.api.command.common.MarketDataS
 import com.alligator.market.domain.instrument.base.model.vo.InstrumentCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Objects;
@@ -13,7 +12,6 @@ import java.util.Objects;
 /**
  * Маппер для {@link ReplaceInstrumentSourcePlanRequest}.
  */
-@Component
 public class ReplaceInstrumentSourcePlanMapper {
 
     private final MarketDataSourceRequestMapper marketDataSourceRequestMapper;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/mapper/InstrumentSourcePlanResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/mapper/InstrumentSourcePlanResponseMapper.java
@@ -3,14 +3,12 @@ package com.alligator.market.backend.sourcing.plan.api.query.common.mapper;
 import com.alligator.market.backend.sourcing.plan.api.query.common.dto.InstrumentSourcePlanResponse;
 import com.alligator.market.backend.sourcing.plan.api.query.common.dto.MarketDataSourceResponse;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 /**
  * Маппер доменной модели {@link InstrumentSourcePlan} в DTO read-side ответов.
  */
-@Component
 public class InstrumentSourcePlanResponseMapper {
 
     private final MarketDataSourceResponseMapper marketDataSourceResponseMapper;

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/mapper/MarketDataSourceResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/query/common/mapper/MarketDataSourceResponseMapper.java
@@ -2,12 +2,10 @@ package com.alligator.market.backend.sourcing.plan.api.query.common.mapper;
 
 import com.alligator.market.backend.sourcing.plan.api.query.common.dto.MarketDataSourceResponse;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
-import org.springframework.stereotype.Component;
 
 /**
  * Маппер доменной модели {@link MarketDataSource} в DTO read-side ответов.
  */
-@Component
 public class MarketDataSourceResponseMapper {
 
     /**

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/command/InstrumentSourcePlanCommandControllersTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/command/InstrumentSourcePlanCommandControllersTest.java
@@ -3,6 +3,7 @@ package com.alligator.market.backend.sourcing.plan.api.command;
 import com.alligator.market.backend.sourcing.plan.api.command.create.controller.CreateInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.delete.controller.DeleteInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.command.replace.controller.ReplaceInstrumentSourcePlanController;
+import com.alligator.market.backend.sourcing.config.plan.api.mapper.InstrumentSourcePlanApiMapperWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.command.create.CreateInstrumentSourcePlanService;
 import com.alligator.market.backend.sourcing.plan.application.command.delete.DeleteInstrumentSourcePlanService;
 import com.alligator.market.backend.sourcing.plan.application.command.replace.ReplaceInstrumentSourcePlanService;
@@ -18,6 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -42,6 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         ReplaceInstrumentSourcePlanController.class,
         DeleteInstrumentSourcePlanController.class
 })
+@Import(InstrumentSourcePlanApiMapperWiringConfig.class)
 class InstrumentSourcePlanCommandControllersTest {
 
     @Autowired

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/query/InstrumentSourcePlanQueryControllersTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/api/query/InstrumentSourcePlanQueryControllersTest.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.sourcing.plan.api.query;
 
-import com.alligator.market.backend.sourcing.plan.api.query.common.mapper.InstrumentSourcePlanResponseMapper;
+import com.alligator.market.backend.sourcing.config.plan.api.mapper.InstrumentSourcePlanApiMapperWiringConfig;
 import com.alligator.market.backend.sourcing.plan.api.query.get.controller.GetInstrumentSourcePlanController;
 import com.alligator.market.backend.sourcing.plan.api.query.list.controller.ListInstrumentSourcePlansController;
 import com.alligator.market.backend.sourcing.plan.api.query.options.controller.InstrumentSourcePlanOptionsQueryController;
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         ListInstrumentSourcePlansController.class,
         InstrumentSourcePlanOptionsQueryController.class
 })
-@Import(InstrumentSourcePlanResponseMapper.class)
+@Import(InstrumentSourcePlanApiMapperWiringConfig.class)
 class InstrumentSourcePlanQueryControllersTest {
 
     @Autowired


### PR DESCRIPTION
### Motivation
- Убрать скрытую регистрацию mapper-ов через `@Component` и привести API mapper-ы фичи `sourcing/plan` к проектной конвенции явной сборки через `config/**`.
- Сохранить обычную семантику конструкторов у mapper-классов и не менять HTTP API / DTO-контракты / бизнес-логику контроллеров.

### Description
- Убраны `@Component` из mapper-классов фичи sourcing/plan и оставлены обычные (instantiable) классы: `MarketDataSourceRequestMapper`, `CreateInstrumentSourcePlanMapper`, `ReplaceInstrumentSourcePlanMapper`, `MarketDataSourceResponseMapper`, `InstrumentSourcePlanResponseMapper`.
- Добавлен единый компактный wiring-config `InstrumentSourcePlanApiMapperWiringConfig` в пакет `sourcing/config/plan/api/mapper` с `@Configuration(proxyBeanMethods = false)`, явными `@Bean(...)` методами и `public static final String BEAN_...` константами для имён бинов.
- В тестах web-layer минимально скорректированы импорты, чтобы контексты контроллеров поднимались без component scanning: `InstrumentSourcePlanQueryControllersTest` и `InstrumentSourcePlanCommandControllersTest` теперь `@Import(InstrumentSourcePlanApiMapperWiringConfig.class)`.
- Mapper-классы остались с публичными конструкторами (если есть зависимости — через конструктор), без перевода в статические утилиты и без переноса логики в `config/**`.
- Изменённые файлы (основное):
  - добавлен: `backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/api/mapper/InstrumentSourcePlanApiMapperWiringConfig.java`
  - изменены: `backend/src/main/java/.../MarketDataSourceRequestMapper.java`, `CreateInstrumentSourcePlanMapper.java`, `ReplaceInstrumentSourcePlanMapper.java`, `MarketDataSourceResponseMapper.java`, `InstrumentSourcePlanResponseMapper.java`
  - изменены тесты: `backend/src/test/java/.../InstrumentSourcePlanQueryControllersTest.java`, `InstrumentSourcePlanCommandControllersTest.java`.

### Testing
- Локальная проверка кода: выполнён поиск/проверка — аннотации `@Component` для перечисленных mapper-классов удалены (проверка `rg` прошла успешно).
- Обновлены web-layer тесты для импорта нового wiring-config; изменения минимальны и направлены только на поднимание Spring MVC контекста в тестах.
- Попытка запустить таргетированные тесты `InstrumentSourcePlanCommandControllersTest` и `InstrumentSourcePlanQueryControllersTest` завершилась ошибкой окружения при резолве зависимостей Maven (загрузка из Maven Central вернула 403), поэтому автоматические тесты в этом рантайме не были успешно выполнены.
- Код закоммичен в репозитории с сообщением: `refactor(backend): wire sourcing plan api mappers via config`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd65de0cec832d8a547145c79a1800)