### PR TITLE
refactor(currency): use standard Spring ResponseEntity in update/delete controllers

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/delete/controller/DeleteCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/delete/controller/DeleteCurrencyController.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.delete.controller;
 
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.delete.DeleteCurrencyService;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +25,6 @@ public class DeleteCurrencyController {
     @DeleteMapping("/{code}")
     public ResponseEntity<Void> delete(@PathVariable String code) {
         deleteCurrencyService.delete(CurrencyCode.of(code));
-        return ResponseEntityFactory.noContent();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/controller/UpdateCurrencyController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/command/update/controller/UpdateCurrencyController.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.controller;
 
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.dto.UpdateCurrencyRequest;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.mapper.UpdateCurrencyRequestMapper;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.command.update.UpdateCurrencyService;
@@ -29,6 +28,6 @@ public class UpdateCurrencyController {
     @PutMapping("/{code}")
     public ResponseEntity<Void> update(@PathVariable String code, @Valid @RequestBody UpdateCurrencyRequest request) {
         updateCurrencyService.update(UpdateCurrencyRequestMapper.toDomain(code, request));
-        return ResponseEntityFactory.noContent();
+        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
### Motivation
- Упростить контроллеры валют, убрать кастомный `ResponseEntityFactory` и использовать стандартный Spring `ResponseEntity` для построения ответов с кодом 204.

### Description
- В `UpdateCurrencyController` удалён импорт `ResponseEntityFactory` и возвращается `ResponseEntity.noContent().build()` в методе `update(...)` без изменения сигнатуры и логики.
- В `DeleteCurrencyController` удалён импорт `ResponseEntityFactory` и возвращается `ResponseEntity.noContent().build()` в методе `delete(...)` без изменения сигнатуры и логики.
- Проверены контроллеры `CreateCurrencyController`, `UpdateCurrencyController`, `DeleteCurrencyController`, `ListCurrenciesController` — они используют `org.springframework.http.ResponseEntity` и больше не импортируют `ResponseEntityFactory`.

### Testing
- Выполнена проверка отсутствия использования `ResponseEntityFactory` командой `rg "ResponseEntityFactory" backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency -n`, проверка успешна.
- Попытка сборки бэкенда с `./mvnw -pl backend -DskipTests compile` была выполнена, но неуспешна из-за проблем с загрузкой Maven bootstrap в окружении (ошибка загрузки `apache-maven-3.9.9-bin.zip`).
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7bdaf2c8832d97f8b88183fd381c)