### PR TITLE
Добавить явный wiring для CreateCurrencyService

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/create/CreateCurrencyServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/create/CreateCurrencyServiceWiringConfig.java
@@ -1,0 +1,31 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.command.create;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.create.CreateCurrencyService;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.persistence.repository.adapter.CurrencyRepositoryWiringConfig;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Явный wiring use-case сервиса создания валюты.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import(CurrencyRepositoryWiringConfig.class)
+public class CreateCurrencyServiceWiringConfig {
+
+    public static final String BEAN_CREATE_CURRENCY_SERVICE = "createCurrencyService";
+
+    /**
+     * Сборка CreateCurrencyService с доменным repository-port.
+     */
+    @Bean(BEAN_CREATE_CURRENCY_SERVICE)
+    public CreateCurrencyService createCurrencyService(
+            @Qualifier(CurrencyRepositoryWiringConfig.BEAN_CURRENCY_REPOSITORY)
+            CurrencyRepository currencyRepository
+    ) {
+        // Создаем use-case сервис с единственной зависимостью.
+        return new CreateCurrencyService(currencyRepository);
+    }
+}


### PR DESCRIPTION
### Motivation
- Предоставить явный application-service wiring, зеркально расположенный в дереве `currency/config/...`, чтобы явно собирать и экспонировать bean `CreateCurrencyService` с доменным `CurrencyRepository`.

### Description
- Добавлен файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/create/CreateCurrencyServiceWiringConfig.java` (package `com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.command.create`) с `@Configuration(proxyBeanMethods = false)`, константой `BEAN_CREATE_CURRENCY_SERVICE`, `@Import(CurrencyRepositoryWiringConfig.class)` и методом `@Bean(BEAN_CREATE_CURRENCY_SERVICE)`, принимающим `@Qualifier(CurrencyRepositoryWiringConfig.BEAN_CURRENCY_REPOSITORY) CurrencyRepository` и возвращающим `new CreateCurrencyService(currencyRepository)`, а также с краткими комментариями на русском языке.

### Testing
- Автоматические тесты не запускались на этом шаге.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df55f48dc0832dbb00a6f5175ae64c)