### PR TITLE
Выделить update-операцию валюты в отдельный контроллер

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java
@@ -3,11 +3,12 @@ package com.alligator.market.backend.instrument.asset.forex.reference.currency.a
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.common.CurrencyDto;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.in.CurrencyUpdateDto;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.mapper.CurrencyDtoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -20,16 +21,6 @@ import java.util.List;
 public class CurrencyController {
 
     private final CurrencyCatalogService service;
-
-    /**
-     * Обновить валюту.
-     */
-    @PutMapping("/{code}")
-    public ResponseEntity<Void> update(@PathVariable String code, @RequestBody CurrencyUpdateDto dto) {
-
-        service.update(CurrencyDtoMapper.toDomainUpdate(code, dto));
-        return ResponseEntityFactory.noContent();
-    }
 
     /**
      * Вернуть все валюты.

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/controller/UpdateCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/controller/UpdateCurrencyController.java
@@ -1,0 +1,34 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.controller;
+
+import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.dto.UpdateCurrencyRequest;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.mapper.UpdateCurrencyRequestMapper;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.update.UpdateCurrencyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST API-адаптер use case обновления валюты.
+ */
+@RestController
+@RequestMapping("/api/v1/currencies")
+@RequiredArgsConstructor
+public class UpdateCurrencyController {
+
+    private final UpdateCurrencyService updateCurrencyService;
+
+    /**
+     * Обновить валюту по коду.
+     */
+    @PutMapping("/{code}")
+    public ResponseEntity<Void> update(@PathVariable String code, @Valid @RequestBody UpdateCurrencyRequest request) {
+        updateCurrencyService.update(UpdateCurrencyRequestMapper.toDomain(code, request));
+        return ResponseEntityFactory.noContent();
+    }
+}


### PR DESCRIPTION
### Motivation
- Разделить ответственность HTTP-адаптеров: вынести `update`-операцию в отдельный контроллер в слайс update, сохранив существующий URL/response-контракт и не затрагивая query-side.

### Description
- Добавлен `UpdateCurrencyController` в `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/controller/UpdateCurrencyController.java` с аннотациями `@RestController`, `@RequestMapping("/api/v1/currencies")` и `@RequiredArgsConstructor` и методом `@PutMapping("/{code}") public ResponseEntity<Void> update(@PathVariable String code, @Valid @RequestBody UpdateCurrencyRequest request)`.
- В `UpdateCurrencyController` реализована логика вызова `updateCurrencyService.update(UpdateCurrencyRequestMapper.toDomain(code, request));` и возврата `ResponseEntityFactory.noContent()`.
- Из `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java` удалён метод обновления и связанные импорты, при этом метод `getAll` и поведение контроллера оставлены без изменений.
- Контракты не изменялись: URL `PUT /api/v1/currencies/{code}` и ответ `204 No Content` сохранены.

### Testing
- Попытка запуска сборки `./mvnw -pl backend -DskipTests compile` не прошла из-за ограничения окружения: wrapper не смог скачать дистрибутив Maven (`Failed to fetch apache-maven-3.9.9-bin.zip`), поэтому автоматическая компиляция/тесты не выполнены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deadcd6510832d8248ecf48d101f67)