### PR TITLE
refactor(currency): migrate create/list controllers to standard ResponseEntity

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/create/controller/CreateCurrencyController.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.controller;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.dto.CreateCurrencyRequest;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.mapper.CreateCurrencyRequestMapper;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create.CreateCurrencyService;
@@ -31,7 +29,7 @@ public class CreateCurrencyController {
      * Создать валюту.
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<String>> create(@Valid @RequestBody CreateCurrencyRequest request) {
+    public ResponseEntity<String> create(@Valid @RequestBody CreateCurrencyRequest request) {
         Currency created = createCurrencyService.create(
                 CreateCurrencyRequestMapper.toDomain(request)
         );
@@ -41,6 +39,6 @@ public class CreateCurrencyController {
                 .path("/{code}")
                 .buildAndExpand(created.code().value())
                 .toUri();
-        return ResponseEntityFactory.created(location, created.code().value());
+        return ResponseEntity.created(location).body(created.code().value());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/controller/ListCurrenciesController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/query/list/controller/ListCurrenciesController.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.controller;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.dto.CurrencyListResponse;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.mapper.CurrencyListResponseMapper;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.query.list.ListCurrenciesService;
@@ -27,13 +25,13 @@ public class ListCurrenciesController {
      * Вернуть все валюты.
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CurrencyListResponse>>> getAll() {
+    public ResponseEntity<List<CurrencyListResponse>> getAll() {
 
-        List<CurrencyListResponse> currencyDtoList = listCurrenciesService.findAll()
+        List<CurrencyListResponse> currencies = listCurrenciesService.findAll()
                 .stream()
                 .map(CurrencyListResponseMapper::toResponse)
                 .toList();
 
-        return ResponseEntityFactory.ok(currencyDtoList);
+        return ResponseEntity.ok(currencies);
     }
 }


### PR DESCRIPTION
### Motivation
- Убрать использование кастомного `ApiResponse` в контроллерах валют и перевести контроллеры `create` и `list` на стандартный Spring `ResponseEntity` для унификации ответов.

### Description
- В `CreateCurrencyController` удалены импорты `ApiResponse` и `ResponseEntityFactory`, сигнатура метода изменена на `ResponseEntity<String>`, возврат заменён на `ResponseEntity.created(location).body(...)` без изменения остальной логики метода.
- В `ListCurrenciesController` удалены импорты `ApiResponse` и `ResponseEntityFactory`, сигнатура метода изменена на `ResponseEntity<List<CurrencyListResponse>>>`, локальная переменная `currencyDtoList` переименована в `currencies`, и возврат заменён на `ResponseEntity.ok(currencies)`.
- Проверено отсутствие импортов `com.alligator.market.backend.common.web.response.ApiResponse` в контроллерах валют; `ResponseEntityFactory` в `UpdateCurrencyController` и `DeleteCurrencyController` оставлен без изменений.
- DTO, mapper, слой сервисов, exception handler, URL-контракт и бизнес-логика не изменялись.

### Testing
- Выполнен поиск импорта `com.alligator.market.backend.common.web.response.ApiResponse` с помощью `rg` по контроллерам и получен результат `NOT_FOUND`, проверка успешна.
- Попытка запустить `./gradlew :backend:compileJava` не удалась из-за отсутствия `gradlew` в окружении, сборка не была выполнена в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb9cb1d1c832da529093060ff6791)