### PR TITLE
Replace custom API error responses with ProblemDetail and centralize validation handling

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/web/advice/GlobalRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/web/advice/GlobalRestExceptionHandler.java
@@ -1,18 +1,18 @@
 package com.alligator.market.backend.common.web.advice;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.error.GlobalErrorCodes;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -26,71 +26,123 @@ public class GlobalRestExceptionHandler {
      * Ошибки валидации тела запроса (@Valid) --> 422.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        String message = ex.getBindingResult()
+    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        log.warn("Validation failed: {}", ex.getMessage());
+
+        ProblemDetail problemDetail = buildProblemDetail(
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "Validation failed",
+                "Request validation failed",
+                GlobalErrorCodes.VALIDATION_ERROR.name()
+        );
+
+        /* Ошибки полей -> компактная карта field -> message. */
+        Map<String, String> fieldErrors = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .collect(Collectors.joining("; "));
-        log.warn("Validation failed: {}", message);
-        return ResponseEntityFactory.unprocessableEntity(GlobalErrorCodes.VALIDATION_ERROR.name(), message);
+                .collect(Collectors.toMap(
+                        error -> error.getField(),
+                        error -> Objects.requireNonNullElse(error.getDefaultMessage(), "Invalid value"),
+                        (first, second) -> first
+                ));
+        problemDetail.setProperty("fieldErrors", fieldErrors);
+
+        return problemDetail;
     }
 
     /**
      * Ошибки валидации параметров (@Validated) --> 400.
      */
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(ConstraintViolationException ex) {
+    public ProblemDetail handleConstraintViolation(ConstraintViolationException ex) {
         String message = ex.getConstraintViolations()
                 .stream()
                 .map(v -> v.getPropertyPath() + ": " + v.getMessage())
                 .collect(Collectors.joining("; "));
         log.warn("Constraint violation: {}", message);
-        return ResponseEntityFactory.badRequest(GlobalErrorCodes.BAD_ARGUMENT.name(), message);
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Bad argument",
+                message,
+                GlobalErrorCodes.BAD_ARGUMENT.name()
+        );
     }
 
     /**
      * Тело запроса не удалось распарсить --> 400.
      */
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
         log.warn("Malformed JSON: {}", ex.getMessage());
-        return ResponseEntityFactory.badRequest(GlobalErrorCodes.MALFORMED_JSON.name(), "Malformed JSON");
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Malformed JSON",
+                "Request body is malformed or unreadable",
+                GlobalErrorCodes.MALFORMED_JSON.name()
+        );
     }
 
     /**
      * Нарушение целостности данных --> 409.
      */
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+    public ProblemDetail handleDataIntegrityViolation(DataIntegrityViolationException ex) {
         log.warn("Data integrity violation: {}", ex.getMostSpecificCause().getMessage());
-        return ResponseEntityFactory.conflict(GlobalErrorCodes.DATA_INTEGRITY_VIOLATION.name(), "Data integrity violation");
+        return buildProblemDetail(
+                HttpStatus.CONFLICT,
+                "Data integrity violation",
+                "Data integrity violation",
+                GlobalErrorCodes.DATA_INTEGRITY_VIOLATION.name()
+        );
     }
 
     /**
      * Некорректно переданные аргументы --> 400.
      */
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+    public ProblemDetail handleIllegalArgument(IllegalArgumentException ex) {
         log.warn("Illegal argument: {}", ex.getMessage());
-        return ResponseEntityFactory.badRequest(GlobalErrorCodes.BAD_ARGUMENT.name(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Bad argument",
+                ex.getMessage(),
+                GlobalErrorCodes.BAD_ARGUMENT.name()
+        );
     }
 
     /**
      * Неподдерживаемые операции --> 500.
      */
     @ExceptionHandler({IllegalStateException.class, UnsupportedOperationException.class})
-    public ResponseEntity<ApiResponse<Void>> handleIllegalState(RuntimeException ex) {
+    public ProblemDetail handleIllegalState(RuntimeException ex) {
         log.error("Illegal state: {}", ex.getMessage(), ex);
-        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, GlobalErrorCodes.UNEXPECTED_ERROR.name(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Unexpected error",
+                ex.getMessage(),
+                GlobalErrorCodes.UNEXPECTED_ERROR.name()
+        );
     }
 
     /**
      * Непредвиденные ошибки --> 500.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex) {
+    public ProblemDetail handleUnexpected(Exception ex) {
         log.error("Unhandled exception", ex);
-        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, GlobalErrorCodes.UNEXPECTED_ERROR.name(), "Unexpected server error");
+        return buildProblemDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Unexpected error",
+                "Unexpected server error",
+                GlobalErrorCodes.UNEXPECTED_ERROR.name()
+        );
+    }
+
+    /* Единый builder ProblemDetail для общего контракта ошибок REST-слоя. */
+    private ProblemDetail buildProblemDetail(HttpStatus status, String title, String detail, String errorCode) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setTitle(title);
+        problemDetail.setProperty("errorCode", errorCode);
+        return problemDetail;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
@@ -14,15 +14,8 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Feature-specific обработчик ошибок API.
@@ -36,10 +29,6 @@ import java.util.stream.Collectors;
         ListCurrenciesController.class
 })
 public class CurrencyRestExceptionHandler {
-
-    /* Локальные коды ошибок HTTP/DTO для currency feature. */
-    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
-    private static final String MALFORMED_REQUEST = "MALFORMED_REQUEST";
 
     /**
      * Валюта с таким кодом уже существует --> 409.
@@ -94,48 +83,6 @@ public class CurrencyRestExceptionHandler {
                 "Currency not found",
                 ex.getMessage(),
                 DomainErrorCode.CURRENCY_NOT_FOUND.name()
-        );
-    }
-
-    /**
-     * Ошибки валидации входного DTO (@Valid) --> 400.
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        log.warn("Request validation failed: {}", ex.getMessage());
-
-        ProblemDetail problemDetail = buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Validation failed",
-                "Request validation failed",
-                VALIDATION_ERROR
-        );
-
-        /* Ошибки полей -> компактная карта field -> message. */
-        Map<String, String> fieldErrors = ex.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .collect(Collectors.toMap(
-                        FieldError::getField,
-                        fieldError -> Objects.requireNonNullElse(fieldError.getDefaultMessage(), "Invalid value"),
-                        (first, second) -> first
-                ));
-        problemDetail.setProperty("fieldErrors", fieldErrors);
-
-        return problemDetail;
-    }
-
-    /**
-     * Некорректное тело запроса (JSON parse / type mismatch) --> 400.
-     */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
-        log.warn("Malformed request body: {}", ex.getMessage());
-        return buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Malformed request",
-                "Request body is malformed or unreadable",
-                MALFORMED_REQUEST
         );
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/api/advice/InstrumentSourcePlanRestExceptionHandler.java
@@ -15,15 +15,8 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Feature-specific обработчик ошибок API.
@@ -45,8 +38,6 @@ public class InstrumentSourcePlanRestExceptionHandler {
     private static final String PROVIDER_CODES_NOT_FOUND = "PROVIDER_CODES_NOT_FOUND";
     private static final String INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS = "INSTRUMENT_SOURCE_PLAN_ALREADY_EXISTS";
     private static final String INSTRUMENT_SOURCE_PLAN_NOT_FOUND = "INSTRUMENT_SOURCE_PLAN_NOT_FOUND";
-    private static final String VALIDATION_ERROR = "VALIDATION_ERROR";
-    private static final String MALFORMED_REQUEST = "MALFORMED_REQUEST";
 
     /**
      * Код инструмента отсутствует в registry --> 400.
@@ -103,49 +94,6 @@ public class InstrumentSourcePlanRestExceptionHandler {
                 "Instrument source plan not found",
                 ex.getMessage(),
                 INSTRUMENT_SOURCE_PLAN_NOT_FOUND
-        );
-    }
-
-    /**
-     * Ошибки валидации входного DTO (@Valid) --> 400.
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        log.warn("Request validation failed: {}", ex.getMessage());
-
-        ProblemDetail problemDetail = buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Validation failed",
-                "Request validation failed",
-                VALIDATION_ERROR
-        );
-
-        /* Поля с ошибками -> компактная карта field -> message. */
-        Map<String, String> fieldErrors = ex.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .collect(Collectors.toMap(
-                        FieldError::getField,
-                        fieldError -> Objects.requireNonNullElse(fieldError.getDefaultMessage(),
-                                "Invalid value"),
-                        (first, second) -> first
-                ));
-        problemDetail.setProperty("fieldErrors", fieldErrors);
-
-        return problemDetail;
-    }
-
-    /**
-     * Некорректное тело запроса (JSON parse / type mismatch) --> 400.
-     */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
-        log.warn("Malformed request body: {}", ex.getMessage());
-        return buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                "Malformed request",
-                "Request body is malformed or unreadable",
-                MALFORMED_REQUEST
         );
     }
 


### PR DESCRIPTION
### Motivation

- Move REST error contract to standard `ProblemDetail` payloads and reduce duplicate per-feature error handlers.
- Provide a unified builder for error responses and include structured `fieldErrors` for validation failures.
- Ensure consistent HTTP status codes for validation, parsing and integrity errors across the API.

### Description

- Replaced custom `ApiResponse`/`ResponseEntityFactory` usage in `GlobalRestExceptionHandler` with `ProblemDetail` return types and added `buildProblemDetail(...)` helper to centralize error metadata and `errorCode` property.
- Added structured `fieldErrors` map for `MethodArgumentNotValidException` and changed its status to `422 Unprocessable Entity`; added logging for validation and parsing errors.
- Removed duplicated `MethodArgumentNotValidException` and `HttpMessageNotReadableException` handlers from feature-specific handlers (`CurrencyRestExceptionHandler`, `InstrumentSourcePlanRestExceptionHandler`) since they are handled globally, and cleaned up unused imports/constants.
- Adjusted other exception handlers to return `ProblemDetail` with appropriate HTTP statuses (`400`, `409`, `500`) and domain/global error codes.

### Testing

- Ran project build and unit tests with `./gradlew build` and `./gradlew test`, and they completed successfully.
- Verified API layer compilation and controller advice wiring by running the application locally and exercising validation and error scenarios, with expected `ProblemDetail` responses returned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa6d746bc832d83c0c9338590bfa6)