### PR TITLE
Адаптация MoexIssFxSpotHandler и каталога к новому AbstractInstrumentHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/handler/MoexIssFxSpotHandler.java
@@ -2,8 +2,6 @@ package com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.
 
 import com.alligator.market.backend.provider.adapter.moex.iss.MoexIssProvider;
 import com.alligator.market.backend.provider.adapter.moex.iss.instrument.forex.spot.support.MoexIssFxSpotSupportCatalog;
-import com.alligator.market.domain.instrument.classification.Asset;
-import com.alligator.market.domain.instrument.classification.Product;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.provider.handler.AbstractInstrumentHandler;
@@ -38,8 +36,8 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
     /* Код обработчика. */
     private static final HandlerCode HANDLER_CODE = HandlerCode.of("MOEX_ISS_FX_SPOT_HANDLER");
 
-    /* Поддерживаемые коды инструментов FOREX_SPOT. */
-    private static final Set<InstrumentCode> SUPPORTED_CODES = MoexIssFxSpotSupportCatalog.SUPPORTED_DOMAIN_CODES;
+    /* Поддерживаемые инструменты FOREX_SPOT. */
+    private static final Set<FxSpot> SUPPORTED_INSTRUMENTS = MoexIssFxSpotSupportCatalog.SUPPORTED_INSTRUMENTS;
 
     /* Web-клиент. */
     private final WebClient webClient;
@@ -56,7 +54,7 @@ public class MoexIssFxSpotHandler extends AbstractInstrumentHandler<MoexIssProvi
      * @param webClient web-клиент, настроенный для запросов провайдеру MOEX ISS по инструментам FOREX_SPOT
      */
     public MoexIssFxSpotHandler(WebClient webClient) {
-        super(HANDLER_CODE, FxSpot.class, Asset.FOREX, Product.SPOT, SUPPORTED_CODES);
+        super(HANDLER_CODE, FxSpot.class, SUPPORTED_INSTRUMENTS);
 
         Objects.requireNonNull(webClient, "webClient must not be null");
         this.webClient = webClient;

--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/support/MoexIssFxSpotSupportCatalog.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/instrument/forex/spot/support/MoexIssFxSpotSupportCatalog.java
@@ -28,6 +28,11 @@ public class MoexIssFxSpotSupportCatalog {
     private static final Map<InstrumentCode, String> DOMAIN_CODE_TO_SECID;
 
     /**
+     * Набор поддерживаемых доменных инструментов.
+     */
+    public static final Set<FxSpot> SUPPORTED_INSTRUMENTS;
+
+    /**
      * Набор кодов поддерживаемых доменных инструментов.
      */
     public static final Set<InstrumentCode> SUPPORTED_DOMAIN_CODES;
@@ -40,6 +45,9 @@ public class MoexIssFxSpotSupportCatalog {
         map.put(CNY_RUB.instrumentCode(), "CNYRUB_TOM");
 
         DOMAIN_CODE_TO_SECID = Collections.unmodifiableMap(map);
+        SUPPORTED_INSTRUMENTS = Collections.unmodifiableSet(
+                new LinkedHashSet<>(List.of(USD_RUB, CNY_RUB))
+        );
         SUPPORTED_DOMAIN_CODES = Collections.unmodifiableSet(
                 new LinkedHashSet<>(DOMAIN_CODE_TO_SECID.keySet())
         );


### PR DESCRIPTION
### Motivation
- Конструктор `AbstractInstrumentHandler` изменён и теперь принимает набор конкретных доменных инструментов вместо отдельных `asset/product` и набора кодов, поэтому обработчики должны передавать полный набор поддерживаемых инструментов. 
- Нужно централизовать построение профиля поддерживаемых инструментов через `SupportedInstrumentsProfile`, чтобы исключить рассинхронизации между каталогом и обработчиком.

### Description
- Добавлен публичный неизменяемый набор `SUPPORTED_INSTRUMENTS` типа `Set<FxSpot>` в `MoexIssFxSpotSupportCatalog` и заполнен существующими инструментами `USD_RUB` и `CNY_RUB`. 
- Обновлён `MoexIssFxSpotHandler`: убраны импорты `Asset`/`Product`, добавлено поле `SUPPORTED_INSTRUMENTS` и вызов конструктора `super(HANDLER_CODE, FxSpot.class, SUPPORTED_INSTRUMENTS)`. 
- Сохранён существующий контракт для преобразования кода инструмента в SECID через `SUPPORTED_DOMAIN_CODES` и `moexSecidOf`, чтобы логика запросов к MOEX не изменилась.

### Testing
- Выполнена проверка `git diff --check`, которая завершилась успешно. 
- Попытка сборки `./mvnw -q -DskipTests compile` завершилась неуспехом из-за сетевой ошибки при загрузке Maven (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`). 
- Локальный коммит изменений был успешно создан (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd94a1eac832da796a081ec4b8178)