### PR TITLE
refactor: преобразовать InstrumentHandler в provider-facing SPI ProviderManagedInstrumentHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss;
 
 import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.provider.AbstractMarketDataProvider;
-import com.alligator.market.domain.provider.handler.AbstractInstrumentHandler;
+import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
 import com.alligator.market.domain.provider.vo.ProviderCode;
 import com.alligator.market.domain.provider.passport.AccessMethod;
 import com.alligator.market.domain.provider.passport.DeliveryMode;
@@ -38,7 +38,7 @@ public final class MoexIssProvider extends AbstractMarketDataProvider<MoexIssPro
      * @param handlers набор обработчиков инструментов
      */
     public MoexIssProvider(
-            Set<? extends AbstractInstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
+            Set<? extends ProviderManagedInstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
     ) {
         super(PROVIDER_CODE, PASSPORT, POLICY, handlers);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssProviderConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssProviderConfig.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss.config;
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.handlers.MoexIssHandlersConfig;
 import com.alligator.market.domain.instrument.base.Instrument;
-import com.alligator.market.domain.provider.handler.AbstractInstrumentHandler;
+import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +28,7 @@ public class MoexIssProviderConfig {
     @Bean(BEAN_NAME)
     public MoexIssProvider moexIssProvider(
             @Qualifier(MoexIssHandlersConfig.BEAN_NAME)
-            Set<AbstractInstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
+            Set<ProviderManagedInstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
     ) {
         return new MoexIssProvider(handlers);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/handlers/MoexIssHandlersConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/handlers/MoexIssHandlersConfig.java
@@ -4,7 +4,7 @@ import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.instrument.forex.spot.handler.MoexIssFxSpotHandlerConfig;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.handler.MoexIssFxSpotHandler;
 import com.alligator.market.domain.instrument.base.Instrument;
-import com.alligator.market.domain.provider.handler.AbstractInstrumentHandler;
+import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -29,7 +29,7 @@ public class MoexIssHandlersConfig {
      * @param fxSpotHandler обработчик инструмента FOREX_SPOT
      */
     @Bean(BEAN_NAME)
-    public Set<AbstractInstrumentHandler<MoexIssProvider, ? extends Instrument>> moexIssHandlers(
+    public Set<ProviderManagedInstrumentHandler<MoexIssProvider, ? extends Instrument>> moexIssHandlers(
             MoexIssFxSpotHandler fxSpotHandler
             // + другие *Handler по мере добавления
     ) {

--- a/domain/src/main/java/com/alligator/market/domain/provider/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/AbstractMarketDataProvider.java
@@ -3,7 +3,7 @@ package com.alligator.market.domain.provider;
 import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.provider.handler.exception.HandlerNotFoundException;
-import com.alligator.market.domain.provider.handler.InstrumentHandler;
+import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.vo.HandlerCode;
@@ -29,7 +29,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
     protected final ProviderPolicy policy;
 
     /* Карта "код инструмента → обработчик инструмента". */
-    private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentHandlerMap;
+    private final Map<InstrumentCode, ProviderManagedInstrumentHandler<P, ? extends Instrument>> instrumentHandlerMap;
 
     /**
      * F-bounded полиморфизм: возвращает текущий экземпляр провайдера в его конкретном дженерик-типе {@code P}.
@@ -53,7 +53,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
             ProviderCode providerCode,
             ProviderPassport passport,
             ProviderPolicy policy,
-            Set<? extends InstrumentHandler<P, ? extends Instrument>> handlers
+            Set<? extends ProviderManagedInstrumentHandler<P, ? extends Instrument>> handlers
     ) {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(passport, "passport must not be null");
@@ -72,7 +72,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         this.instrumentHandlerMap = buildInstrumentHandlerMap(providerCode, handlers);
 
         // Прикрепляем обработчики к провайдеру
-        for (InstrumentHandler<P, ? extends Instrument> h : handlers) {
+        for (ProviderManagedInstrumentHandler<P, ? extends Instrument> h : handlers) {
             h.attachTo(self());
         }
     }
@@ -101,7 +101,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         Objects.requireNonNull(instrument, "instrument must not be null");
 
         // Находим обработчик (или бросаем исключение)
-        InstrumentHandler<P, I> handler = findHandlerOrThrow(instrument);
+        ProviderManagedInstrumentHandler<P, I> handler = findHandlerOrThrow(instrument);
 
         // Делегируем вызов обработчику
         return handler.quote(instrument);
@@ -118,18 +118,18 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
      * @param handlers     набор обработчиков
      * @return неизменяемую карту
      */
-    private static <P extends MarketDataProvider> Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>>
+    private static <P extends MarketDataProvider> Map<InstrumentCode, ProviderManagedInstrumentHandler<P, ? extends Instrument>>
     buildInstrumentHandlerMap(
             ProviderCode providerCode,
-            Set<? extends InstrumentHandler<P, ? extends Instrument>> handlers
+            Set<? extends ProviderManagedInstrumentHandler<P, ? extends Instrument>> handlers
     ) {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(handlers, "handlers must not be null");
 
-        Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> map = new LinkedHashMap<>();
+        Map<InstrumentCode, ProviderManagedInstrumentHandler<P, ? extends Instrument>> map = new LinkedHashMap<>();
         Set<HandlerCode> handlerCodes = new HashSet<>();
 
-        for (InstrumentHandler<P, ? extends Instrument> h : handlers) {
+        for (ProviderManagedInstrumentHandler<P, ? extends Instrument> h : handlers) {
             Objects.requireNonNull(h, "handler must not be null");
 
             HandlerCode handlerCode = Objects.requireNonNull(h.handlerCode(), "handlerCode must not be null");
@@ -144,7 +144,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
             for (InstrumentCode instrumentCode : codes) {
                 Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
-                InstrumentHandler<P, ? extends Instrument> prev = map.putIfAbsent(instrumentCode, h);
+                ProviderManagedInstrumentHandler<P, ? extends Instrument> prev = map.putIfAbsent(instrumentCode, h);
                 if (prev != null) {
                     throw new IllegalStateException("Provider '" + providerCode.value() +
                             "' contains instrument code '" + instrumentCode.value() +
@@ -161,14 +161,14 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
      * Ищет обработчик инструмента или бросает исключение.
      */
     @SuppressWarnings("unchecked")
-    protected final <I extends Instrument> InstrumentHandler<P, I> findHandlerOrThrow(I instrument) {
+    protected final <I extends Instrument> ProviderManagedInstrumentHandler<P, I> findHandlerOrThrow(I instrument) {
         Objects.requireNonNull(instrument, "instrument must not be null");
 
         InstrumentCode code = Objects.requireNonNull(instrument.instrumentCode(),
                 "instrumentCode must not be null");
 
-        InstrumentHandler<P, I> handler =
-                (InstrumentHandler<P, I>) instrumentHandlerMap.get(code);
+        ProviderManagedInstrumentHandler<P, I> handler =
+                (ProviderManagedInstrumentHandler<P, I>) instrumentHandlerMap.get(code);
 
         if (handler == null) {
             throw new HandlerNotFoundException(code, providerCode);

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
@@ -15,10 +15,10 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Обработчик финансового инструмента.
+ * Базовая реализация внутреннего SPI обработчика инструмента.
  */
 public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
-        implements InstrumentHandler<P, I> {
+        implements ProviderManagedInstrumentHandler<P, I> {
 
     /* Код обработчика. */
     private final HandlerCode handlerCode;
@@ -70,13 +70,11 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
         return handlerCode;
     }
 
-    @Override
-    public final AssetClass assetClass() {
+    protected final AssetClass assetClass() {
         return assetClass;
     }
 
-    @Override
-    public final ContractType contractType() {
+    protected final ContractType contractType() {
         return contractType;
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/ProviderManagedInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/ProviderManagedInstrumentHandler.java
@@ -1,8 +1,6 @@
 package com.alligator.market.domain.provider.handler;
 
 import com.alligator.market.domain.instrument.base.Instrument;
-import com.alligator.market.domain.instrument.base.classification.AssetClass;
-import com.alligator.market.domain.instrument.base.classification.ContractType;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.provider.MarketDataProvider;
 import com.alligator.market.domain.provider.vo.HandlerCode;
@@ -12,9 +10,11 @@ import org.reactivestreams.Publisher;
 import java.util.Set;
 
 /**
- * Доменный контракт обработчика финансового инструмента.
+ * Внутренний SPI обработчика инструмента, управляемого провайдером.
+ *
+ * <p>Важно: это provider-facing контракт и не внешний доменный API.</p>
  */
-public interface InstrumentHandler<P extends MarketDataProvider, I extends Instrument> {
+public interface ProviderManagedInstrumentHandler<P extends MarketDataProvider, I extends Instrument> {
 
     /**
      * Уникальный код обработчика (идентификатор).
@@ -22,19 +22,14 @@ public interface InstrumentHandler<P extends MarketDataProvider, I extends Instr
     HandlerCode handlerCode();
 
     /**
-     * Класс актива поддерживаемых инструментов.
-     */
-    AssetClass assetClass();
-
-    /**
-     * Тип контракта поддерживаемых инструментов.
-     */
-    ContractType contractType();
-
-    /**
      * Коды поддерживаемых инструментов.
      */
     Set<InstrumentCode> supportedInstrumentCodes();
+
+    /**
+     * Прикрепляет обработчик к провайдеру.
+     */
+    void attachTo(P provider);
 
     /**
      * Поток котировок для заданного инструмента.


### PR DESCRIPTION
### Motivation
- Сохранить существующий интерфейс обработчика, но пересмотреть его семантику: это не внешний доменный контракт, а внутренний provider-facing SPI.
- Обеспечить, чтобы `AbstractMarketDataProvider` зависел от SPI, а не от конкретной абстрактной реализации обработчика.
- Сохранять текущее поведение `quote(...)` и lifecycle (`attachTo`) без изменений.

### Description
- Переименован `InstrumentHandler` → `ProviderManagedInstrumentHandler` и файл перемещён в `domain/src/main/java/com/alligator/market/domain/provider/handler/ProviderManagedInstrumentHandler.java`, JavaDoc обновлён чтобы явно указать, что это внутренний provider-facing SPI.
- Суже�� интерфейс SPI: оставлены только `handlerCode()`, `supportedInstrumentCodes()`, `attachTo(P provider)` и `quote(I instrument)`; удалены `assetClass()` и `contractType()` из интерфейса.
- `AbstractInstrumentHandler` теперь реализует `ProviderManagedInstrumentHandler`, сохранил публичные финальные методы `handlerCode()`, `supportedInstrumentCodes()`, `attachTo(...)`, `quote(...)`, а `assetClass()` и `contractType()` сделаны `protected final` как внутренняя конфигурация и валидационная механика.
- `AbstractMarketDataProvider` обновлён для использования `ProviderManagedInstrumentHandler` во всех generics/картах/поиске обработчика; логика сборки карты, проверки инвариантов, `attachTo(self())` и делегирование `quote(...)` оставлены без изменений.
- Обновлена проводка/конфигурация провайдера MOEX ISS (`MoexIssProvider`, `MoexIssProviderConfig`, `MoexIssHandlersConfig`) на зависимость от SPI вместо `AbstractInstrumentHandler` и исправлены соответствующие импорты/дженерики.

### Testing
- Запуск `./mvnw test` не прошёл в этом окружении из-за невозможности скачать bootstrap Maven (ошибка при загрузке из Maven Central).
- Запуск `mvn test` (системный Maven) завершился ошибкой разрешения parent POM из Maven Central (HTTP 403), поэтому модульные/интеграционные тесты не были выполнены.
- Локальные статические проверки: проект файлы и ссылки по коду обновлены (импорты и generics), предупреждений компиляции связанных с `InstrumentHandler` в тексте изменений сейчас не обнаружено по обходному анализу кода.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e0187c88832d9ecd06282c225f4b)