### PR TITLE
feat(currency): jOOQ-адаптер для CurrencyRepository и перенастройка wiring

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/persistence/repository/adapter/CurrencyRepositoryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/persistence/repository/adapter/CurrencyRepositoryWiringConfig.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.config.persistence.repository.adapter;
 
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jpa.CurrencyJpaRepository;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.repository.adapter.CurrencyRepositoryAdapter;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jooq.repository.JooqCurrencyRepositoryAdapter;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,7 +15,7 @@ public class CurrencyRepositoryWiringConfig {
     public static final String BEAN_CURRENCY_REPOSITORY = "currencyRepository";
 
     @Bean(BEAN_CURRENCY_REPOSITORY)
-    public CurrencyRepository currencyRepository(CurrencyJpaRepository jpaRepository) {
-        return new CurrencyRepositoryAdapter(jpaRepository);
+    public CurrencyRepository currencyRepository(DSLContext dsl) {
+        return new JooqCurrencyRepositoryAdapter(dsl);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
@@ -1,0 +1,159 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jooq.repository;
+
+import com.alligator.market.backend.common.persistence.jpa.constraint.DbErrors;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyAlreadyExistsException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNameDuplicateException;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.Currency;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.alligator.market.backend.infra.jooq.generated.tables.Currency.CURRENCY;
+
+/**
+ * jOOQ-адаптер доменного репозитория валют.
+ */
+public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
+
+    /* Имена UQ ограничений (должны совпадать с фактическими именами в DDL/схеме). */
+    private static final String UQ_CURRENCY_CODE = "uq_currency_code";
+    private static final String UQ_CURRENCY_NAME = "uq_currency_name";
+
+    /* DSLContext для выполнения SQL-запросов через jOOQ. */
+    private final DSLContext dsl;
+
+    public JooqCurrencyRepositoryAdapter(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    @Override
+    public Currency create(Currency currency) {
+        Objects.requireNonNull(currency, "currency must not be null");
+
+        /* Создаем новую запись валюты и маппим нарушения уникальности в application-ошибки. */
+        try {
+            Record createdRecord = dsl.insertInto(CURRENCY)
+                    .set(CURRENCY.CODE, currency.code().value())
+                    .set(CURRENCY.NAME, currency.name())
+                    .set(CURRENCY.COUNTRY, currency.country())
+                    .set(CURRENCY.FRACTION_DIGITS, currency.fractionDigits())
+                    .returning(
+                            CURRENCY.CODE,
+                            CURRENCY.NAME,
+                            CURRENCY.COUNTRY,
+                            CURRENCY.FRACTION_DIGITS
+                    )
+                    .fetchOne();
+
+            if (createdRecord == null) {
+                throw new IllegalStateException("Currency insert returned no row");
+            }
+
+            return toDomain(createdRecord);
+        } catch (DataIntegrityViolationException ex) {
+            if (DbErrors.isViolationOf(ex, UQ_CURRENCY_CODE)) {
+                throw new CurrencyAlreadyExistsException(currency.code());
+            }
+            if (DbErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
+                throw new CurrencyNameDuplicateException(currency.name());
+            }
+            throw ex;
+        } catch (DataAccessException ex) {
+            throw ex;
+        }
+    }
+
+    @Override
+    public Currency update(Currency currency) {
+        Objects.requireNonNull(currency, "currency must not be null");
+
+        /* Обновляем только изменяемые поля и возвращаем актуальную модель после update. */
+        try {
+            Optional<Record> updatedRecord = dsl.update(CURRENCY)
+                    .set(CURRENCY.NAME, currency.name())
+                    .set(CURRENCY.COUNTRY, currency.country())
+                    .set(CURRENCY.FRACTION_DIGITS, currency.fractionDigits())
+                    .where(CURRENCY.CODE.eq(currency.code().value()))
+                    .returning(
+                            CURRENCY.CODE,
+                            CURRENCY.NAME,
+                            CURRENCY.COUNTRY,
+                            CURRENCY.FRACTION_DIGITS
+                    )
+                    .fetchOptional();
+
+            return updatedRecord
+                    .map(this::toDomain)
+                    .orElseThrow(() -> new CurrencyNotFoundException(currency.code()));
+        } catch (DataIntegrityViolationException ex) {
+            if (DbErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
+                throw new CurrencyNameDuplicateException(currency.name());
+            }
+            throw ex;
+        } catch (DataAccessException ex) {
+            throw ex;
+        }
+    }
+
+    @Override
+    public void deleteByCode(CurrencyCode code) {
+        Objects.requireNonNull(code, "code must not be null");
+
+        /* Удаляем валюту по коду, отсутствие записи считаем бизнес-ошибкой. */
+        int deletedRows = dsl.deleteFrom(CURRENCY)
+                .where(CURRENCY.CODE.eq(code.value()))
+                .execute();
+
+        if (deletedRows == 0) {
+            throw new CurrencyNotFoundException(code);
+        }
+    }
+
+    @Override
+    public Optional<Currency> findByCode(CurrencyCode code) {
+        Objects.requireNonNull(code, "code must not be null");
+
+        return dsl.select(
+                        CURRENCY.CODE,
+                        CURRENCY.NAME,
+                        CURRENCY.COUNTRY,
+                        CURRENCY.FRACTION_DIGITS
+                )
+                .from(CURRENCY)
+                .where(CURRENCY.CODE.eq(code.value()))
+                .fetchOptional(this::toDomain);
+    }
+
+    @Override
+    public List<Currency> findAll() {
+        return dsl.select(
+                        CURRENCY.CODE,
+                        CURRENCY.NAME,
+                        CURRENCY.COUNTRY,
+                        CURRENCY.FRACTION_DIGITS
+                )
+                .from(CURRENCY)
+                .orderBy(CURRENCY.CODE.asc())
+                .fetch(this::toDomain);
+    }
+
+    /* Маппинг записи jOOQ в доменную модель Currency. */
+    private Currency toDomain(Record record) {
+        Objects.requireNonNull(record, "record must not be null");
+
+        return new Currency(
+                CurrencyCode.of(record.get(CURRENCY.CODE)),
+                record.get(CURRENCY.NAME),
+                record.get(CURRENCY.COUNTRY),
+                record.get(CURRENCY.FRACTION_DIGITS)
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Заменить реализацию порта `CurrencyRepository` на jOOQ-адаптер с использованием сгенерированной jOOQ-схемы для таблицы `currency`, сохранив прежнюю внешнюю семантику; оптимистическая блокировка больше не используется.

### Description
- Добавлен `JooqCurrencyRepositoryAdapter` в `backend/src/main/java/.../persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java`, реализующий `CurrencyRepository` и принимающий `DSLContext` в конструкторе.
- Реализованы методы порта `create`, `update`, `deleteByCode`, `findByCode` и `findAll` с прямым маппингом jOOQ `Record` → `Currency` через `CurrencyCode.of(...)` и без JPA-зависимостей.
- Обработаны ошибки уникальности через существующую утилиту `DbErrors.isViolationOf(...)`, маппинг ограничений: `uq_currency_code` → `CurrencyAlreadyExistsException`, `uq_currency_name` → `CurrencyNameDuplicateException`, а отсутствие записи в `update`/`deleteByCode` приводит к `CurrencyNotFoundException`.
- Обновлён `CurrencyRepositoryWiringConfig` для создания бина `CurrencyRepository` через `DSLContext` и `JooqCurrencyRepositoryAdapter` вместо JPA-адаптера (`backend/src/main/java/.../CurrencyRepositoryWiringConfig.java`).

### Testing
- Выполнена попытка сборки бэкенд-модуля командой `mvn -pl backend -am -DskipTests compile`, которая не завершилась успешно в этом окружении из-за ошибки разрешения внешних зависимостей (Maven Central вернул `403 Forbidden` при скачивании parent POM), поэтому автоматическая компиляция не прошла.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e42454b8832d9849d48735aca825)