### PR TITLE
Вынос общих REST-ошибок в GlobalRestExceptionHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
@@ -14,15 +14,8 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Feature-specific обработчик ошибок API.
@@ -36,10 +29,6 @@ import java.util.stream.Collectors;
         ListCurrenciesController.class
 })
 public class CurrencyRestExceptionHandler {
-
-    /* Локальные коды ошибок HTTP/DTO для currency feature. */
-    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
-    private static final String MALFORMED_REQUEST = "MALFORMED_REQUEST";
 
     /**
      * Валюта с таким кодом уже существует --> 409.
@@ -94,48 +83,6 @@ public class CurrencyRestExceptionHandler {
                 "Currency not found",
                 ex.getMessage(),
                 DomainErrorCode.CURRENCY_NOT_FOUND.name()
-        );
-    }
-
-    /**
-     * Ошибки валидации входного DTO (@Valid) --> 400.
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        log.warn("Request validation failed: {}", ex.getMessage());
-
-        ProblemDetail problemDetail = buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Validation failed",
-                "Request validation failed",
-                VALIDATION_ERROR
-        );
-
-        /* Ошибки полей -> компактная карта field -> message. */
-        Map<String, String> fieldErrors = ex.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .collect(Collectors.toMap(
-                        FieldError::getField,
-                        fieldError -> Objects.requireNonNullElse(fieldError.getDefaultMessage(), "Invalid value"),
-                        (first, second) -> first
-                ));
-        problemDetail.setProperty("fieldErrors", fieldErrors);
-
-        return problemDetail;
-    }
-
-    /**
-     * Некорректное тело запроса (JSON parse / type mismatch) --> 400.
-     */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
-        log.warn("Malformed request body: {}", ex.getMessage());
-        return buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Malformed request",
-                "Request body is malformed or unreadable",
-                MALFORMED_REQUEST
         );
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
@@ -15,15 +15,8 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Feature-specific обработчик ошибок API.
@@ -45,8 +38,6 @@ public class InstrumentSourcePlanRestExceptionHandler {
     private static final String PROVIDER_CODES_NOT_FOUND = "PROVIDER_CODES_NOT_FOUND";
     private static final String INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS = "INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS";
     private static final String INSTRUMENT_SOURCE_PLAN_NOT_FOUND = "INSTRUMENT_SOURCE_PLAN_NOT_FOUND";
-    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
-    private static final String MALFORMED_REQUEST = "MALFORMED_REQUEST";
 
     /**
      * Код инструмента отсутствует в registry --> 400.
@@ -103,49 +94,6 @@ public class InstrumentSourcePlanRestExceptionHandler {
                 "Instrument source plan not found",
                 ex.getMessage(),
                 INSTRUMENT_SOURCE_PLAN_NOT_FOUND
-        );
-    }
-
-    /**
-     * Ошибки валидации входного DTO (@Valid) --> 400.
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        log.warn("Request validation failed: {}", ex.getMessage());
-
-        ProblemDetail problemDetail = buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Validation failed",
-                "Request validation failed",
-                VALIDATION_ERROR
-        );
-
-        /* Поля с ошибками -> компактная карта field -> message. */
-        Map<String, String> fieldErrors = ex.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .collect(Collectors.toMap(
-                        FieldError::getField,
-                        fieldError -> Objects.requireNonNullElse(fieldError.getDefaultMessage(),
-                                "Invalid value"),
-                        (first, second) -> first
-                ));
-        problemDetail.setProperty("fieldErrors", fieldErrors);
-
-        return problemDetail;
-    }
-
-    /**
-     * Некорректное тело запроса (JSON parse / type mismatch) --> 400.
-     */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
-        log.warn("Malformed request body: {}", ex.getMessage());
-        return buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Malformed request",
-                "Request body is malformed or unreadable",
-                MALFORMED_REQUEST
         );
     }
 


### PR DESCRIPTION
### Motivation
- Уточнить границы ответственности: оставить в feature-обработчиках только ошибки уровня application, а общие технические/парсинг/валидационные ошибки централизовать в глобальном обработчике.
- Устранить дублирование обработки ошибок и обеспечить единый контракт для общих ошибок REST-слоя.

### Description
- Удалены обработчики `MethodArgumentNotValidException` и `HttpMessageNotReadableException` вместе с сопутствующими импортами и локальными кодами ошибок из `CurrencyRestExceptionHandler` (файл `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java`).
- Удалены обработчики `MethodArgumentNotValidException` и `HttpMessageNotReadableException` вместе с сопутствующими импортами и локальными кодами ошибок из `InstrumentSourcePlanRestExceptionHandler` (файл `backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java`).
- В фичевых обработчиках сохранены только feature-specific application исключения и общий `buildProblemDetail` для формирования `ProblemDetail`.
- Глобальный обработчик `GlobalRestExceptionHandler` уже содержит обработку общих ошибок (`MethodArgumentNotValidException`, `HttpMessageNotReadableException` и др.), поэтому общая логика централизована в `backend/src/main/java/com/alligator/market/backend/common/web/advice/GlobalRestExceptionHandler.java`.

### Testing
- Попытка выполнить сборку `./mvnw -pl backend -DskipTests compile` в окружении завершилась неудачей из‑за невозможности скачать дистрибутив Maven (`repo.maven.apache.org`), поэтому автоматическая сборка/компиляция не выполнена.
- Автоматические тесты не запускались в этом окружении; изменений логики обработки application-исключений не было, только удаление дублирующейся обработки общих ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa6d746bc832d83c0c9338590bfa6)