### PR TITLE
Усилить семантику удаления FX_SPOT в jOOQ-репозитории

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
@@ -127,9 +127,13 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
                     throw new FxSpotNotFoundException(instrumentCode);
                 }
 
-                tx.deleteFrom(INSTRUMENT_REGISTRY)
+                int deletedRegistryRows = tx.deleteFrom(INSTRUMENT_REGISTRY)
                         .where(INSTRUMENT_REGISTRY.CODE.eq(instrumentCode.value()))
                         .execute();
+
+                if (deletedRegistryRows == 0) {
+                    throw new IllegalStateException("FX_SPOT registry row was not found during delete");
+                }
             });
         } catch (DataAccessException ex) {
             throw new FxSpotDeleteException(instrumentCode, ex);


### PR DESCRIPTION
### Motivation
- Сделать операцию удаления в `JooqFxSpotRepositoryAdapter` более строгой и явной при рассинхронизации данных между `INSTRUMENT_FX_SPOT` и `INSTRUMENT_REGISTRY`, сохранив при этом бизнес-проверку использования на application-слое и оставив FK как последнюю техзащиту.

### Description
- В `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java` добавлена проверка результата удаления из `INSTRUMENT_REGISTRY` — сохраняется в `deletedRegistryRows` и при `0` бросается `IllegalStateException("FX_SPOT registry row was not found during delete")`.
- Сохранён порядок и атомарность удаления: всё выполняется внутри одной `dsl.transaction(...)`, сначала удаляется `INSTRUMENT_FX_SPOT`, затем `INSTRUMENT_REGISTRY`.
- Грани маппинга исключений оставлены прежними: только `DataAccessException` маппится в `FxSpotDeleteException`, а `FxSpotNotFoundException` и новый `IllegalStateException` не перехватываются и проходят как есть.
- Сохранил текущие семантики `create` и `update` (транзакционность и поведение при дубликатах/отсутствии строки) и не ввёл зависимостей от JPA/старых Entity/Mapper/CurrencyRepository.

### Testing
- Запуск сборки модуля (автоматическая проверка): `./mvnw -pl backend -DskipTests compile`, сборка не завершилась из-за невозможности скачать дистрибутив Maven в окружении (`Failed to fetch https://repo.maven.apache.org/...`).
- В рамках CI-раннера модульных/интеграционных тестов не запускалось из-за проблемы с окружением, изменений к тестам не вносил.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5e0edbb4832d8ac5edd1e1198558)