### PR TITLE
refactor(currency): локальный REST-обработчик ошибок переведен на ProblemDetail

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.advice;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.create.controller.CreateCurrencyController;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.delete.controller.DeleteCurrencyController;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.command.update.controller.UpdateCurrencyController;
@@ -14,12 +12,20 @@ import com.alligator.market.domain.common.exception.DomainErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 /**
- * Локальный обработчик ошибок currency-feature для REST-контроллеров.
+ * Локальный обработчик ошибок currency feature для REST-контроллеров.
  */
 @Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -31,39 +37,113 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 })
 public class CurrencyRestExceptionHandler {
 
+    /* Локальные коды ошибок HTTP/DTO для currency feature. */
+    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
+    private static final String MALFORMED_REQUEST = "MALFORMED_REQUEST";
+
     /**
      * Валюта с таким кодом уже существует --> 409.
      */
     @ExceptionHandler(CurrencyAlreadyExistsException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyAlreadyExists(CurrencyAlreadyExistsException ex) {
+    public ProblemDetail currencyAlreadyExists(CurrencyAlreadyExistsException ex) {
         log.warn("Currency already exists: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_ALREADY_EXISTS.name(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.CONFLICT,
+                "Currency already exists",
+                ex.getMessage(),
+                DomainErrorCode.CURRENCY_ALREADY_EXISTS.name()
+        );
     }
 
     /**
      * Валюта с таким именем уже существует --> 409.
      */
     @ExceptionHandler(CurrencyNameDuplicateException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyNameDuplicate(CurrencyNameDuplicateException ex) {
+    public ProblemDetail currencyNameDuplicate(CurrencyNameDuplicateException ex) {
         log.warn("Currency name duplicate: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_NAME_DUPLICATE.name(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.CONFLICT,
+                "Currency name duplicate",
+                ex.getMessage(),
+                DomainErrorCode.CURRENCY_NAME_DUPLICATE.name()
+        );
     }
 
     /**
      * Валюта используется внешними фичами/агрегатами --> 409.
      */
     @ExceptionHandler(CurrencyInUseException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyInUse(CurrencyInUseException ex) {
+    public ProblemDetail currencyInUse(CurrencyInUseException ex) {
         log.warn("Currency is in use: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.CURRENCY_IN_USE.name(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.CONFLICT,
+                "Currency is in use",
+                ex.getMessage(),
+                DomainErrorCode.CURRENCY_IN_USE.name()
+        );
     }
 
     /**
      * Валюта не найдена --> 404.
      */
     @ExceptionHandler(CurrencyNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyNotFound(CurrencyNotFoundException ex) {
+    public ProblemDetail currencyNotFound(CurrencyNotFoundException ex) {
         log.warn("Currency not found: {}", ex.getMessage());
-        return ResponseEntityFactory.notFound(DomainErrorCode.CURRENCY_NOT_FOUND.name(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.NOT_FOUND,
+                "Currency not found",
+                ex.getMessage(),
+                DomainErrorCode.CURRENCY_NOT_FOUND.name()
+        );
+    }
+
+    /**
+     * Ошибки валидации входного DTO (@Valid) --> 400.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        log.warn("Request validation failed: {}", ex.getMessage());
+
+        ProblemDetail problemDetail = buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Validation failed",
+                "Request validation failed",
+                VALIDATION_ERROR
+        );
+
+        /* Ошибки полей -> компактная карта field -> message. */
+        Map<String, String> fieldErrors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .collect(Collectors.toMap(
+                        FieldError::getField,
+                        fieldError -> Objects.requireNonNullElse(fieldError.getDefaultMessage(), "Invalid value"),
+                        (first, second) -> first
+                ));
+        problemDetail.setProperty("fieldErrors", fieldErrors);
+
+        return problemDetail;
+    }
+
+    /**
+     * Некорректное тело запроса (JSON parse / type mismatch) --> 400.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+        log.warn("Malformed request body: {}", ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Malformed request",
+                "Request body is malformed or unreadable",
+                MALFORMED_REQUEST
+        );
+    }
+
+    /* Общий builder ProblemDetail для единообразного контракта ошибок currency feature. */
+    private ProblemDetail buildProblemDetail(HttpStatus status, String title, String detail, String errorCode) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setTitle(title);
+        problemDetail.setProperty("errorCode", errorCode);
+        return problemDetail;
     }
 }


### PR DESCRIPTION
### Motivation
- Привести контракт ошибок currency feature к `ProblemDetail`, чтобы feature имела собственный error contract и общий `DomainExceptionHandler` не знал о currency-специфике.

### Description
- Перевёл `CurrencyRestExceptionHandler` на `ProblemDetail`, убрав использование `ApiResponse`, `ResponseEntity` и `ResponseEntityFactory` и добавив `HttpStatus`/`ProblemDetail` и необходимые импорты для валидации/парсинга (`MethodArgumentNotValidException`, `HttpMessageNotReadableException`, `FieldError`).
- Для бизнес-исключений добавлены локальные обработчики, возвращающие `ProblemDetail` с нужным `status`, `title`, `detail` и `errorCode` из `DomainErrorCode` для `CurrencyAlreadyExistsException`, `CurrencyNameDuplicateException`, `CurrencyInUseException` и `CurrencyNotFoundException`.
- Добавлены локальные HTTP/DTO обработчики: `MethodArgumentNotValidException` -> `400 Validation failed` с `errorCode=VALIDATION_ERROR` и свойством `fieldErrors` (карта `field -> message`, при дублях берётся первое значение), и `HttpMessageNotReadableException` -> `400 Malformed request` с `errorCode=MALFORMED_REQUEST`.
- Добавлен приватный helper `buildProblemDetail(HttpStatus, String title, String detail, String errorCode)` и сохранены `@Order(Ordered.HIGHEST_PRECEDENCE)` и `@RestControllerAdvice(assignableTypes=...)` ограничения для currency-контроллеров; изменён файл: `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java`.

### Testing
- Попытка компиляции модуля с пропуском тестов: `./mvnw -pl backend -am -DskipTests compile` завершилась неуспешно из-за невозможности скачать дистрибутив Maven в текущем окружении (`wget: Failed to fetch https://repo.maven.apache.org/...`), поэтому сборка не была подтверждена локально.
- Статический просмотр кода и diff-проверка показали, что все currency-specific обработки перемещены в локальный `CurrencyRestExceptionHandler`, а `DomainExceptionHandler` не требует изменений (он уже не содержал currency-specific handlers).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9966ae8c832d9a786af35231bde0)