### PR TITLE
Добавить SupportedInstrumentProfile в com.alligator.market.domain.provider.handler.instrument

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/instrument/SupportedInstrumentProfile.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/instrument/SupportedInstrumentProfile.java
@@ -1,0 +1,46 @@
+package com.alligator.market.domain.provider.handler.instrument;
+
+import com.alligator.market.domain.instrument.Instrument;
+import com.alligator.market.domain.instrument.classification.Asset;
+import com.alligator.market.domain.instrument.classification.Product;
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+
+import java.util.Objects;
+
+/**
+ * Компактный профиль поддерживаемого инструмента для конфигурации обработчика.
+ *
+ * <p>Назначение: отделяет служебные признаки supported-инструмента
+ * от полной доменной модели и снижает шум в сборке handler.</p>
+ */
+public record SupportedInstrumentProfile(
+        InstrumentCode instrumentCode,
+        Class<? extends Instrument> instrumentJavaClass,
+        Asset asset,
+        Product product
+) {
+
+    /**
+     * Канонический конструктор с fail-fast валидацией.
+     */
+    public SupportedInstrumentProfile {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+        Objects.requireNonNull(instrumentJavaClass, "instrumentJavaClass must not be null");
+        Objects.requireNonNull(asset, "asset must not be null");
+        Objects.requireNonNull(product, "product must not be null");
+    }
+
+    /**
+     * Фабрика профиля из доменной модели инструмента.
+     */
+    public static SupportedInstrumentProfile from(Instrument instrument) {
+        Objects.requireNonNull(instrument, "instrument must not be null");
+
+        return new SupportedInstrumentProfile(
+                Objects.requireNonNull(instrument.instrumentCode(), "instrumentCode must not be null"),
+                instrument.getClass(),
+                Objects.requireNonNull(instrument.asset(), "asset must not be null"),
+                Objects.requireNonNull(instrument.product(), "product must not be null")
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Добавить компактный профиль поддерживаемого инструмента для отделения служебных признаков от полной доменной модели и уменьшения шума при конфигурации обработчиков.

### Description
- Добавлен `SupportedInstrumentProfile` (Java record) в `domain/src/main/java/com/alligator/market/domain/provider/handler/instrument` с полями `InstrumentCode`, `Class<? extends Instrument>`, `Asset`, `Product`, каноническим конструктором с `Objects.requireNonNull(...)` и фабричным методом `from(Instrument)`.

### Testing
- Попытки автоматической валидации: `./gradlew :domain:compileJava` не выполнен (в репозитории нет `gradlew`), затем `mvn -pl domain -am -DskipTests compile` завершился неудачно из-за невозможности резолва parent POM (Maven Central вернул HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92f48e020832db9f01d4a31aaacf1)