### PR TITLE
Переименование Instrument.assetClass → asset и AssetClass → Asset

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/dto/FxSpotListResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/dto/FxSpotListResponse.java
@@ -8,7 +8,7 @@ import com.alligator.market.domain.instrument.asset.forex.fxspot.classification.
 public record FxSpotListResponse(
         String instrumentCode,
         String symbol,
-        String assetClass,
+        String asset,
         String contractType,
         String baseCurrency,
         String quoteCurrency,

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/mapper/FxSpotListResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/mapper/FxSpotListResponseMapper.java
@@ -20,7 +20,7 @@ public final class FxSpotListResponseMapper {
         return new FxSpotListResponse(
                 fxSpot.instrumentCode().value(),
                 fxSpot.instrumentSymbol().value(),
-                fxSpot.assetClass().name(),
+                fxSpot.asset().name(),
                 fxSpot.contractType().name(),
                 fxSpot.base().code().value(),
                 fxSpot.quote().code().value(),

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.support.MoexIssFxSpotSupportCatalog;
-import com.alligator.market.domain.instrument.base.classification.AssetClass;
+import com.alligator.market.domain.instrument.base.classification.Asset;
 import com.alligator.market.domain.instrument.base.classification.ContractType;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
@@ -56,7 +56,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
      * @param webClient web-клиент, настроенный для запросов провайдеру MOEX ISS по инструментам FOREX_SPOT
      */
     public MoexIssFxSpotHandler(WebClient webClient) {
-        super(HANDLER_CODE, FxSpot.class, AssetClass.FOREX, ContractType.SPOT, SUPPORTED_CODES);
+        super(HANDLER_CODE, FxSpot.class, Asset.FOREX, ContractType.SPOT, SUPPORTED_CODES);
 
         Objects.requireNonNull(webClient, "webClient must not be null");
         this.webClient = webClient;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/FxSpot.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.instrument.asset.forex.fxspot;
 
 import com.alligator.market.domain.instrument.asset.forex.fxspot.classification.FxSpotTenor;
-import com.alligator.market.domain.instrument.base.classification.AssetClass;
+import com.alligator.market.domain.instrument.base.classification.Asset;
 import com.alligator.market.domain.instrument.base.classification.ContractType;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.base.Instrument;
@@ -60,8 +60,8 @@ public record FxSpot(
     }
 
     @Override
-    public AssetClass assetClass() {
-        return AssetClass.FOREX;
+    public Asset asset() {
+        return Asset.FOREX;
     }
 
     @Override

--- a/domain/src/main/java/com/alligator/market/domain/instrument/base/Instrument.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/base/Instrument.java
@@ -1,6 +1,6 @@
 package com.alligator.market.domain.instrument.base;
 
-import com.alligator.market.domain.instrument.base.classification.AssetClass;
+import com.alligator.market.domain.instrument.base.classification.Asset;
 import com.alligator.market.domain.instrument.base.classification.ContractType;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.instrument.base.vo.InstrumentSymbol;
@@ -26,7 +26,7 @@ public interface Instrument {
     /**
      * Актив финансового инструмента.
      */
-    AssetClass assetClass();
+    Asset asset();
 
     /**
      * Контракт финансового инструмента.

--- a/domain/src/main/java/com/alligator/market/domain/instrument/base/classification/Asset.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/base/classification/Asset.java
@@ -3,7 +3,7 @@ package com.alligator.market.domain.instrument.base.classification;
 /**
  * Класс актива, к которому относится финансовый инструмент.
  */
-public enum AssetClass {
+public enum Asset {
     COMMODITY,
     EQUITY,
     FOREX,

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
@@ -1,7 +1,7 @@
 package com.alligator.market.domain.provider.handler;
 
 import com.alligator.market.domain.instrument.base.Instrument;
-import com.alligator.market.domain.instrument.base.classification.AssetClass;
+import com.alligator.market.domain.instrument.base.classification.Asset;
 import com.alligator.market.domain.instrument.base.classification.ContractType;
 import com.alligator.market.domain.instrument.base.vo.InstrumentCode;
 import com.alligator.market.domain.marketdata.tick.model.QuoteTick;
@@ -27,7 +27,7 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
     private final Class<I> instrumentJavaClass;
 
     /* Класс актива поддерживаемых инструментов. */
-    private final AssetClass assetClass;
+    private final Asset asset;
 
     /* Тип контракта поддерживаемых инструментов. */
     private final ContractType contractType;
@@ -44,13 +44,13 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
     protected AbstractInstrumentHandler(
             HandlerCode handlerCode,
             Class<I> instrumentJavaClass,
-            AssetClass assetClass,
+            Asset asset,
             ContractType contractType,
             Set<InstrumentCode> supportedInstrumentCodes
     ) {
         Objects.requireNonNull(handlerCode, "handlerCode must not be null");
         Objects.requireNonNull(instrumentJavaClass, "instrumentJavaClass must not be null");
-        Objects.requireNonNull(assetClass, "assetClass must not be null");
+        Objects.requireNonNull(asset, "asset must not be null");
         Objects.requireNonNull(contractType, "contractType must not be null");
         Objects.requireNonNull(supportedInstrumentCodes, "supportedInstrumentCodes must not be null");
 
@@ -60,7 +60,7 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
 
         this.handlerCode = handlerCode;
         this.instrumentJavaClass = instrumentJavaClass;
-        this.assetClass = assetClass;
+        this.asset = asset;
         this.contractType = contractType;
         this.supportedInstrumentCodes = freezeSupportedInstrumentCodes(supportedInstrumentCodes);
     }
@@ -70,8 +70,8 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
         return handlerCode;
     }
 
-    protected final AssetClass assetClass() {
-        return assetClass;
+    protected final Asset asset() {
+        return asset;
     }
 
     protected final ContractType contractType() {
@@ -164,14 +164,14 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
             );
         }
 
-        if (instrument.assetClass() != assetClass) {
+        if (instrument.asset() != asset) {
             throw new IllegalArgumentException(
-                    "Instrument '%s' has assetClass '%s', but handler '%s' expects '%s'"
+                    "Instrument '%s' has asset '%s', but handler '%s' expects '%s'"
                             .formatted(
                                     instrumentCode.value(),
-                                    instrument.assetClass(),
+                                    instrument.asset(),
                                     handlerCode.value(),
-                                    assetClass
+                                    asset
                             )
             );
         }


### PR DESCRIPTION
### Motivation
- Упростить API и привести нейминг к более короткому и единообразному виду, заменив `assetClass` на `asset` и `AssetClass` на `Asset`.
- Обновить все места использования этого контракта, чтобы избежать несовместимостей между доменом и бэкенд-слоем.

### Description
- Переименован enum `AssetClass` в `Asset` вместе с файлом `domain/src/main/java/com/alligator/market/domain/instrument/base/classification/Asset.java` и соответствующим импортом везде, где использовался этот тип.
- В интерфейсе `Instrument` метод `assetClass()` заменён на `asset()` и обновлены все реализации интерфейса (в т.ч. `FxSpot`).
- В `AbstractInstrumentHandler` переименованы поле/параметры/методы и сообщения валидации с `assetClass` на `asset`, и соответствующая логика сравнения теперь использует `instrument.asset()`.
- Обновлены DTO и мапперы для FX spot: поле `assetClass` в `FxSpotListResponse` переименовано в `asset`, а маппер теперь использует `fxSpot.asset().name()`; также обновлён MOEX-обработчик для передачи `Asset.FOREX`.

### Testing
- Попытка сборки проекта запуском `./mvnw -q -DskipTests compile` была выполнена автоматически, но завершилась неудачей из‑за того, что Maven wrapper не смог скачать необходимый дистрибутив (`wget: Failed to fetch https://repo.maven.apache.org/...`).
- Никаких автоматических тестов запущено не было из‑за ограничения окружения, поэтому компиляция и тесты необходимо запустить в CI/локально после восстановления сетевого доступа для `mvnw`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c3dae6f0832daedd26c69e9a1a29)