### PR TITLE
Добавить `UpdateCurrencyService` для обновления валюты

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/update/UpdateCurrencyService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/update/UpdateCurrencyService.java
@@ -1,0 +1,38 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.update;
+
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.exception.CurrencyNotFoundException;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+
+/**
+ * Use-case сервис обновления валюты.
+ */
+@Slf4j
+public final class UpdateCurrencyService {
+
+    private final CurrencyRepository currencyRepository;
+
+    public UpdateCurrencyService(CurrencyRepository currencyRepository) {
+        this.currencyRepository = Objects.requireNonNull(currencyRepository,
+                "currencyRepository must not be null");
+    }
+
+    public void update(Currency currency) {
+        Objects.requireNonNull(currency, "currency must not be null");
+
+        Currency current = currencyRepository.findByCode(currency.code())
+                .orElseThrow(() -> new CurrencyNotFoundException(currency.code()));
+
+        // Если изменений нет -> пропускаем обновление без записи в хранилище.
+        if (current.equals(currency)) {
+            log.debug("Currency {} update skipped: nothing to change", currency.code().value());
+            return;
+        }
+
+        Currency updated = currencyRepository.update(currency);
+        log.info("Currency {} updated", updated.code().value());
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить отдельный use-case сервис для обновления валюты, чтобы выделить логику обновления в свой слайс по аналогии с существующими `CreateCurrencyService` и `DeleteCurrencyService`.

### Description
- Создан файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/command/update/UpdateCurrencyService.java` с финальным классом `UpdateCurrencyService`, аннотацией `@Slf4j`, полем `private final CurrencyRepository currencyRepository` и конструктором с `Objects.requireNonNull`.
- Реализован метод `public void update(Currency currency)` с проверкой `Objects.requireNonNull(currency, ...)`, загрузкой текущей сущности через `currencyRepository.findByCode(...).orElseThrow(new CurrencyNotFoundException(...))`, пропуском обновления при отсутствии изменений (`current.equals(currency)`), вызовом `currencyRepository.update(currency)` и логированием результата.
- Добавлены краткие комментарии на русском в стиле проекта и не затронуты другие файлы.

### Testing
- Автоматические тесты не запускались на этом шаге.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de24dd4500832db35adf87c2e210e7)