### PR TITLE
Remove dead currency technical error codes from DomainErrorCode

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
@@ -26,9 +26,6 @@ public enum DomainErrorCode {
     CURRENCY_NAME_DUPLICATE(DomainErrorType.CONFLICT),
     CURRENCY_NOT_FOUND(DomainErrorType.NOT_FOUND),
     CURRENCY_IN_USE(DomainErrorType.CONFLICT),
-    CURRENCY_CREATE_FAILED(DomainErrorType.TECHNICAL),
-    CURRENCY_UPDATE_FAILED(DomainErrorType.TECHNICAL),
-    CURRENCY_DELETE_FAILED(DomainErrorType.TECHNICAL),
 
     /* FOREX_SPOT инструмент: */
     FX_SPOT_ALREADY_EXISTS(DomainErrorType.CONFLICT),


### PR DESCRIPTION
### Motivation
- Удалить неиспользуемые технические коды ошибок для валют после удаления feature-specific technical exceptions, оставив только бизнес-коды валют.

### Description
- Удалены enum-константы `CURRENCY_CREATE_FAILED`, `CURRENCY_UPDATE_FAILED` и `CURRENCY_DELETE_FAILED` из блока "Валюты" в `domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java`.
- Сохранены бизнес/application коды для валют (`CURRENCY_ALREADY_EXISTS`, `CURRENCY_NAME_DUPLICATE`, `CURRENCY_NOT_FOUND`, `CURRENCY_IN_USE`) без изменений.
- Другие разделы и технические коды `FOREX_SPOT`, `DomainErrorType` и обработчики не изменялись.

### Testing
- Автоматических тестов не запускал; изменения локально проверены с помощью `git diff` и успешно закоммичены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8f835e0c832db5b1555ac22d2653)