### PR TITLE
refactor(backend): перенести пакет passport в корень provider

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/passport/config/PassportCatalogServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/passport/config/PassportCatalogServiceWiringConfig.java
@@ -1,7 +1,7 @@
-package com.alligator.market.backend.provider.catalog.passport.config;
+package com.alligator.market.backend.provider.passport.config;
 
-import com.alligator.market.backend.provider.catalog.passport.service.PassportCatalogService;
-import com.alligator.market.backend.provider.catalog.passport.service.PassportCatalogServiceImpl;
+import com.alligator.market.backend.provider.passport.service.PassportCatalogService;
+import com.alligator.market.backend.provider.passport.service.PassportCatalogServiceImpl;
 import com.alligator.market.backend.provider.readmodel.passport.config.query.ProviderPassportQueryPortWiringConfig;
 import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/backend/src/main/java/com/alligator/market/backend/provider/passport/service/PassportCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/passport/service/PassportCatalogService.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.catalog.passport.service;
+package com.alligator.market.backend.provider.passport.service;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;

--- a/backend/src/main/java/com/alligator/market/backend/provider/passport/service/PassportCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/passport/service/PassportCatalogServiceImpl.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.catalog.passport.service;
+package com.alligator.market.backend.provider.passport.service;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;

--- a/backend/src/main/java/com/alligator/market/backend/provider/passport/web/PassportController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/passport/web/PassportController.java
@@ -1,10 +1,10 @@
-package com.alligator.market.backend.provider.catalog.passport.web;
+package com.alligator.market.backend.provider.passport.web;
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
-import com.alligator.market.backend.provider.catalog.passport.service.PassportCatalogService;
-import com.alligator.market.backend.provider.catalog.passport.web.dto.out.PassportResponseDto;
-import com.alligator.market.backend.provider.catalog.passport.web.dto.mapper.PassportDtoMapper;
+import com.alligator.market.backend.provider.passport.service.PassportCatalogService;
+import com.alligator.market.backend.provider.passport.web.dto.out.PassportResponseDto;
+import com.alligator.market.backend.provider.passport.web.dto.mapper.PassportDtoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/alligator/market/backend/provider/passport/web/dto/mapper/PassportDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/passport/web/dto/mapper/PassportDtoMapper.java
@@ -1,6 +1,6 @@
-package com.alligator.market.backend.provider.catalog.passport.web.dto.mapper;
+package com.alligator.market.backend.provider.passport.web.dto.mapper;
 
-import com.alligator.market.backend.provider.catalog.passport.web.dto.out.PassportResponseDto;
+import com.alligator.market.backend.provider.passport.web.dto.out.PassportResponseDto;
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/passport/web/dto/out/PassportResponseDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/passport/web/dto/out/PassportResponseDto.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.catalog.passport.web.dto.out;
+package com.alligator.market.backend.provider.passport.web.dto.out;
 
 /**
  * DTO для передачи паспорта провайдера (out).


### PR DESCRIPTION
### Motivation
- Упростить структуру пакетов, переместив пакет `passport` из `provider/catalog/passport` в `provider/passport` и убрать лишний уровень `catalog`.

### Description
- Перенесены файлы из `backend/src/main/java/com/alligator/market/backend/provider/catalog/passport` в `backend/src/main/java/com/alligator/market/backend/provider/passport` (6 Java-файлов). 
- Обновлены объявления пакетов и внутренние `import`-пути с `com.alligator.market.backend.provider.catalog.passport...` на `com.alligator.market.backend.provider.passport...` в перенесённых классах. 
- Удалён пустой каталог `provider/catalog` после перемещения, вносящих изменений в логику кода не было. 

### Testing
- Попытка выполнить `./mvnw -pl backend -DskipTests compile` завершилась неудачей в окружении из-за ошибки загрузки дистрибутива Maven (`Failed to fetch apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38ab449c4832da5e09ce65c89cd12)