### PR TITLE
Уточнить инварианты конструктора AbstractInstrumentHandler в Javadoc

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
@@ -35,7 +35,7 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
      * <ul>
      *     <li>Выполняет базовые проверки параметров;</li>
      *     <li>Собирает сводный профиль инструментов, поддерживаемых обработчиком;</li>
-     *     <li>Валидирует инварианты: ... ;</li>
+     *     <li>Валидирует инварианты: java-класс инструмента, единые asset/product и уникальность instrumentCode;</li>
      * </ul>
      */
     protected AbstractInstrumentHandler(


### PR DESCRIPTION
### Motivation
- Уточнить Javadoc конструктора `AbstractInstrumentHandler`, заменив placeholder `...` явным перечислением проверяемых инвариантов для лучшей читаемости и поддержки.

### Description
- В Javadoc конструктора `AbstractInstrumentHandler` заменён текст `...` на конкретное перечисление инвариантов: java-класс инструмента, единые `asset`/`product` и уникальность `instrumentCode`.

### Testing
- Документационное изменение; автоматические тесты не запускались, изменение не влияет на runtime-логику и зафиксировано коммитом.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcfff0424832d9c1fab28ed697e3c)