### PR TITLE
Явный wiring для ListCurrenciesService

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/query/list/ListCurrenciesServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/query/list/ListCurrenciesServiceWiringConfig.java
@@ -1,0 +1,30 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.query.list;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.query.list.ListCurrenciesService;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.persistence.repository.adapter.CurrencyRepositoryWiringConfig;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Wiring-конфигурация {@link ListCurrenciesService}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import(CurrencyRepositoryWiringConfig.class)
+public class ListCurrenciesServiceWiringConfig {
+
+    public static final String BEAN_LIST_CURRENCIES_SERVICE = "listCurrenciesService";
+
+    /**
+     * Собирает query service для получения списка валют.
+     */
+    @Bean(BEAN_LIST_CURRENCIES_SERVICE)
+    public ListCurrenciesService listCurrenciesService(
+            @Qualifier(CurrencyRepositoryWiringConfig.BEAN_CURRENCY_REPOSITORY)
+            CurrencyRepository currencyRepository
+    ) {
+        return new ListCurrenciesService(currencyRepository);
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить явную wiring-конфигурацию для query-сервиса, чтобы конфиг зеркально отражал структуру фичи `currency` и обеспечивал явную сборку bean для `ListCurrenciesService`.

### Description
- Создан файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/query/list/ListCurrenciesServiceWiringConfig.java` с `@Configuration(proxyBeanMethods = false)`, `@Import(CurrencyRepositoryWiringConfig.class)` и константой `BEAN_LIST_CURRENCIES_SERVICE`.
- Добавлен `@Bean(BEAN_LIST_CURRENCIES_SERVICE)` метод `listCurrenciesService(...)`, который получает `CurrencyRepository` через `@Qualifier(CurrencyRepositoryWiringConfig.BEAN_CURRENCY_REPOSITORY)` и возвращает `new ListCurrenciesService(currencyRepository)`; в коде добавлены краткие комментарии на русском в стиле проекта.

### Testing
- Автоматических тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df6db74e04832d921a79f0424cb62b)