### PR TITLE
Refactor SupportedInstrumentsProfile construction responsibilities

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/AbstractInstrumentHandler.java
@@ -1,8 +1,6 @@
 package com.alligator.market.domain.provider.handler;
 
 import com.alligator.market.domain.instrument.Instrument;
-import com.alligator.market.domain.instrument.classification.Asset;
-import com.alligator.market.domain.instrument.classification.Product;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.marketdata.tick.model.QuoteTick;
 import com.alligator.market.domain.provider.MarketDataProvider;
@@ -10,7 +8,6 @@ import com.alligator.market.domain.provider.handler.instrument.SupportedInstrume
 import com.alligator.market.domain.provider.vo.HandlerCode;
 import org.reactivestreams.Publisher;
 
-import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,9 +30,8 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
     /**
      * Конструктор: обработчик сам выводит свой профиль из набора поддерживаемых инструментов.
      * <ul>
-     *     <li>Выполняет базовые проверки параметров;</li>
      *     <li>Собирает сводный профиль инструментов, поддерживаемых обработчиком;</li>
-     *     <li>Валидирует инварианты: java-класс инструмента, единые asset/product и уникальность instrumentCode;</li>
+     *     <li>Передает валидацию и построение профиля в {@link SupportedInstrumentsProfile};</li>
      * </ul>
      */
     protected AbstractInstrumentHandler(
@@ -43,17 +39,11 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
             Class<I> instrumentClass,
             Set<? extends I> supportedInstruments
     ) {
-        Objects.requireNonNull(handlerCode, "handlerCode must not be null");
-        Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
-        Objects.requireNonNull(supportedInstruments, "supportedInstruments must not be null");
-
-        if (supportedInstruments.isEmpty()) {
-            throw new IllegalArgumentException("supportedInstruments must not be empty");
-        }
-
-        SupportedInstrumentsProfile profile =
-                buildSupportedInstrumentProfile(handlerCode, instrumentClass, supportedInstruments);
-
+        SupportedInstrumentsProfile profile = SupportedInstrumentsProfile.fromSupportedInstruments(
+                handlerCode,
+                instrumentClass,
+                supportedInstruments
+        );
         this.handlerCode = handlerCode;
         this.supportedInstrumentsProfile = profile;
     }
@@ -102,93 +92,6 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
      */
     protected final P provider() {
         return requireAttachedProvider();
-    }
-
-    /*
-     * Собирает и валидирует сводный профиль поддерживаемых инструментов.
-     */
-    private static <I extends Instrument> SupportedInstrumentsProfile buildSupportedInstrumentProfile(
-            HandlerCode handlerCode,
-            Class<I> instrumentClass,
-            Set<? extends I> supportedInstruments
-    ) {
-        Asset resolvedAsset = null;
-        Product resolvedProduct = null;
-        LinkedHashSet<InstrumentCode> resolvedCodes = new LinkedHashSet<>();
-
-        for (I instrument : supportedInstruments) {
-            Objects.requireNonNull(instrument, "supportedInstrument must not be null");
-
-            InstrumentCode instrumentCode = Objects.requireNonNull(
-                    instrument.instrumentCode(),
-                    "supported instrumentCode must not be null"
-            );
-
-            if (!instrumentClass.isInstance(instrument)) {
-                throw new IllegalArgumentException(
-                        "Supported instrument '%s' has java class '%s', but handler '%s' expects '%s'"
-                                .formatted(
-                                        instrumentCode.value(),
-                                        instrument.getClass().getName(),
-                                        handlerCode.value(),
-                                        instrumentClass.getName()
-                                )
-                );
-            }
-
-            Asset currentAsset = Objects.requireNonNull(
-                    instrument.asset(),
-                    "supported asset must not be null"
-            );
-
-            Product currentProduct = Objects.requireNonNull(
-                    instrument.product(),
-                    "supported product must not be null"
-            );
-
-            if (resolvedAsset == null) {
-                resolvedAsset = currentAsset;
-                resolvedProduct = currentProduct;
-            } else {
-                if (currentAsset != resolvedAsset) {
-                    throw new IllegalArgumentException(
-                            "Supported instruments of handler '%s' have inconsistent asset: expected '%s', but found '%s' for instrument '%s'"
-                                    .formatted(
-                                            handlerCode.value(),
-                                            resolvedAsset,
-                                            currentAsset,
-                                            instrumentCode.value()
-                                    )
-                    );
-                }
-
-                if (currentProduct != resolvedProduct) {
-                    throw new IllegalArgumentException(
-                            "Supported instruments of handler '%s' have inconsistent product: expected '%s', but found '%s' for instrument '%s'"
-                                    .formatted(
-                                            handlerCode.value(),
-                                            resolvedProduct,
-                                            currentProduct,
-                                            instrumentCode.value()
-                                    )
-                    );
-                }
-            }
-
-            if (!resolvedCodes.add(instrumentCode)) {
-                throw new IllegalArgumentException(
-                        "Supported instrument code '%s' is duplicated in handler '%s'"
-                                .formatted(instrumentCode.value(), handlerCode.value())
-                );
-            }
-        }
-
-        return new SupportedInstrumentsProfile(
-                freezeSupportedInstrumentCodes(resolvedCodes),
-                instrumentClass,
-                resolvedAsset,
-                resolvedProduct
-        );
     }
 
     /*
@@ -261,18 +164,4 @@ public abstract class AbstractInstrumentHandler<P extends MarketDataProvider, I 
         );
     }
 
-    /*
-     * Возвращает неизменяемую защищенную копию списка поддерживаемых инструментов.
-     */
-    private static Set<InstrumentCode> freezeSupportedInstrumentCodes(Set<InstrumentCode> supportedInstrumentCodes) {
-        Objects.requireNonNull(supportedInstrumentCodes, "supportedInstrumentCodes must not be null");
-
-        LinkedHashSet<InstrumentCode> copy = new LinkedHashSet<>(supportedInstrumentCodes.size());
-        for (InstrumentCode code : supportedInstrumentCodes) {
-            Objects.requireNonNull(code, "code must not be null");
-            copy.add(code);
-        }
-
-        return java.util.Collections.unmodifiableSet(copy);
-    }
 }

--- a/domain/src/main/java/com/alligator/market/domain/provider/handler/instrument/SupportedInstrumentsProfile.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/handler/instrument/SupportedInstrumentsProfile.java
@@ -4,7 +4,10 @@ import com.alligator.market.domain.instrument.Instrument;
 import com.alligator.market.domain.instrument.classification.Asset;
 import com.alligator.market.domain.instrument.classification.Product;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.provider.vo.HandlerCode;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -27,15 +30,118 @@ public record SupportedInstrumentsProfile(
 ) {
 
     /**
+     * Строит сводный профиль из supportedInstruments с полной fail-fast валидацией.
+     */
+    public static <I extends Instrument> SupportedInstrumentsProfile fromSupportedInstruments(
+            HandlerCode handlerCode,
+            Class<I> instrumentClass,
+            Set<? extends I> supportedInstruments
+    ) {
+        Objects.requireNonNull(handlerCode, "handlerCode must not be null");
+        Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
+        Objects.requireNonNull(supportedInstruments, "supportedInstruments must not be null");
+
+        if (supportedInstruments.isEmpty()) {
+            throw new IllegalArgumentException("supportedInstruments must not be empty");
+        }
+
+        Asset resolvedAsset = null;
+        Product resolvedProduct = null;
+        LinkedHashSet<InstrumentCode> resolvedCodes = new LinkedHashSet<>();
+
+        for (I instrument : supportedInstruments) {
+            Objects.requireNonNull(instrument, "supportedInstrument must not be null");
+
+            InstrumentCode instrumentCode = Objects.requireNonNull(
+                    instrument.instrumentCode(),
+                    "supported instrumentCode must not be null"
+            );
+
+            if (!instrumentClass.isInstance(instrument)) {
+                throw new IllegalArgumentException(
+                        "Supported instrument '%s' has java class '%s', but handler '%s' expects '%s'"
+                                .formatted(
+                                        instrumentCode.value(),
+                                        instrument.getClass().getName(),
+                                        handlerCode.value(),
+                                        instrumentClass.getName()
+                                )
+                );
+            }
+
+            Asset currentAsset = Objects.requireNonNull(instrument.asset(), "supported asset must not be null");
+            Product currentProduct = Objects.requireNonNull(instrument.product(), "supported product must not be null");
+
+            if (resolvedAsset == null) {
+                resolvedAsset = currentAsset;
+                resolvedProduct = currentProduct;
+            } else {
+                if (currentAsset != resolvedAsset) {
+                    throw new IllegalArgumentException(
+                            "Supported instruments of handler '%s' have inconsistent asset: expected '%s', but found '%s' for instrument '%s'"
+                                    .formatted(
+                                            handlerCode.value(),
+                                            resolvedAsset,
+                                            currentAsset,
+                                            instrumentCode.value()
+                                    )
+                    );
+                }
+
+                if (currentProduct != resolvedProduct) {
+                    throw new IllegalArgumentException(
+                            "Supported instruments of handler '%s' have inconsistent product: expected '%s', but found '%s' for instrument '%s'"
+                                    .formatted(
+                                            handlerCode.value(),
+                                            resolvedProduct,
+                                            currentProduct,
+                                            instrumentCode.value()
+                                    )
+                    );
+                }
+            }
+
+            if (!resolvedCodes.add(instrumentCode)) {
+                throw new IllegalArgumentException(
+                        "Supported instrument code '%s' is duplicated in handler '%s'"
+                                .formatted(instrumentCode.value(), handlerCode.value())
+                );
+            }
+        }
+
+        return new SupportedInstrumentsProfile(
+                freezeSupportedInstrumentCodes(resolvedCodes),
+                instrumentClass,
+                resolvedAsset,
+                resolvedProduct
+        );
+    }
+
+    /**
      * Канонический конструктор с fail-fast валидацией.
      */
     public SupportedInstrumentsProfile {
-        Objects.requireNonNull(supportedInstrumentCodes, "instrumentCode must not be null");
+        Objects.requireNonNull(supportedInstrumentCodes, "supportedInstrumentCodes must not be null");
         Objects.requireNonNull(instrumentClass, "instrumentClass must not be null");
         Objects.requireNonNull(asset, "asset must not be null");
         Objects.requireNonNull(product, "product must not be null");
 
         // Создаём защитную копию набора
         supportedInstrumentCodes = Set.copyOf(supportedInstrumentCodes);
+    }
+
+    /*
+     * Возвращает неизменяемую защищенную копию списка поддерживаемых инструментов.
+     */
+    private static Set<InstrumentCode> freezeSupportedInstrumentCodes(Set<InstrumentCode> supportedInstrumentCodes) {
+        Objects.requireNonNull(supportedInstrumentCodes, "supportedInstrumentCodes must not be null");
+
+        LinkedHashSet<InstrumentCode> copy = new LinkedHashSet<>(supportedInstrumentCodes.size());
+        for (InstrumentCode code : supportedInstrumentCodes) {
+            Objects.requireNonNull(code, "code must not be null");
+            copy.add(code);
+        }
+
+        return Collections.unmodifiableSet(copy);
     }
 }


### PR DESCRIPTION
### Motivation
- Упростить `AbstractInstrumentHandler` за счёт переноса логики сборки профиля поддерживаемых инструментов внутрь `SupportedInstrumentsProfile` и сохранить runtime-валидацию в handler.
- Централизовать валидацию и построение профиля (классы, asset/product, уникальность кодов) в одном месте для ясности ответственности и уменьшения дублирования.

### Description
- Добавлен статический factory-метод `SupportedInstrumentsProfile.fromSupportedInstruments(...)`, который выполняет полную fail-fast валидацию входных параметров и собирает профиль из `supportedInstruments`.
- Хелпер `freezeSupportedInstrumentCodes(...)` перемещён в `SupportedInstrumentsProfile` как приватный static-метод и используется внутри фабрики для создания защищённого неизменяемого набора кодов.
- Упрощён конструктор `AbstractInstrumentHandler` — теперь он делегирует построение профиля в `SupportedInstrumentsProfile.fromSupportedInstruments(...)`, а устаревшие приватные методы `buildSupportedInstrumentProfile(...)` и `freezeSupportedInstrumentCodes(...)` удалены.
- Сохранено текущее поведение runtime-валидации в `AbstractInstrumentHandler` (метод `quote(...)` и `requireInstrumentMatchesSupportedProfile(...)` остались без изменений), а канонический конструктор record продолжает делать защитную копию через `Set.copyOf(...)`.

### Testing
- Попытка собрать модуль `domain` через `./mvnw -pl domain -DskipTests compile` не удалась из-за проблем с загрузкой Maven wrapper в окружении (`Failed to fetch apache-maven-3.9.9-bin.zip`).
- Попытка собрать через `mvn -pl domain -DskipTests compile` закончилась неудачей из-за сетевых ограничений при резолве зависимостей (HTTP 403 от Maven Central), поэтому автоматическая компиляция не прошла в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd248fd18832dafbda5fba9979234)