### PR TITLE
Добавить wiring-конфиг для UpdateCurrencyService

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/update/UpdateCurrencyServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/update/UpdateCurrencyServiceWiringConfig.java
@@ -1,0 +1,30 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.command.update;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.update.UpdateCurrencyService;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.persistence.repository.adapter.CurrencyRepositoryWiringConfig;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Wiring-конфигурация {@link UpdateCurrencyService}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import(CurrencyRepositoryWiringConfig.class)
+public class UpdateCurrencyServiceWiringConfig {
+
+    public static final String BEAN_UPDATE_CURRENCY_SERVICE = "updateCurrencyService";
+
+    /**
+     * Собирает application service для обновления валюты.
+     */
+    @Bean(BEAN_UPDATE_CURRENCY_SERVICE)
+    public UpdateCurrencyService updateCurrencyService(
+            @Qualifier(CurrencyRepositoryWiringConfig.BEAN_CURRENCY_REPOSITORY)
+            CurrencyRepository currencyRepository
+    ) {
+        return new UpdateCurrencyService(currencyRepository);
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить явный wiring для `UpdateCurrencyService` в зеркальной структуре `currency/config/.../application/command/update`, чтобы явным образом зарегистрировать bean `updateCurrencyService` аналогично уже существующим create/delete конфигам.

### Description
- Создан файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/command/update/UpdateCurrencyServiceWiringConfig.java` с корректным `package`, аннотацией `@Configuration(proxyBeanMethods = false)`, константой `BEAN_UPDATE_CURRENCY_SERVICE`, `@Import(CurrencyRepositoryWiringConfig.class)`, методом `@Bean(BEAN_UPDATE_CURRENCY_SERVICE)` который принимает `CurrencyRepository` через `@Qualifier(CurrencyRepositoryWiringConfig.BEAN_CURRENCY_REPOSITORY)` и возвращает `new UpdateCurrencyService(currencyRepository)`, добавлены краткие комментарии на русском.

### Testing
- Автоматизированные тесты не запускались; изменение является wiring-only и не затрагивает бизнес-логику.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df6a316938832d89f47d0ebe7bcb29)