### PR TITLE
Локализовать SourcePlan existence query в fxspot sourcing contributor

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/SourcePlanFxSpotUsageContributor.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/SourcePlanFxSpotUsageContributor.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing;
 
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.FxSpotUsageContributor;
-import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.port.SourcePlanExistenceQueryPort;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 
 import java.util.Objects;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/adapter/JooqSourcePlanExistenceQueryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/adapter/JooqSourcePlanExistenceQueryAdapter.java
@@ -1,6 +1,6 @@
-package com.alligator.market.backend.sourcing.plan.application.query.existence.adapter;
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.adapter;
 
-import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.port.SourcePlanExistenceQueryPort;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import org.jooq.DSLContext;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/port/SourcePlanExistenceQueryPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/usage/contributor/sourcing/port/SourcePlanExistenceQueryPort.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.sourcing.plan.application.query.existence.port;
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.port;
 
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/FxSpotUsageContributorWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/FxSpotUsageContributorWiringConfig.java
@@ -2,8 +2,8 @@ package com.alligator.market.backend.instrument.asset.forex.fxspot.config.applic
 
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.FxSpotUsageContributor;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.SourcePlanFxSpotUsageContributor;
-import com.alligator.market.backend.sourcing.config.plan.application.query.existence.SourcePlanExistenceQueryWiringConfig;
-import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.usage.contributor.sourcing.SourcePlanExistenceQueryWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.port.SourcePlanExistenceQueryPort;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/sourcing/SourcePlanExistenceQueryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/sourcing/SourcePlanExistenceQueryWiringConfig.java
@@ -1,7 +1,7 @@
-package com.alligator.market.backend.sourcing.config.plan.application.query.existence;
+package com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.usage.contributor.sourcing;
 
-import com.alligator.market.backend.sourcing.plan.application.query.existence.adapter.JooqSourcePlanExistenceQueryAdapter;
-import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.adapter.JooqSourcePlanExistenceQueryAdapter;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.port.SourcePlanExistenceQueryPort;
 import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
### Motivation
- Порт `SourcePlanExistenceQueryPort` используется только для проверки использования инструмента в contributor `sourcing/source_plan`, поэтому его логичнее держать рядом с потребителем для уменьшения межмодульной связанности.

### Description
- Перемещены `SourcePlanExistenceQueryPort`, jOOQ-адаптер и wiring-конфигурация в пакет `instrument.asset.forex.fxspot.application.usage.contributor.sourcing` рядом с `SourcePlanFxSpotUsageContributor`.
- Обновлены импорты в `SourcePlanFxSpotUsageContributor` и `FxSpotUsageContributorWiringConfig` на новые пакеты в контексте `fxspot`.
- Сохранены имена bean'ов и контракт порта (`existsByInstrumentCode`) для минимального риска регрессий.

### Testing
- Выполнена попытка сборки `mvn -pl backend -am -DskipTests compile`, которая не завершилась из-за сетевого ограничения окружения (403 при загрузке `spring-boot-starter-parent:4.0.5`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede897f534832d8e7153e347c2a82b)