### PR TITLE
Развязать FX Spot от currency JPA, оставив FX Spot на JPA

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/jpa/FxSpotEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/jpa/FxSpotEntity.java
@@ -1,7 +1,6 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.jpa;
 
 import com.alligator.market.backend.instrument.base.catalog.persistence.jpa.InstrumentEntity;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jpa.CurrencyEntity;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.base.vo.InstrumentSymbol;
 import com.alligator.market.domain.instrument.base.classification.AssetClass;
@@ -70,44 +69,29 @@ import java.util.Objects;
 public class FxSpotEntity extends InstrumentEntity {
 
     /**
-     * Базовая валюта инструмента (FK на {@code currency.code}).
+     * Базовая валюта инструмента (FK на {@code currency.code} на уровне БД).
      *
      * <p>Ключевые моменты:</p>
      * <ul>
      *   <li>Поле задает неизменяемый атрибут инструмента, поэтому {@code updatable=false} и запрет
      *   на переназначение через сеттер {@link Setter}.</li>
-     *   <li>{@link ManyToOne}: связь по внешнему ключу (многие FOREX_SPOT могут ссылаться на одну валюту).</li>
-     *   <li>{@link JoinColumn}: FK-колонка {@code base_currency} ссылается на {@code currency.code}.</li>
-     *   <li>{@code fetch = LAZY}: валюту загружаем только при обращении к полю.</li>
-     *   <li>{@code optional = false}: ссылка обязательна.</li>
+     *   <li>Храним scalar-значение {@link CurrencyCode}, без {@code @ManyToOne} зависимости от currency-JPA модели.</li>
      * </ul>
      */
     @Setter(AccessLevel.NONE)
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "base_currency", referencedColumnName = "code",
-            foreignKey = @ForeignKey(name = "fk_fx_spot_base"),
-            nullable = false,
-            updatable = false
-    )
-    private CurrencyEntity baseCurrency;
+    @Column(name = "base_currency", nullable = false, updatable = false)
+    private CurrencyCode baseCurrencyCode;
 
     /**
-     * Котируемая валюта инструмента (FK на {@code currency.code}).
+     * Котируемая валюта инструмента (FK на {@code currency.code} на уровне БД).
      *
-     * <p>Ключевые моменты аналогичны {@link #baseCurrency}.</p>
+     * <p>Ключевые моменты аналогичны {@link #baseCurrencyCode}.</p>
      */
     @Setter(AccessLevel.NONE)
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "quote_currency", referencedColumnName = "code",
-            foreignKey = @ForeignKey(name = "fk_fx_spot_quote"),
-            nullable = false,
-            updatable = false
-    )
-    private CurrencyEntity quoteCurrency;
+    @Column(name = "quote_currency", nullable = false, updatable = false)
+    private CurrencyCode quoteCurrencyCode;
 
     /**
      * Тенор даты расчетов.
@@ -147,23 +131,20 @@ public class FxSpotEntity extends InstrumentEntity {
      * родительскую сущность финансового инструмента.</p>
      */
     public FxSpotEntity(
-            CurrencyEntity baseCurrency,
-            CurrencyEntity quoteCurrency,
+            CurrencyCode baseCurrencyCode,
+            CurrencyCode quoteCurrencyCode,
             FxSpotTenor tenor
     ) {
-        this.baseCurrency = Objects.requireNonNull(baseCurrency, "baseCurrency must not be null");
-        this.quoteCurrency = Objects.requireNonNull(quoteCurrency, "quoteCurrency must not be null");
+        this.baseCurrencyCode = Objects.requireNonNull(baseCurrencyCode, "baseCurrencyCode must not be null");
+        this.quoteCurrencyCode = Objects.requireNonNull(quoteCurrencyCode, "quoteCurrencyCode must not be null");
         this.tenor = Objects.requireNonNull(tenor, "tenor must not be null");
 
-        final CurrencyCode baseCode = baseCurrency.getCode();
-        final CurrencyCode quoteCode = quoteCurrency.getCode();
-
-        if (baseCode.equals(quoteCode)) {
+        if (baseCurrencyCode.equals(quoteCurrencyCode)) {
             throw new IllegalArgumentException("base and quote currencies must be different");
         }
 
-        final InstrumentSymbol symbol = FxSpotCodec.fxSpotSymbol(baseCode, quoteCode, tenor);
-        final InstrumentCode code = FxSpotCodec.fxSpotCode(baseCode, quoteCode, tenor);
+        final InstrumentSymbol symbol = FxSpotCodec.fxSpotSymbol(baseCurrencyCode, quoteCurrencyCode, tenor);
+        final InstrumentCode code = FxSpotCodec.fxSpotCode(baseCurrencyCode, quoteCurrencyCode, tenor);
 
         // Инициализируем родительскую сущность
         initIdentity(code, symbol, AssetClass.FOREX, ContractType.SPOT);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/jpa/FxSpotEntityMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/jpa/FxSpotEntityMapper.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.jpa;
 
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jpa.CurrencyEntity;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jpa.mapper.CurrencyEntityMapper;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 
@@ -22,17 +20,15 @@ public final class FxSpotEntityMapper {
     }
 
     /**
-     * Доменная модель + JPA-сущности валют -> JPA-сущность инструмента FOREX_SPOT.
+     * Доменная модель -> новая JPA-сущность инструмента FOREX_SPOT.
      */
-    public static FxSpotEntity toNewEntity(FxSpot model, CurrencyEntity baseEntity, CurrencyEntity quoteEntity) {
+    public static FxSpotEntity toNewEntity(FxSpot model) {
         Objects.requireNonNull(model, "FxSpot model must not be null");
-        Objects.requireNonNull(baseEntity, "entity of base currency must not be null");
-        Objects.requireNonNull(quoteEntity, "entity of quote currency must not be null");
 
         // Создаем JPA-сущность, используя специальный безопасный конструктор
         FxSpotEntity entity = new FxSpotEntity(
-                baseEntity,
-                quoteEntity,
+                model.base().code(),
+                model.quote().code(),
                 model.tenor()
         );
 
@@ -74,8 +70,8 @@ public final class FxSpotEntityMapper {
 
         // Собираем и возвращаем доменную модель
         return new FxSpot(
-                CurrencyEntityMapper.toDomain(e.getBaseCurrency()),
-                CurrencyEntityMapper.toDomain(e.getQuoteCurrency()),
+                e.getBaseCurrencyCode(),
+                e.getQuoteCurrencyCode(),
                 e.getTenor(),
                 digits
         );

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/jpa/FxSpotJpaRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/jpa/FxSpotJpaRepository.java
@@ -18,5 +18,5 @@ public interface FxSpotJpaRepository extends JpaRepository<FxSpotEntity, Long> {
     /**
      * Проверить, используется ли заданная валюта хотя бы в одном инструменте.
      */
-    boolean existsByBaseCurrency_CodeOrQuoteCurrency_Code(CurrencyCode baseCurrency, CurrencyCode quoteCurrency);
+    boolean existsByBaseCurrencyCodeOrQuoteCurrencyCode(CurrencyCode baseCurrency, CurrencyCode quoteCurrency);
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/catalog/persistence/repository/FxSpotRepositoryAdapter.java
@@ -1,8 +1,6 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.repository;
 
 import com.alligator.market.backend.common.persistence.jpa.constraint.DbErrors;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jpa.CurrencyEntity;
-import com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jpa.CurrencyJpaRepository;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.jpa.FxSpotEntity;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.jpa.FxSpotEntityMapper;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.jpa.FxSpotJpaRepository;
@@ -10,6 +8,7 @@ import com.alligator.market.domain.instrument.asset.forex.fxspot.exception.*;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;
 import jakarta.validation.ConstraintViolationException;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Objects;
@@ -26,29 +24,26 @@ import java.util.Optional;
 /**
  * Адаптер доменного репозитория инструментов FOREX_SPOT (в контексте Spring Data JPA).
  */
-@Repository
 @RequiredArgsConstructor
 public class FxSpotRepositoryAdapter implements FxSpotRepository {
 
     /* Имя UQ ограничения (должно совпадать с фактическим именем в DDL/схеме). */
     private static final String UQ_INSTRUMENT_CODE = "uq_instrument_code";
 
-    /* JPA-репозитории для инструментов FOREX_SPOT и валют. */
+    /* JPA-репозиторий FOREX_SPOT + доменный репозиторий валют для existence-check. */
     private final FxSpotJpaRepository jpaRepository;
-    private final CurrencyJpaRepository currencyJpaRepository;
+    private final CurrencyRepository currencyRepository;
 
     @Override
     public FxSpot create(FxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
-        // Ищем JPA-сущности составных валют (бизнес‑ошибки при отсутствии)
-        CurrencyEntity baseEntity = currencyJpaRepository.findByCode(fxSpot.base().code())
-                .orElseThrow(() -> new CurrencyNotFoundException(fxSpot.base().code()));
-        CurrencyEntity quoteEntity = currencyJpaRepository.findByCode(fxSpot.quote().code())
-                .orElseThrow(() -> new CurrencyNotFoundException(fxSpot.quote().code()));
+        // Проверяем существование составных валют (бизнес‑ошибки при отсутствии)
+        ensureCurrencyExists(fxSpot.base().code());
+        ensureCurrencyExists(fxSpot.quote().code());
 
         // Создаем JPA-сущность, используя специальный метод
-        FxSpotEntity entity = FxSpotEntityMapper.toNewEntity(fxSpot, baseEntity, quoteEntity);
+        FxSpotEntity entity = FxSpotEntityMapper.toNewEntity(fxSpot);
 
         // Пробуем сохранить созданную сущность и маппим наиболее вероятные ошибки
         try {
@@ -138,6 +133,14 @@ public class FxSpotRepositoryAdapter implements FxSpotRepository {
     public boolean existsByCurrencyCode(CurrencyCode currencyCode) {
         Objects.requireNonNull(currencyCode, "currencyCode must not be null");
 
-        return jpaRepository.existsByBaseCurrency_CodeOrQuoteCurrency_Code(currencyCode, currencyCode);
+        return jpaRepository.existsByBaseCurrencyCodeOrQuoteCurrencyCode(currencyCode, currencyCode);
+    }
+
+    /* Проверяет наличие валюты в reference-справочнике. */
+    private void ensureCurrencyExists(CurrencyCode code) {
+        Objects.requireNonNull(code, "currency code must not be null");
+        if (currencyRepository.findByCode(code).isEmpty()) {
+            throw new CurrencyNotFoundException(code);
+        }
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/persistence/repository/adapter/FxSpotRepositoryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/persistence/repository/adapter/FxSpotRepositoryWiringConfig.java
@@ -1,0 +1,25 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.config.persistence.repository.adapter;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.jpa.FxSpotJpaRepository;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.catalog.persistence.repository.FxSpotRepositoryAdapter;
+import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.repository.CurrencyRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring-конфигурация {@link FxSpotRepository}.
+ */
+@Configuration(proxyBeanMethods = false)
+public class FxSpotRepositoryWiringConfig {
+
+    public static final String BEAN_FX_SPOT_REPOSITORY = "fxSpotRepository";
+
+    @Bean(BEAN_FX_SPOT_REPOSITORY)
+    public FxSpotRepository fxSpotRepository(
+            FxSpotJpaRepository fxSpotJpaRepository,
+            CurrencyRepository currencyRepository
+    ) {
+        return new FxSpotRepositoryAdapter(fxSpotJpaRepository, currencyRepository);
+    }
+}


### PR DESCRIPTION
### Motivation
- Убрать жёсткую зависимость FX Spot от JPA-модели валюты, чтобы feature `currency` можно было переводить на jOOQ независимо от FX Spot. 
- Сохранить текущее поведение FX Spot (JPA-персистенс, идентичность, валидации, DB-ключи) без изменения схемы таблицы `instrument_fx_spot`.

### Description
- В `FxSpotEntity` удалены поля `CurrencyEntity` и `@ManyToOne`; добавлены scalar-поля `baseCurrencyCode` и `quoteCurrencyCode` типа `CurrencyCode` с маппингом на те же колонки `base_currency` и `quote_currency` и свойствами `nullable = false`, `updatable = false`, а конструктор теперь принимает `CurrencyCode` и сохраняет логику `FxSpotCodec` и проверку `base != quote` (`FxSpotEntity`).
- `FxSpotEntityMapper` упрощён: создание entity теперь строится напрямую из доменной модели `FxSpot` (`toNewEntity` принимает только `FxSpot`), а `toDomain` собирает доменную модель из scalar-кодов вместо `CurrencyEntity` (`FxSpotEntityMapper`).
- `FxSpotRepositoryAdapter` убрал зависимость от `CurrencyJpaRepository`; перед `create` выполняется явная проверка существования валют через доменный `CurrencyRepository` и при отсутствии выбрасывается `CurrencyNotFoundException`, создание сущности идёт через обновлённый mapper без загрузки `CurrencyEntity` (`FxSpotRepositoryAdapter`).
- Переименован derived-метод в `FxSpotJpaRepository` для соответствия новым полям: `existsByBaseCurrencyCodeOrQuoteCurrencyCode(...)`.
- Добавлена явная wiring-конфигурация `FxSpotRepositoryWiringConfig`, которая создаёт `FxSpotRepositoryAdapter` с зависимостями `FxSpotJpaRepository` и `CurrencyRepository`, чтобы новая бизнес-зависимость была подключена явно.

### Testing
- Выполнены попытки собрать проект: `./mvnw -q -DskipTests compile` завершился ошибкой загрузки Maven Wrapper (невозможно скачать дистрибутив в среде). 
- Системная сборка `mvn -q -DskipTests compile` завершилась ошибкой разрешения parent POM (HTTP 403 от Maven Central), поэтому полная компиляция/CI-проверки не были завершены. 
- Unit- и интеграционные тесты запускались не были из-за проблем с разрешением зависимостей в среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fdb2e680832d9f167bd533accf8b)