### PR TITLE
Добавить локальный маппер UpdateCurrencyRequestMapper

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/mapper/UpdateCurrencyRequestMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/mapper/UpdateCurrencyRequestMapper.java
@@ -1,0 +1,32 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.mapper;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.dto.UpdateCurrencyRequest;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+
+import java.util.Objects;
+
+/**
+ * Локальный маппер преобразования Update request в доменную модель валюты.
+ */
+public final class UpdateCurrencyRequestMapper {
+
+    private UpdateCurrencyRequestMapper() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Преобразование входного request в доменную модель.
+     */
+    public static Currency toDomain(String code, UpdateCurrencyRequest request) {
+        Objects.requireNonNull(code, "code must not be null");
+        Objects.requireNonNull(request, "request must not be null");
+
+        return new Currency(
+                CurrencyCode.of(code),
+                request.name(),
+                request.country(),
+                request.fractionDigits()
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить локальный mapper для преобразования `UpdateCurrencyRequest` в доменную модель `Currency` в слайсе обновления валюты.

### Description
- Добавлен финальный utility-класс `UpdateCurrencyRequestMapper` с приватным конструктором и статическим методом `toDomain(String code, UpdateCurrencyRequest request)`, выполняющим `Objects.requireNonNull` для аргументов и возвращающим `new Currency(CurrencyCode.of(code), request.name(), request.country(), request.fractionDigits())` в файле `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/mapper/UpdateCurrencyRequestMapper.java`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5868e864832d88feea80f67e4bf2)