### PR TITLE
Rename ProviderManagedInstrumentHandler to InstrumentHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss;
 
 import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.provider.AbstractMarketDataProvider;
-import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
+import com.alligator.market.domain.provider.handler.InstrumentHandler;
 import com.alligator.market.domain.provider.vo.ProviderCode;
 import com.alligator.market.domain.provider.passport.AccessMethod;
 import com.alligator.market.domain.provider.passport.DeliveryMode;
@@ -38,7 +38,7 @@ public final class MoexIssProvider extends AbstractMarketDataProvider<MoexIssPro
      * @param handlers набор обработчиков инструментов
      */
     public MoexIssProvider(
-            Set<? extends ProviderManagedInstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
+            Set<? extends InstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
     ) {
         super(PROVIDER_CODE, PASSPORT, POLICY, handlers);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssProviderConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/MoexIssProviderConfig.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss.config;
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.handlers.MoexIssHandlersConfig;
 import com.alligator.market.domain.instrument.base.Instrument;
-import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
+import com.alligator.market.domain.provider.handler.InstrumentHandler;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +28,7 @@ public class MoexIssProviderConfig {
     @Bean(BEAN_NAME)
     public MoexIssProvider moexIssProvider(
             @Qualifier(MoexIssHandlersConfig.BEAN_NAME)
-            Set<ProviderManagedInstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
+            Set<InstrumentHandler<MoexIssProvider, ? extends Instrument>> handlers
     ) {
         return new MoexIssProvider(handlers);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/handlers/MoexIssHandlersConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/config/handlers/MoexIssHandlersConfig.java
@@ -4,7 +4,7 @@ import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.config.instrument.forex.spot.handler.MoexIssFxSpotHandlerConfig;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.handler.MoexIssFxSpotHandler;
 import com.alligator.market.domain.instrument.base.Instrument;
-import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
+import com.alligator.market.domain.provider.handler.InstrumentHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -29,7 +29,7 @@ public class MoexIssHandlersConfig {
      * @param fxSpotHandler обработчик инструмента FOREX_SPOT
      */
     @Bean(BEAN_NAME)
-    public Set<ProviderManagedInstrumentHandler<MoexIssProvider, ? extends Instrument>> moexIssHandlers(
+    public Set<InstrumentHandler<MoexIssProvider, ? extends Instrument>> moexIssHandlers(
             MoexIssFxSpotHandler fxSpotHandler
             // + другие *Handler по мере добавления
     ) {

--- a/domain/src/main/java/com/alligator/market/domain/provider/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/AbstractMarketDataProvider.java
@@ -3,7 +3,7 @@ package com.alligator.market.domain.provider;
 import com.alligator.market.domain.instrument.base.Instrument;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.provider.handler.exception.HandlerNotFoundException;
-import com.alligator.market.domain.provider.handler.ProviderManagedInstrumentHandler;
+import com.alligator.market.domain.provider.handler.InstrumentHandler;
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.policy.ProviderPolicy;
 import com.alligator.market.domain.provider.vo.HandlerCode;
@@ -29,7 +29,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
     protected final ProviderPolicy policy;
 
     /* Карта "код инструмента → обработчик инструмента". */
-    private final Map<InstrumentCode, ProviderManagedInstrumentHandler<P, ? extends Instrument>> instrumentHandlerMap;
+    private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentHandlerMap;
 
     /**
      * F-bounded полиморфизм: возвращает текущий экземпляр провайдера в его конкретном дженерик-типе {@code P}.
@@ -53,7 +53,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
             ProviderCode providerCode,
             ProviderPassport passport,
             ProviderPolicy policy,
-            Set<? extends ProviderManagedInstrumentHandler<P, ? extends Instrument>> handlers
+            Set<? extends InstrumentHandler<P, ? extends Instrument>> handlers
     ) {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(passport, "passport must not be null");
@@ -72,7 +72,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         this.instrumentHandlerMap = buildInstrumentHandlerMap(providerCode, handlers);
 
         // Прикрепляем обработчики к провайдеру
-        for (ProviderManagedInstrumentHandler<P, ? extends Instrument> h : handlers) {
+        for (InstrumentHandler<P, ? extends Instrument> h : handlers) {
             h.attachTo(self());
         }
     }
@@ -101,7 +101,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         Objects.requireNonNull(instrument, "instrument must not be null");
 
         // Находим обработчик (или бросаем исключение)
-        ProviderManagedInstrumentHandler<P, I> handler = findHandlerOrThrow(instrument);
+        InstrumentHandler<P, I> handler = findHandlerOrThrow(instrument);
 
         // Делегируем запрос котировки обработчику
         return handler.quote(instrument);
@@ -118,18 +118,18 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
      * @param handlers     набор обработчиков
      * @return неизменяемую карту
      */
-    private static <P extends MarketDataProvider> Map<InstrumentCode, ProviderManagedInstrumentHandler<P, ? extends Instrument>>
+    private static <P extends MarketDataProvider> Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>>
     buildInstrumentHandlerMap(
             ProviderCode providerCode,
-            Set<? extends ProviderManagedInstrumentHandler<P, ? extends Instrument>> handlers
+            Set<? extends InstrumentHandler<P, ? extends Instrument>> handlers
     ) {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(handlers, "handlers must not be null");
 
-        Map<InstrumentCode, ProviderManagedInstrumentHandler<P, ? extends Instrument>> map = new LinkedHashMap<>();
+        Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> map = new LinkedHashMap<>();
         Set<HandlerCode> handlerCodes = new HashSet<>();
 
-        for (ProviderManagedInstrumentHandler<P, ? extends Instrument> h : handlers) {
+        for (InstrumentHandler<P, ? extends Instrument> h : handlers) {
             Objects.requireNonNull(h, "handler must not be null");
 
             HandlerCode handlerCode = Objects.requireNonNull(h.handlerCode(), "handlerCode must not be null");
@@ -144,7 +144,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
             for (InstrumentCode instrumentCode : codes) {
                 Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
-                ProviderManagedInstrumentHandler<P, ? extends Instrument> prev = map.putIfAbsent(instrumentCode, h);
+                InstrumentHandler<P, ? extends Instrument> prev = map.putIfAbsent(instrumentCode, h);
                 if (prev != null) {
                     throw new IllegalStateException("Provider '" + providerCode.value() +
                             "' contains instrument code '" + instrumentCode.value() +
@@ -161,14 +161,14 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
      * Ищет обработчик инструмента или бросает исключение.
      */
     @SuppressWarnings("unchecked")
-    protected final <I extends Instrument> ProviderManagedInstrumentHandler<P, I> findHandlerOrThrow(I instrument) {
+    protected final <I extends Instrument> InstrumentHandler<P, I> findHandlerOrThrow(I instrument) {
         Objects.requireNonNull(instrument, "instrument must not be null");
 
         InstrumentCode code = Objects.requireNonNull(instrument.instrumentCode(),
                 "instrumentCode must not be null");
 
-        ProviderManagedInstrumentHandler<P, I> handler =
-                (ProviderManagedInstrumentHandler<P, I>) instrumentHandlerMap.get(code);
+        InstrumentHandler<P, I> handler =
+                (InstrumentHandler<P, I>) instrumentHandlerMap.get(code);
 
         if (handler == null) {
             throw new HandlerNotFoundException(code, providerCode);

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * Базовая реализация внутреннего SPI обработчика инструмента.
  */
 public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I extends Instrument>
-        implements ProviderManagedInstrumentHandler<P, I> {
+        implements InstrumentHandler<P, I> {
 
     /* Код обработчика. */
     private final HandlerCode handlerCode;

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/InstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/InstrumentHandler.java
@@ -14,7 +14,7 @@ import java.util.Set;
  *
  * <p>Примечание: это provider-facing контракт, а не внешний доменный API.</p>
  */
-public interface ProviderManagedInstrumentHandler<P extends MarketDataProvider, I extends Instrument> {
+public interface InstrumentHandler<P extends MarketDataProvider, I extends Instrument> {
 
     /**
      * Уникальный код обработчика (идентификатор).


### PR DESCRIPTION
### Motivation

- Упростить и унифицировать имя интерфейса обработчика инструмента в домене, переименовав `ProviderManagedInstrumentHandler` в более короткое и понятное `InstrumentHandler`.
- Это чисто рефакторинг без изменения поведения или контракта методов интерфейса.

### Description

- Переименован интерфейс `ProviderManagedInstrumentHandler` → `InstrumentHandler` и файл `domain/src/main/java/com/alligator/market/domain/provider/handler/ProviderManagedInstrumentHandler.java` → `InstrumentHandler.java` с сохранением всех методов и сигнатур.
- Обновлены все ссылки и импорты на новый тип в `AbstractInstrumentHandler`, `AbstractMarketDataProvider`, `MoexIssProvider`, `MoexIssProviderConfig` и `MoexIssHandlersConfig` с соответствующей корректировкой generic-типов.
- Изменения ограничены переименованием типа и не затрагивают логику, проверки или API методов интерфейса.

### Testing

- Выполнен поиск по коду `rg -n "ProviderManagedInstrumentHandler|InstrumentHandler"`, и проверено отсутствие оставшихся упоминаний старого имени, результат успешен.
- Попытка сборки с `./mvnw -q -DskipTests compile` была выполнена, но сборка не началась из-за ошибки загрузки Maven-дистрибутива в окружении (`Failed to fetch apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ea183b30832d984c3290d143fa3a)