### PR TITLE
Add CurrencyRepositoryWiringConfig and remove @Repository from adapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/config/currency/persistence/repository/adapter/CurrencyRepositoryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/config/currency/persistence/repository/adapter/CurrencyRepositoryWiringConfig.java
@@ -1,0 +1,25 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.config.currency.persistence.repository.adapter;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jpa.CurrencyJpaRepository;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.repository.adapter.CurrencyRepositoryAdapter;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Явный wiring доменного {@link CurrencyRepository} через текущий adapter.
+ */
+@Configuration(proxyBeanMethods = false)
+public class CurrencyRepositoryWiringConfig {
+
+    public static final String BEAN_CURRENCY_REPOSITORY = "currencyRepository";
+
+    /**
+     * Сборка доменного repository-port для currency feature.
+     */
+    @Bean(BEAN_CURRENCY_REPOSITORY)
+    public CurrencyRepository currencyRepository(CurrencyJpaRepository jpaRepository) {
+        // Передаем зависимости adapter'а в явной точке сборки.
+        return new CurrencyRepositoryAdapter(jpaRepository);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/repository/adapter/CurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/repository/adapter/CurrencyRepositoryAdapter.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,7 +21,6 @@ import java.util.Optional;
 /**
  * Адаптер доменного репозитория валют (в контексте Spring Data JPA).
  */
-@Repository
 @RequiredArgsConstructor
 public class CurrencyRepositoryAdapter implements CurrencyRepository {
 


### PR DESCRIPTION
### Motivation

- Сделать явный wiring для доменного `CurrencyRepository` и заложить зеркальную `config`-структуру для feature `currency`.
- Перевести регистрацию адаптера на явную точку сборки вместо автоматического сканирования stereotype-аннотацией.

### Description

- Удалил Spring stereotype `@Repository` и соответствующий импорт из `CurrencyRepositoryAdapter` при сохранении всей бизнес-логики класса (файл: `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/repository/adapter/CurrencyRepositoryAdapter.java`).
- Добавил новый конфиг `CurrencyRepositoryWiringConfig` по зеркальному пути `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/config/currency/persistence/repository/adapter/CurrencyRepositoryWiringConfig.java` с аннотацией `@Configuration(proxyBeanMethods = false)` и константой `BEAN_CURRENCY_REPOSITORY = "currencyRepository"`.
- В конфиге создал `@Bean(BEAN_CURRENCY_REPOSITORY)` который возвращает доменный `com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository` через `new CurrencyRepositoryAdapter(jpaRepository)` и передаёт только реально используемую зависимость `CurrencyJpaRepository`.
- Добавил краткие комментарии на русском в wiring-классе в стиле проекта.

### Testing

- Попытка собрать с Gradle `./gradlew :backend:compileJava` завершилась ошибкой из-за отсутствия `./gradlew` в окружении (failed).
- Попытка собрать модуль с Maven wrapper `./mvnw -pl backend -DskipTests compile` завершилась неудачей из‑за ошибки скачивания дистрибутива Maven (`wget` failed), сборка не выполнена.
- Все изменения закоммичены в репозитории и патч добавлен (см. созданный файл `CurrencyRepositoryWiringConfig.java` и модифицированный `CurrencyRepositoryAdapter.java`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4e771c30832d97cadacbf73a0c3f)