### PR TITLE
Добавить wiring-конфигурацию для DeleteCurrencyService

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/delete/DeleteCurrencyServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/delete/DeleteCurrencyServiceWiringConfig.java
@@ -1,0 +1,37 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.command.delete;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.delete.DeleteCurrencyService;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.usage.port.CurrencyUsageCheckPort;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.usage.port.CurrencyUsageCheckPortWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.persistence.repository.adapter.CurrencyRepositoryWiringConfig;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Wiring-конфигурация {@link DeleteCurrencyService}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        CurrencyRepositoryWiringConfig.class,
+        CurrencyUsageCheckPortWiringConfig.class
+})
+public class DeleteCurrencyServiceWiringConfig {
+
+    public static final String BEAN_DELETE_CURRENCY_SERVICE = "deleteCurrencyService";
+
+    /**
+     * Явно собираем use-case сервис удаления валюты из требуемых портов.
+     */
+    @Bean(BEAN_DELETE_CURRENCY_SERVICE)
+    public DeleteCurrencyService deleteCurrencyService(
+            @Qualifier(CurrencyRepositoryWiringConfig.BEAN_CURRENCY_REPOSITORY)
+            CurrencyRepository currencyRepository,
+            @Qualifier(CurrencyUsageCheckPortWiringConfig.BEAN_CURRENCY_USAGE_CHECK_PORT)
+            CurrencyUsageCheckPort currencyUsageCheckPort
+    ) {
+        return new DeleteCurrencyService(currencyRepository, currencyUsageCheckPort);
+    }
+}


### PR DESCRIPTION
### Motivation
- Обеспечить явное wiring для `DeleteCurrencyService` в зеркальной структуре конфига feature `currency` для явной сборки application service bean.
- Сделать конфигурацию согласованной с уже существующим `CreateCurrencyServiceWiringConfig` и доступными портами/репозиториями.

### Description
- Создан файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/delete/DeleteCurrencyServiceWiringConfig.java` с корректным `package` и аннотацией `@Configuration(proxyBeanMethods = false)`.
- Добавлена константа `BEAN_DELETE_CURRENCY_SERVICE = "deleteCurrencyService"` и bean-метод `@Bean(BEAN_DELETE_CURRENCY_SERVICE)` который возвращает `new DeleteCurrencyService(...)`.
- Подключены зависимости через `@Import` для `CurrencyRepositoryWiringConfig` и `CurrencyUsageCheckPortWiringConfig` и параметры метода помечены `@Qualifier` с соответствующими именами бинов.
- Добавлены краткие Javadoc/комментарии на русском в стиле проекта.

### Testing
- Выполнена проверка статуса репозитория командой `git status --short`, команда завершилась успешно.
- Файл был добавлен и зафиксирован командой `git add && git commit -m "Add explicit wiring config for DeleteCurrencyService"`, коммит прошёл успешно.
- Содержимое нового файла было выведено командой `nl -ba` для визуальной проверки и показало ожидаемую структуру файла.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df67a67f98832dafc1c3fb457be99c)