### PR TITLE
Добавить UpdateCurrencyRequest DTO с HTTP-валидацией

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/dto/UpdateCurrencyRequest.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/dto/UpdateCurrencyRequest.java
@@ -1,0 +1,23 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * HTTP-запрос на обновление валюты.
+ */
+public record UpdateCurrencyRequest(
+        @NotBlank(message = "name must not be blank")
+        String name,
+
+        @NotBlank(message = "country must not be blank")
+        String country,
+
+        @NotNull(message = "fractionDigits must not be null")
+        @Min(value = 0, message = "fractionDigits must be greater than or equal to 0")
+        @Max(value = 10, message = "fractionDigits must be less than or equal to 10")
+        Integer fractionDigits
+) {
+}


### PR DESCRIPTION
### Motivation
- Создать отдельный request DTO для операции обновления валюты с серверной HTTP-валидацией полей и без поля `code` (код приходит из path variable).

### Description
- Добавлен `record UpdateCurrencyRequest` в `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.dto` с полями `name`, `country`, `fractionDigits` и аннотациями `@NotBlank`, `@NotNull`, `@Min`, `@Max` согласно ТЗ, а также добавлен JavaDoc на русском "HTTP-запрос на обновление валюты.".

### Testing
- Автоматических тестов не запускалось для этого шага.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3ac70e5c832d80f592d0e001cb8e)