### PR TITLE
Добавить query-side use-case `ListCurrenciesService`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/query/list/ListCurrenciesService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/query/list/ListCurrenciesService.java
@@ -1,0 +1,31 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.query.list;
+
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Use-case сервис получения списка валют.
+ */
+@Slf4j
+public final class ListCurrenciesService {
+
+    /* Репозиторий для чтения справочника валют. */
+    private final CurrencyRepository currencyRepository;
+
+    public ListCurrenciesService(CurrencyRepository currencyRepository) {
+        this.currencyRepository = Objects.requireNonNull(currencyRepository,
+                "currencyRepository must not be null");
+    }
+
+    public List<Currency> findAll() {
+        // Загружаем полный список валют.
+        List<Currency> result = currencyRepository.findAll();
+        log.debug("Found {} currencies", result.size());
+
+        return result;
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить отдельный query-side use-case сервис для получения списка валют через `CurrencyRepository` в слое приложения справочника валют.

### Description
- Создан файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/query/list/ListCurrenciesService.java` с `public final class ListCurrenciesService`, аннотацией `@Slf4j`, полем `private final CurrencyRepository currencyRepository`, конструктором с `Objects.requireNonNull(currencyRepository, "currencyRepository must not be null")` и методом `public List<Currency> findAll()` который вызывает `currencyRepository.findAll()`, логирует количество и возвращает результат.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deaebd32ac832da7b53b0125f55f59)