### PR TITLE
Remove currency optimistic locking version field

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jpa/CurrencyEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jpa/CurrencyEntity.java
@@ -63,10 +63,6 @@ public class CurrencyEntity {
     @Column(name = "id")
     private Long id;
 
-    @Version
-    @Column(name = "version", nullable = false)
-    private Long version;
-
     /**
      * Код валюты (натуральный ключ).
      *

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/repository/adapter/CurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/repository/adapter/CurrencyRepositoryAdapter.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 
 /**
  * Адаптер доменного репозитория валют (в контексте Spring Data JPA).
+ *
+ * <p>Currency хранится как reference data, поэтому optimistic locking в этой feature не используется.</p>
  */
 @RequiredArgsConstructor
 public class CurrencyRepositoryAdapter implements CurrencyRepository {

--- a/backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260416_01__drop_currency_version.sql
+++ b/backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260416_01__drop_currency_version.sql
@@ -1,0 +1,3 @@
+-- Удаляем version у reference data валют: optimistic locking для currency не используется.
+ALTER TABLE currency
+    DROP COLUMN version;


### PR DESCRIPTION
### Motivation
- Currency является reference data и не требует optimistic locking, поэтому поле `version` и связанная логика усложняют persistence-модель без пользы.

### Description
- Удалено поле `version` и аннотация JPA `@Version` из `CurrencyEntity` (`backend/src/main/java/.../persistence/jpa/CurrencyEntity.java`).
- Добавлен короткий комментарий в адаптер `CurrencyRepositoryAdapter`, что в этой feature optimistic locking сознательно не используется (`backend/src/main/java/.../persistence/repository/adapter/CurrencyRepositoryAdapter.java`).
- Добавлена миграция Flyway `V20260416_01__drop_currency_version.sql`, которая удаляет колонку `version` из таблицы `currency` без изменения остальных ограничений (`backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260416_01__drop_currency_version.sql`).
- Проведён поиск по коду, чтобы не переносить `version` в domain/DTO/API и не оставлять зависимостей от optimistic locking в currency feature.

### Testing
- Выполнен поиск по коду (`rg`) на предмет `version`/`@Version` в рамках currency feature и подтверждена их отмена в JPA-слое для валюты.
- Попытка собрать модуль `backend` с пропуском jOOQ генерации командой `mvn -pl backend -DskipTests -Djooq.codegen.skip=true compile` завершилась неуспешно из-за проблем с доступом к Maven Central (HTTP 403), поэтому полная компиляция и регенерация jOOQ в текущем окружении не были подтверждены.
- Автоматические тесты не изменялись и не запускались в рамках этого PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e0b0f814832d92aee0cf2e587b08)