### PR TITLE
Синхронизация jOOQ и sourcing на instrument_registry

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -127,7 +127,7 @@
                                     <includes>
                                         (?x)
                                         (
-                                            | instrument_base
+                                            | instrument_registry
                                             | instrument_source_plan
                                             | instrument_market_data_source
                                             | provider_passport

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/port/adapter/JooqInstrumentCodeExistenceAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/port/adapter/JooqInstrumentCodeExistenceAdapter.java
@@ -6,7 +6,7 @@ import org.jooq.DSLContext;
 
 import java.util.Objects;
 
-import static com.alligator.market.backend.infra.jooq.generated.tables.InstrumentBase.INSTRUMENT_BASE;
+import static com.alligator.market.backend.infra.jooq.generated.tables.InstrumentRegistry.INSTRUMENT_REGISTRY;
 
 /**
  * jOOQ-адаптер порта проверки существования инструмента.
@@ -25,8 +25,8 @@ public final class JooqInstrumentCodeExistenceAdapter implements InstrumentCodeE
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         return dsl.fetchExists(
-                dsl.selectFrom(INSTRUMENT_BASE)
-                        .where(INSTRUMENT_BASE.CODE.eq(instrumentCode.value()))
+                dsl.selectFrom(INSTRUMENT_REGISTRY)
+                        .where(INSTRUMENT_REGISTRY.CODE.eq(instrumentCode.value()))
         );
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/adapter/JooqInstrumentOptionsQueryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/options/adapter/JooqInstrumentOptionsQueryAdapter.java
@@ -7,7 +7,7 @@ import org.jooq.DSLContext;
 import java.util.List;
 import java.util.Objects;
 
-import static com.alligator.market.backend.infra.jooq.generated.tables.InstrumentBase.INSTRUMENT_BASE;
+import static com.alligator.market.backend.infra.jooq.generated.tables.InstrumentRegistry.INSTRUMENT_REGISTRY;
 
 /**
  * jOOQ-адаптер порта получения доступных кодов инструментов.
@@ -23,10 +23,10 @@ public final class JooqInstrumentOptionsQueryAdapter implements InstrumentOption
 
     @Override
     public List<InstrumentCode> findAllInstrumentCodes() {
-        return dsl.select(INSTRUMENT_BASE.CODE)
-                .from(INSTRUMENT_BASE)
-                .orderBy(INSTRUMENT_BASE.CODE.asc())
-                .fetch(INSTRUMENT_BASE.CODE)
+        return dsl.select(INSTRUMENT_REGISTRY.CODE)
+                .from(INSTRUMENT_REGISTRY)
+                .orderBy(INSTRUMENT_REGISTRY.CODE.asc())
+                .fetch(INSTRUMENT_REGISTRY.CODE)
                 .stream()
                 .map(InstrumentCode::new)
                 .toList();


### PR DESCRIPTION
### Motivation

- Необходимо перевести jOOQ-генерацию и sourcing-адаптеры с таблицы `instrument_base` на новую `instrument_registry` после миграции схемы базы данных.

### Description

- Обновлён jOOQ generation config в `backend/pom.xml` — в секции `<includes>` заменён `instrument_base` на `instrument_registry` и остальные таблицы оставлены без изменений.
- Переведены адаптеры sourcing: в `JooqInstrumentCodeExistenceAdapter` заменён static import на `InstrumentRegistry.INSTRUMENT_REGISTRY` и запрос изменён на `selectFrom(INSTRUMENT_REGISTRY).where(INSTRUMENT_REGISTRY.CODE.eq(...))`.
- Переведён `JooqInstrumentOptionsQueryAdapter` на `InstrumentRegistry` с изменением static import и запроса на `dsl.select(INSTRUMENT_REGISTRY.CODE).from(INSTRUMENT_REGISTRY).orderBy(INSTRUMENT_REGISTRY.CODE.asc()).fetch(INSTRUMENT_REGISTRY.CODE)`.
- Логика и имена классов не менялись и ручное редактирование сгенерированных источников не выполнялось.

### Testing

- Запуск jOOQ generation через Maven `mvn -pl backend -DskipTests generate-sources` был выполнен в CI-окружении, но завершился с ошибкой разрешения внешних зависимостей из-за недоступности `org.springframework.boot:spring-boot-starter-parent:4.0.5` (HTTP 403), поэтому генерацию в этом окружении подтвердить не удалось.
- Проверка поиска по коду `rg -n "generated\.tables\.InstrumentBase" backend/src/main/java` подтвердила отсутствие оставшихся ссылок на `InstrumentBase` в `backend/src/main/java`.
- Статически проверено, что адаптеры теперь импортируют и используют `InstrumentRegistry` вместо `InstrumentBase` (просмотр изменённых файлов).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37159848c832da671ba6679fc425b)