### PR TITLE
Добавить `CurrencyListResponse` DTO и `CurrencyListResponseMapper`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/dto/CurrencyListResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/dto/CurrencyListResponse.java
@@ -1,0 +1,10 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.dto;
+
+/* Элемент списка валют для list query. */
+public record CurrencyListResponse(
+        String code,
+        String name,
+        String country,
+        Integer fractionDigits
+) {
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/mapper/CurrencyListResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/mapper/CurrencyListResponseMapper.java
@@ -1,0 +1,27 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.mapper;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.dto.CurrencyListResponse;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+
+import java.util.Objects;
+
+/* Маппер доменной валюты в response list query. */
+public final class CurrencyListResponseMapper {
+
+    private CurrencyListResponseMapper() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static CurrencyListResponse toResponse(Currency currency) {
+        // Проверяем входной аргумент на null.
+        Objects.requireNonNull(currency, "currency must not be null");
+
+        // Маппим доменную модель в локальный response DTO.
+        return new CurrencyListResponse(
+                currency.code().value(),
+                currency.name(),
+                currency.country(),
+                currency.fractionDigits()
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Выделить локальный response DTO и маппер для среза list query валют, чтобы иметь отдельный контракт для списка и не ломать существующие общие DTO/мапперы.
- Следующий атомарный шаг ввести отдельный response-формат и утилитарный маппер без изменений контроллеров и существующих DTO/мапперов.

### Description
- Добавлен `record` `CurrencyListResponse` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.dto` с полями `code`, `name`, `country`, `fractionDigits` и русским комментарием над объектом.
- Добавлен финальный утилитарный класс `CurrencyListResponseMapper` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.mapper` с приватным конструктором, выбрасывающим `UnsupportedOperationException("Utility class")`.
- В `CurrencyListResponseMapper` реализован статический метод `public static CurrencyListResponse toResponse(Currency currency)`, который выполняет `Objects.requireNonNull(currency, "currency must not be null")` и маппит поля как `currency.code().value()`, `currency.name()`, `currency.country()` и `currency.fractionDigits()`.

### Testing
- Автоматизированных тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb23e3438832d9dfa82d1a54a9be3)