### PR TITLE
Внедрить growth-ready usage-check для FX_SPOT (SourcePlan contributor)

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
@@ -6,6 +6,7 @@ import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.cr
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.delete.controller.DeleteFxSpotController;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.update.controller.UpdateFxSpotController;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.controller.ListFxSpotsController;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotInUseException;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.exception.FxSpotAlreadyExistsException;
@@ -51,6 +52,13 @@ public class FxSpotRestExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> fxSpotSameCurrencies(FxSpotSameCurrenciesException ex) {
         log.warn("FX Spot same currencies: {}", ex.getMessage());
         return ResponseEntityFactory.badRequest(DomainErrorCode.FX_SPOT_SAME_CURRENCIES.name(), ex.getMessage());
+    }
+
+
+    @ExceptionHandler(FxSpotInUseException.class)
+    public ResponseEntity<ApiResponse<Void>> fxSpotInUse(FxSpotInUseException ex) {
+        log.warn("FX Spot is in use: {}", ex.getMessage());
+        return ResponseEntityFactory.conflict(DomainErrorCode.FX_SPOT_IN_USE.name(), ex.getMessage());
     }
 
     @ExceptionHandler(CurrencyNotFoundException.class)

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/delete/DeleteFxSpotService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/delete/DeleteFxSpotService.java
@@ -1,5 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.delete;
 
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotInUseException;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.port.FxSpotUsageCheckPort;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import lombok.extern.slf4j.Slf4j;
@@ -13,14 +15,25 @@ import java.util.Objects;
 public final class DeleteFxSpotService {
 
     private final FxSpotRepository fxSpotRepository;
+    private final FxSpotUsageCheckPort fxSpotUsageCheckPort;
 
-    public DeleteFxSpotService(FxSpotRepository fxSpotRepository) {
+    public DeleteFxSpotService(
+            FxSpotRepository fxSpotRepository,
+            FxSpotUsageCheckPort fxSpotUsageCheckPort
+    ) {
         this.fxSpotRepository = Objects.requireNonNull(fxSpotRepository,
                 "fxSpotRepository must not be null");
+        this.fxSpotUsageCheckPort = Objects.requireNonNull(fxSpotUsageCheckPort,
+                "fxSpotUsageCheckPort must not be null");
     }
 
     public void delete(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        // Бизнес‑правило: удаление запрещено, пока инструмент используется в других фичах.
+        if (fxSpotUsageCheckPort.isUsed(instrumentCode)) {
+            throw new FxSpotInUseException(instrumentCode);
+        }
 
         fxSpotRepository.deleteByCode(instrumentCode);
         log.info("FX_SPOT instrument {} deleted", instrumentCode.value());

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/exception/FxSpotInUseException.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/exception/FxSpotInUseException.java
@@ -1,0 +1,23 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception;
+
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+
+import java.util.Objects;
+
+/**
+ * Ошибка application-слоя: FX_SPOT инструмент используется в связанных сценариях.
+ */
+public final class FxSpotInUseException extends IllegalStateException {
+
+    private final InstrumentCode instrumentCode;
+
+    public FxSpotInUseException(InstrumentCode instrumentCode) {
+        super("FX_SPOT instrument '%s' is in use".formatted(
+                Objects.requireNonNull(instrumentCode, "instrumentCode must not be null").value()));
+        this.instrumentCode = instrumentCode;
+    }
+
+    public InstrumentCode instrumentCode() {
+        return instrumentCode;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/FxSpotUsageContributor.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/FxSpotUsageContributor.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor;
+
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+
+/**
+ * Проверка использования FX_SPOT инструмента конкретным внешним contributor.
+ */
+public interface FxSpotUsageContributor {
+
+    /**
+     * Флаг, сигнализирующий об использовании инструмента конкретным contributor.
+     */
+    boolean isUsed(InstrumentCode instrumentCode);
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/SourcePlanFxSpotUsageContributor.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/SourcePlanFxSpotUsageContributor.java
@@ -1,0 +1,27 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.FxSpotUsageContributor;
+import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+
+import java.util.Objects;
+
+/**
+ * Проверка использования FX_SPOT инструмента для contributor: sourcing/source_plan.
+ */
+public final class SourcePlanFxSpotUsageContributor implements FxSpotUsageContributor {
+
+    private final SourcePlanExistenceQueryPort sourcePlanExistenceQueryPort;
+
+    public SourcePlanFxSpotUsageContributor(SourcePlanExistenceQueryPort sourcePlanExistenceQueryPort) {
+        this.sourcePlanExistenceQueryPort = Objects.requireNonNull(sourcePlanExistenceQueryPort,
+                "sourcePlanExistenceQueryPort must not be null");
+    }
+
+    @Override
+    public boolean isUsed(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        return sourcePlanExistenceQueryPort.existsByInstrumentCode(instrumentCode);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/port/FxSpotUsageCheckPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/port/FxSpotUsageCheckPort.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.port;
+
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+
+/**
+ * Порт проверки использования FX_SPOT инструмента.
+ */
+public interface FxSpotUsageCheckPort {
+
+    /**
+     * Возвращает {@code true}, если инструмент используется хотя бы в одном contributor.
+     */
+    boolean isUsed(InstrumentCode instrumentCode);
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/port/adapter/FxSpotUsageCheckAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/port/adapter/FxSpotUsageCheckAdapter.java
@@ -1,0 +1,40 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.port.adapter;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.FxSpotUsageContributor;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.port.FxSpotUsageCheckPort;
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Адаптер проверки использования FX_SPOT инструмента по всем подключенным contributors.
+ */
+public final class FxSpotUsageCheckAdapter implements FxSpotUsageCheckPort {
+
+    /* Набор contributors, участвующих в общей проверке использования FX_SPOT инструмента. */
+    private final List<FxSpotUsageContributor> contributors;
+
+    public FxSpotUsageCheckAdapter(List<FxSpotUsageContributor> contributors) {
+        Objects.requireNonNull(contributors, "contributors must not be null");
+
+        this.contributors = List.copyOf(contributors);
+
+        for (FxSpotUsageContributor contributor : this.contributors) {
+            Objects.requireNonNull(contributor, "contributor must not be null");
+        }
+    }
+
+    @Override
+    public boolean isUsed(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        for (FxSpotUsageContributor contributor : contributors) {
+            if (contributor.isUsed(instrumentCode)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/command/delete/DeleteFxSpotServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/command/delete/DeleteFxSpotServiceWiringConfig.java
@@ -1,6 +1,9 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.command.delete;
 
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.delete.DeleteFxSpotService;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.port.FxSpotUsageCheckPort;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.usage.contributor.FxSpotUsageContributorWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.usage.port.FxSpotUsageCheckPortWiringConfig;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.config.persistence.repository.adapter.FxSpotRepositoryWiringConfig;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,7 +15,11 @@ import org.springframework.context.annotation.Import;
  * Wiring-конфигурация {@link DeleteFxSpotService}.
  */
 @Configuration(proxyBeanMethods = false)
-@Import(FxSpotRepositoryWiringConfig.class)
+@Import({
+        FxSpotRepositoryWiringConfig.class,
+        FxSpotUsageCheckPortWiringConfig.class,
+        FxSpotUsageContributorWiringConfig.class
+})
 public class DeleteFxSpotServiceWiringConfig {
 
     public static final String BEAN_DELETE_FX_SPOT_SERVICE = "deleteFxSpotService";
@@ -20,8 +27,10 @@ public class DeleteFxSpotServiceWiringConfig {
     @Bean(BEAN_DELETE_FX_SPOT_SERVICE)
     public DeleteFxSpotService deleteFxSpotService(
             @Qualifier(FxSpotRepositoryWiringConfig.BEAN_FX_SPOT_REPOSITORY)
-            FxSpotRepository fxSpotRepository
+            FxSpotRepository fxSpotRepository,
+            @Qualifier(FxSpotUsageCheckPortWiringConfig.BEAN_FX_SPOT_USAGE_CHECK_PORT)
+            FxSpotUsageCheckPort fxSpotUsageCheckPort
     ) {
-        return new DeleteFxSpotService(fxSpotRepository);
+        return new DeleteFxSpotService(fxSpotRepository, fxSpotUsageCheckPort);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/FxSpotUsageContributorWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/FxSpotUsageContributorWiringConfig.java
@@ -1,0 +1,28 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.usage.contributor;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.FxSpotUsageContributor;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.SourcePlanFxSpotUsageContributor;
+import com.alligator.market.backend.sourcing.config.plan.application.query.existence.SourcePlanExistenceQueryWiringConfig;
+import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Wiring-конфигурация {@link FxSpotUsageContributor}.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import(SourcePlanExistenceQueryWiringConfig.class)
+public class FxSpotUsageContributorWiringConfig {
+
+    public static final String BEAN_SOURCE_PLAN_FX_SPOT_USAGE_CONTRIBUTOR = "sourcePlanFxSpotUsageContributor";
+
+    @Bean(BEAN_SOURCE_PLAN_FX_SPOT_USAGE_CONTRIBUTOR)
+    public FxSpotUsageContributor sourcePlanFxSpotUsageContributor(
+            @Qualifier(SourcePlanExistenceQueryWiringConfig.BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT)
+            SourcePlanExistenceQueryPort sourcePlanExistenceQueryPort
+    ) {
+        return new SourcePlanFxSpotUsageContributor(sourcePlanExistenceQueryPort);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/port/FxSpotUsageCheckPortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/port/FxSpotUsageCheckPortWiringConfig.java
@@ -1,0 +1,23 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.usage.port;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.FxSpotUsageContributor;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.port.FxSpotUsageCheckPort;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.port.adapter.FxSpotUsageCheckAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * Wiring-конфигурация {@link FxSpotUsageCheckPort}.
+ */
+@Configuration(proxyBeanMethods = false)
+public class FxSpotUsageCheckPortWiringConfig {
+
+    public static final String BEAN_FX_SPOT_USAGE_CHECK_PORT = "fxSpotUsageCheckPort";
+
+    @Bean(BEAN_FX_SPOT_USAGE_CHECK_PORT)
+    public FxSpotUsageCheckPort fxSpotUsageCheckPort(List<FxSpotUsageContributor> contributors) {
+        return new FxSpotUsageCheckAdapter(contributors);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/existence/SourcePlanExistenceQueryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/application/query/existence/SourcePlanExistenceQueryWiringConfig.java
@@ -1,0 +1,21 @@
+package com.alligator.market.backend.sourcing.config.plan.application.query.existence;
+
+import com.alligator.market.backend.sourcing.plan.application.query.existence.adapter.JooqSourcePlanExistenceQueryAdapter;
+import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import org.jooq.DSLContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring-конфигурация {@link SourcePlanExistenceQueryPort}.
+ */
+@Configuration(proxyBeanMethods = false)
+public class SourcePlanExistenceQueryWiringConfig {
+
+    public static final String BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT = "sourcePlanExistenceQueryPort";
+
+    @Bean(BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT)
+    public SourcePlanExistenceQueryPort sourcePlanExistenceQueryPort(DSLContext dsl) {
+        return new JooqSourcePlanExistenceQueryAdapter(dsl);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/existence/adapter/JooqSourcePlanExistenceQueryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/existence/adapter/JooqSourcePlanExistenceQueryAdapter.java
@@ -1,0 +1,32 @@
+package com.alligator.market.backend.sourcing.plan.application.query.existence.adapter;
+
+import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import org.jooq.DSLContext;
+
+import java.util.Objects;
+
+import static com.alligator.market.backend.infra.jooq.generated.tables.SourcePlan.SOURCE_PLAN;
+
+/**
+ * jOOQ-адаптер existence-проверки source plan.
+ */
+public final class JooqSourcePlanExistenceQueryAdapter implements SourcePlanExistenceQueryPort {
+
+    /* DSLContext для выполнения SQL-запросов через jOOQ. */
+    private final DSLContext dsl;
+
+    public JooqSourcePlanExistenceQueryAdapter(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    @Override
+    public boolean existsByInstrumentCode(InstrumentCode instrumentCode) {
+        Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
+
+        return dsl.fetchExists(
+                dsl.selectFrom(SOURCE_PLAN)
+                        .where(SOURCE_PLAN.INSTRUMENT_CODE.eq(instrumentCode.value()))
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/existence/port/SourcePlanExistenceQueryPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/application/query/existence/port/SourcePlanExistenceQueryPort.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.sourcing.plan.application.query.existence.port;
+
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+
+/**
+ * Query-порт existence-проверки source plan по коду инструмента.
+ */
+public interface SourcePlanExistenceQueryPort {
+
+    /**
+     * Возвращает {@code true}, если source plan существует.
+     */
+    boolean existsByInstrumentCode(InstrumentCode instrumentCode);
+}

--- a/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
@@ -23,6 +23,7 @@ public enum DomainErrorCode {
     FX_SPOT_ALREADY_EXISTS(DomainErrorType.CONFLICT),
     FX_SPOT_NOT_FOUND(DomainErrorType.NOT_FOUND),
     FX_SPOT_SAME_CURRENCIES(DomainErrorType.BAD_REQUEST),
+    FX_SPOT_IN_USE(DomainErrorType.CONFLICT),
     FX_SPOT_CREATE_FAILED(DomainErrorType.TECHNICAL),
     FX_SPOT_UPDATE_FAILED(DomainErrorType.TECHNICAL),
     FX_SPOT_DELETE_FAILED(DomainErrorType.TECHNICAL);


### PR DESCRIPTION
### Motivation
- Убрать зависимость удаления `FxSpot` от «технического FK-конфликта» и ввести явную бизнес‑проверку «инструмент используется». 
- Построить расширяемую архитектуру проверки использования по аналогии с currency usage, где `fxspot` владеет портом проверки и может принимать множество contributors. 
- Для sourcing сделать корректный existence‑query на `source_plan`, не используя `JooqInstrumentSourcePlanRepository.findByInstrumentCode(...)` и не восстанавливая план через `market_data_source`.

### Description
- Добавлены интерфейс `FxSpotUsageContributor` и порт `FxSpotUsageCheckPort` с агрегирующим адаптером `FxSpotUsageCheckAdapter`, который делает defensive copy, null‑checks и short‑circuit на первом `true` от contributor'а. 
- Добавлен query‑порт `SourcePlanExistenceQueryPort`, jOOQ‑адаптер `JooqSourcePlanExistenceQueryAdapter` (использует `fetchExists` над `SOURCE_PLAN`) и wiring `SourcePlanExistenceQueryWiringConfig`. 
- Реализован первый contributor `SourcePlanFxSpotUsageContributor`, который делегирует проверку в `SourcePlanExistenceQueryPort`, и добавлены wiring‑конфигурации `FxSpotUsageContributorWiringConfig` и `FxSpotUsageCheckPortWiringConfig` для сборки списка contributors. 
- Введено бизнес‑исключение `FxSpotInUseException` и новый код ошибки `DomainErrorCode.FX_SPOT_IN_USE`, интегрированы в `DeleteFxSpotService` (инъекция `FxSpotUsageCheckPort` и проверка до удаления) и в `FxSpotRestExceptionHandler` (HTTP 409). 

### Testing
- Попытка сборки `./mvnw -q -DskipTests compile` была выполнена и завершилась неудачей из‑за ограничения окружения: Maven Wrapper не смог скачать дистрибутив (`Failed to fetch ... apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7c4bf744832db94ed4dbcc88cbb8)