### PR TITLE
Добавить защитную копию для supportedInstrumentCodes в SupportedInstrumentsProfile

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/instrument/SupportedInstrumentsProfile.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/instrument/SupportedInstrumentsProfile.java
@@ -34,5 +34,8 @@ public record SupportedInstrumentsProfile(
         Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
         Objects.requireNonNull(asset, "asset must not be null");
         Objects.requireNonNull(product, "product must not be null");
+
+        // Создаём защитную копию набора, чтобы исключить внешние мутации.
+        supportedInstrumentCodes = Set.copyOf(supportedInstrumentCodes);
     }
 }


### PR DESCRIPTION
### Motivation
- Исключить внешние мутации множества кодов инструментов после создания профиля и сделать поведение профиля более безопасным и предсказуемым.

### Description
- В каноническом конструкторе `SupportedInstrumentsProfile` добавлена строка `supportedInstrumentCodes = Set.copyOf(supportedInstrumentCodes);` при сохранении существующей `null`-валидации.

### Testing
- Попытка собрать модуль командой `./gradlew :domain:compileJava` не удалась из-за отсутствия `gradlew`, а `./mvnw -pl domain -DskipTests compile` не завершилась из-за ошибки загрузки Maven в этом окружении, поэтому автоматическая сборка не выполнена.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd059adf4832d88ce74a03ae56305)