### PR TITLE
Use jOOQ fetchOptional mapper to return Currency domain from update

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
@@ -77,7 +77,7 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
 
         /* Обновляем только изменяемые поля и возвращаем актуальную модель после update. */
         try {
-            Optional<Record> updatedRecord = dsl.update(CURRENCY)
+            Optional<Currency> updatedCurrency = dsl.update(CURRENCY)
                     .set(CURRENCY.NAME, currency.name())
                     .set(CURRENCY.COUNTRY, currency.country())
                     .set(CURRENCY.FRACTION_DIGITS, currency.fractionDigits())
@@ -88,10 +88,9 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
                             CURRENCY.COUNTRY,
                             CURRENCY.FRACTION_DIGITS
                     )
-                    .fetchOptional();
+                    .fetchOptional(this::toDomain);
 
-            return updatedRecord
-                    .map(this::toDomain)
+            return updatedCurrency
                     .orElseThrow(() -> new CurrencyNotFoundException(currency.code()));
         } catch (DataIntegrityViolationException ex) {
             if (DbErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {


### PR DESCRIPTION
### Motivation
- Simplify the `update` flow by mapping the jOOQ returning result directly to the domain `Currency` to remove a redundant mapping step.

### Description
- Replace `fetchOptional()` + `.map(this::toDomain)` on the jOOQ update with `fetchOptional(this::toDomain)` and adjust the local variable to `Optional<Currency>` so the update returns the domain object directly.

### Testing
- Ran the backend unit test suite with `./gradlew test` and repository integration tests; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e8f57764832da94f96b82ae8de87)