### PR TITLE
Переименовать instrument_market_data_source в market_data_source

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -129,7 +129,7 @@
                                         (
                                             | instrument_registry
                                             | instrument_source_plan
-                                            | instrument_market_data_source
+                                            | market_data_source
                                             | provider_passport
                                             | currency
                                         )

--- a/backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_market_data_source.sql
+++ b/backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_market_data_source.sql
@@ -1,5 +1,5 @@
--- instrument_market_data_source: источники рыночных данных для конкретного инструмента.
-CREATE TABLE instrument_market_data_source
+-- market_data_source: источники рыночных данных для конкретного инструмента.
+CREATE TABLE market_data_source
 (
     -- Суррогатный PK
     id              BIGSERIAL   PRIMARY KEY,
@@ -11,15 +11,15 @@ CREATE TABLE instrument_market_data_source
     priority        INTEGER     NOT NULL,
 
     -- Ограничения ссылочной целостности
-    CONSTRAINT fk_instr_market_data_source_plan
+    CONSTRAINT fk_market_data_source_plan
         FOREIGN KEY (instrument_code)
             REFERENCES instrument_source_plan (instrument_code)
             ON DELETE CASCADE,
 
     -- Ограничения уникальности
-    CONSTRAINT uk_instr_market_data_source_instr_provider UNIQUE (instrument_code, provider_code),
-    CONSTRAINT uk_instr_market_data_source_instr_priority UNIQUE (instrument_code, priority),
+    CONSTRAINT uk_market_data_source_instr_provider UNIQUE (instrument_code, provider_code),
+    CONSTRAINT uk_market_data_source_instr_priority UNIQUE (instrument_code, priority),
 
     -- Ограничения доменной валидности
-    CONSTRAINT chk_instr_market_data_source_priority CHECK (priority >= 0)
+    CONSTRAINT chk_market_data_source_priority CHECK (priority >= 0)
 );


### PR DESCRIPTION
### Motivation
- Упростить и стандартизировать имя таблицы для источников рыночных данных, избежав префиксных дублей в схеме базы данных.
- Обновить конфигурацию генерации jOOQ, чтобы соответствовать новому имени таблицы и поддерживать корректную генерацию кода.

### Description
- Переименована миграция создания таблицы в `backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_market_data_source.sql` и изменён `CREATE TABLE` с `instrument_market_data_source` на `market_data_source`.
- Переименованы сопутствующие ограничения в миграции с префикса `instr_market_data_source` на `market_data_source` (`fk`, `uk`, `chk`).
- Обновлён список таблиц для генерации jOOQ в `backend/pom.xml`, заменив `instrument_market_data_source` на `market_data_source`.
- Старая миграция файл был удалён/переименован в ходе изменений (фактический файл миграции теперь `V20260407_02__create_market_data_source.sql`).

### Testing
- Запущена команда `mvn -q -DskipTests compile` в каталоге `backend`, но сборка не завершилась успешно из-за невозможности разрешить parent POM `org.springframework.boot:spring-boot-starter-parent:4.0.5` (HTTP 403 от Maven Central), поэтому полная валидация сборки не прошла.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e377868f84832da52724b860f14edf)