### PR TITLE
Убрать версионирование для instrument_base

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/base/catalog/persistence/jpa/InstrumentEntity.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/base/catalog/persistence/jpa/InstrumentEntity.java
@@ -49,10 +49,6 @@ public abstract class InstrumentEntity {
     @Column(name = "id")
     private Long id;
 
-    @Version
-    @Column(name = "version", nullable = false)
-    private Long version;
-
     /**
      * Внутренний код инструмента (идентификатор).
      */

--- a/backend/src/main/resources/db/migration/instrument/base/V20260418_01__drop_instrument_base_version.sql
+++ b/backend/src/main/resources/db/migration/instrument/base/V20260418_01__drop_instrument_base_version.sql
@@ -1,0 +1,3 @@
+-- Удаляем version у instrument_base: optimistic locking для инструментов не используется.
+ALTER TABLE instrument_base
+    DROP COLUMN version;


### PR DESCRIPTION
### Motivation
- Отказ от optimistic locking для базовой сущности инструментов: версионирование поля `version` не используется для `instrument_base` и должно быть удалено на уровне кода и БД.

### Description
- Удалено поле `version` и аннотация `@Version` из JPA-сущности `backend/src/main/java/com/alligator/market/backend/instrument/base/catalog/persistence/jpa/InstrumentEntity.java`.
- Добавлена миграция Flyway `backend/src/main/resources/db/migration/instrument/base/V20260418_01__drop_instrument_base_version.sql`, которая выполняет `ALTER TABLE instrument_base DROP COLUMN version;`.
- Синхронизировал модель и схему базы данных, чтобы избежать расхождений между JPA-entity и реальной таблицей.

### Testing
- Попытка скомпилировать модуль бэкенда командой `mvn -pl backend -DskipTests compile` была выполнена, но завершилась ошибкой разрешения зависимостей из инфраструктурной причины (Maven Central вернул HTTP 403 при скачивании `org.springframework.boot:spring-boot-starter-parent:4.0.5`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e351dc6884832d9f415d0d08191c05)