### PR TITLE
Вынести currency-обработчики исключений в локальный RestControllerAdvice

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/advice/DomainExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/advice/DomainExceptionHandler.java
@@ -2,11 +2,7 @@ package com.alligator.market.backend.common.web.advice;
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyInUseException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyAlreadyExistsException;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNameDuplicateException;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.exception.*;
 import com.alligator.market.domain.provider.model.handler.exception.HandlerNotFoundException;
 import com.alligator.market.domain.provider.model.handler.exception.InstrumentNotSupportedException;
@@ -30,42 +26,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice
 public class DomainExceptionHandler {
-
-    /**
-     * Валюта с таким кодом уже существует --> 409.
-     */
-    @ExceptionHandler(CurrencyAlreadyExistsException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyAlreadyExists(CurrencyAlreadyExistsException ex) {
-        log.warn("Currency already exists: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_ALREADY_EXISTS.name(), ex.getMessage());
-    }
-
-    /**
-     * Валюта с таким именем уже существует --> 409.
-     */
-    @ExceptionHandler(CurrencyNameDuplicateException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyNameDuplicate(CurrencyNameDuplicateException ex) {
-        log.warn("Currency name duplicate: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_NAME_DUPLICATE.name(), ex.getMessage());
-    }
-
-    /**
-     * Валюта используется внешними фичами/агрегатами --> 409.
-     */
-    @ExceptionHandler(CurrencyInUseException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyInUse(CurrencyInUseException ex) {
-        log.warn("Currency is in use: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_IN_USE.name(), ex.getMessage());
-    }
-
-    /**
-     * Валюта не найдена --> 404.
-     */
-    @ExceptionHandler(CurrencyNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyNotFound(CurrencyNotFoundException ex) {
-        log.warn("Currency not found: {}", ex.getMessage());
-        return ResponseEntityFactory.notFound(DomainErrorCode.CURRENCY_NOT_FOUND.name(), ex.getMessage());
-    }
 
     /**
      * Валюта уже используется при создании FOREX_SPOT --> 409.

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
@@ -1,0 +1,69 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.advice;
+
+import com.alligator.market.backend.common.web.response.ApiResponse;
+import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.controller.CreateCurrencyController;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.delete.controller.DeleteCurrencyController;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.controller.UpdateCurrencyController;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.query.list.controller.ListCurrenciesController;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyAlreadyExistsException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyInUseException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNameDuplicateException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
+import com.alligator.market.domain.common.exception.DomainErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Локальный обработчик ошибок currency-feature для REST-контроллеров.
+ */
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(assignableTypes = {
+        CreateCurrencyController.class,
+        UpdateCurrencyController.class,
+        DeleteCurrencyController.class,
+        ListCurrenciesController.class
+})
+public class CurrencyRestExceptionHandler {
+
+    /**
+     * Валюта с таким кодом уже существует --> 409.
+     */
+    @ExceptionHandler(CurrencyAlreadyExistsException.class)
+    public ResponseEntity<ApiResponse<Void>> currencyAlreadyExists(CurrencyAlreadyExistsException ex) {
+        log.warn("Currency already exists: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_ALREADY_EXISTS.name(), ex.getMessage());
+    }
+
+    /**
+     * Валюта с таким именем уже существует --> 409.
+     */
+    @ExceptionHandler(CurrencyNameDuplicateException.class)
+    public ResponseEntity<ApiResponse<Void>> currencyNameDuplicate(CurrencyNameDuplicateException ex) {
+        log.warn("Currency name duplicate: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_NAME_DUPLICATE.name(), ex.getMessage());
+    }
+
+    /**
+     * Валюта используется внешними фичами/агрегатами --> 409.
+     */
+    @ExceptionHandler(CurrencyInUseException.class)
+    public ResponseEntity<ApiResponse<Void>> currencyInUse(CurrencyInUseException ex) {
+        log.warn("Currency is in use: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_IN_USE.name(), ex.getMessage());
+    }
+
+    /**
+     * Валюта не найдена --> 404.
+     */
+    @ExceptionHandler(CurrencyNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> currencyNotFound(CurrencyNotFoundException ex) {
+        log.warn("Currency not found: {}", ex.getMessage());
+        return ResponseEntityFactory.notFound(DomainErrorCode.CURRENCY_NOT_FOUND.name(), ex.getMessage());
+    }
+}


### PR DESCRIPTION
### Motivation
- Сделать обработку ошибок фичи `currency` локальной внутри её API-контроллеров и убрать знание о `currency` из общего `DomainExceptionHandler`.
- Сохранить существующий формат error-response через `ResponseEntityFactory` и `ApiResponse` без изменения поведения клиентов.

### Description
- Добавлен новый класс `CurrencyRestExceptionHandler` в пакет `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.advice` с аннотациями `@Slf4j`, `@Order(Ordered.HIGHEST_PRECEDENCE)` и `@RestControllerAdvice(assignableTypes = {...})`, реализующий четыре обработчика для `CurrencyAlreadyExistsException`, `CurrencyNameDuplicateException`, `CurrencyInUseException` и `CurrencyNotFoundException` и логирующий события через `log.warn(...)`.
- Удалены соответствующие импорты и четыре handler-метода из `backend/src/main/java/com/alligator/market/backend/common/web/advice/DomainExceptionHandler.java`, при этом все fxspot/provider и прочие общие обработчики оставлены без изменений.
- Формат ответов и используемые коды ошибок (`DomainErrorCode.*`) оставлены прежними и возвращаются через `ResponseEntityFactory`/`ApiResponse`.

### Testing
- Попытка локальной компиляции через отсутствующий wrapper `./gradlew :backend:compileJava` не выполнена, так как `gradlew` в репозитории отсутствует (команда не найдена).
- Попытка компиляции через Maven wrapper `./mvnw -pl backend -DskipTests compile` завершилась неудачей из-за ошибки при загрузке дистрибутива Maven (`wget: Failed to fetch ...`), поэтому автоматическая компиляция/тесты в окружении не прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9552a9b4832dbfa2596a57b4791e)