### PR TITLE
Выделен query-контроллер для списка валют

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/controller/ListCurrenciesController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/controller/ListCurrenciesController.java
@@ -1,9 +1,10 @@
-package com.alligator.market.backend.instrument.asset.forex.reference.currency.api;
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.controller;
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.common.CurrencyDto;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.dto.mapper.CurrencyDtoMapper;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.query.list.ListCurrenciesService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,26 +13,24 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-/**
- * REST-контроллер для валют.
- */
+/* Query-контроллер для получения списка валют. */
 @RestController
 @RequestMapping("/api/v1/currencies")
 @RequiredArgsConstructor
-public class CurrencyController {
+public class ListCurrenciesController {
 
-    private final CurrencyCatalogService service;
+    /* Сервис получения справочника валют. */
+    private final ListCurrenciesService listCurrenciesService;
 
-    /**
-     * Вернуть все валюты.
-     */
+    /* Вернуть все валюты в неизменном response-контракте. */
     @GetMapping
     public ResponseEntity<ApiResponse<List<CurrencyDto>>> getAll() {
-
-        List<CurrencyDto> currencyDtoList = service.findAll()
+        // Конвертируем доменные сущности в DTO ответа.
+        List<CurrencyDto> currencyDtoList = listCurrenciesService.findAll()
                 .stream()
                 .map(CurrencyDtoMapper::toCurrencyDto)
                 .toList();
+
         return ResponseEntityFactory.ok(currencyDtoList);
     }
 }


### PR DESCRIPTION
### Motivation
- Завершить query-side для `getAll` путем выделения отдельного query controller и использования отдельного query service вместо старого контроллера. 
- Сохранить существующий URL-контракт и формат ответа для совместимости с клиентами (`/api/v1/currencies`, `ResponseEntity<ApiResponse<List<CurrencyDto>>>`).

### Description
- Добавлен файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/controller/ListCurrenciesController.java`, реализующий query-контроллер и использующий `ListCurrenciesService` и `CurrencyDtoMapper` для формирования ответа. 
- Удалён старый контроллер `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/CurrencyController.java` и перенесена логика `getAll` в новую структуру query-slice. 
- Сервис `ListCurrenciesService` в пакете `application.query.list` соответствует требованиям (класс `final`, `@Slf4j`, `Objects.requireNonNull` в конструкторе, метод `findAll()` вызывает `currencyRepository.findAll()` и делает debug-лог). 
- Добавлены краткие комментарии на русском в стиле проекта и не изменён response/DTO/mapper контракт.

### Testing
- Сборка попыткой: `./mvnw -pl backend -DskipTests compile` — сборка не завершилась из-за окружной проблемы загрузки Maven дистрибутива (`wget: Failed to fetch ...apache-maven-3.9.9-bin.zip`).
- Никаких автоматизированных unit/integration тестов не выполнялось в рамках этого изменения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deafb7d2a8832d9634c1313067a863)