### PR TITLE
Implement attachedHandlerCodes in AbstractMarketDataProvider

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/AbstractMarketDataProvider.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/AbstractMarketDataProvider.java
@@ -28,6 +28,9 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
     /* Политика провайдера. */
     protected final ProviderPolicy policy;
 
+    /* Набор кодов подключенных обработчиков. */
+    private final Set<HandlerCode> attachedHandlerCodes;
+
     /* Карта "код инструмента → обработчик инструмента". */
     private final Map<InstrumentCode, InstrumentHandler<P, ? extends Instrument>> instrumentHandlerMap;
 
@@ -65,6 +68,7 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         this.providerCode = providerCode;
         this.passport = passport;
         this.policy = policy;
+        this.attachedHandlerCodes = buildAttachedHandlerCodes(handlers);
 
         // Собираем неизменяемую однозначную карту "код инструмента → обработчик инструмента"
         this.instrumentHandlerMap = buildInstrumentHandlerMap(providerCode, handlers);
@@ -88,6 +92,11 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
     @Override
     public ProviderPolicy policy() {
         return policy;
+    }
+
+    @Override
+    public Set<HandlerCode> attachedHandlerCodes() {
+        return attachedHandlerCodes;
     }
 
     /**
@@ -153,6 +162,20 @@ public abstract class AbstractMarketDataProvider<P extends MarketDataProvider>
         }
 
         return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Собирает неизменяемый набор кодов подключенных обработчиков.
+     */
+    private static <P extends MarketDataProvider> Set<HandlerCode> buildAttachedHandlerCodes(
+            Set<? extends InstrumentHandler<P, ? extends Instrument>> handlers
+    ) {
+        Set<HandlerCode> result = new LinkedHashSet<>();
+        for (InstrumentHandler<P, ? extends Instrument> h : handlers) {
+            Objects.requireNonNull(h, "handler must not be null");
+            result.add(Objects.requireNonNull(h.handlerCode(), "handlerCode must not be null"));
+        }
+        return Collections.unmodifiableSet(result);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- В контракте `MarketDataProvider` объявлен метод `attachedHandlerCodes()`, но абстрактная реализация не предоставляла его реализации и хранение данных, необходимых для возврата этого набора.
- Нужно централизованно собирать и хранить набор кодов подключённых обработчиков для всех провайдеров и сделать его неизменяемым и null-safe.

### Description
- Добавлено поле `attachedHandlerCodes` в `AbstractMarketDataProvider` и его инициализация в конструкторе через `buildAttachedHandlerCodes(...)` в файле `domain/src/main/java/com/alligator/market/domain/provider/AbstractMarketDataProvider.java`.
- Реализован метод `attachedHandlerCodes()` с возвратом ранее собранного неизменяемого набора кодов обработчиков.
- Добавлен приватный статический хелпер `buildAttachedHandlerCodes(...)`, который выполняет null-проверки на обработчики и их коды и возвращает `Collections.unmodifiableSet(...)`.
- Изменения закоммичены с сообщением `Implement attached handler codes in abstract provider`.

### Testing
- Выполнена команда `mvn -pl domain test -q`, но запуск тестов не прошёл из-за проблем с разрешением зависимостей в окружении: `403 Forbidden` при скачивании `org.springframework.boot:spring-boot-starter-parent:4.0.5` из Maven Central, поэтому автоматические тесты не смогли выполниться.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd48b22e0832d877272ff5d88fe25)