### PR TITLE
Вынести existsByCurrencyCode из доменного FxSpotRepository в application query port

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/query/usage/adapter/JooqFxSpotCurrencyUsageQueryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/query/usage/adapter/JooqFxSpotCurrencyUsageQueryAdapter.java
@@ -1,0 +1,34 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.usage.adapter;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.usage.port.FxSpotCurrencyUsageQueryPort;
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+import org.jooq.DSLContext;
+
+import java.util.Objects;
+
+import static com.alligator.market.backend.infra.jooq.generated.tables.InstrumentFxSpot.INSTRUMENT_FX_SPOT;
+
+/**
+ * jOOQ-адаптер query-port проверки использования валюты в FOREX_SPOT.
+ */
+public final class JooqFxSpotCurrencyUsageQueryAdapter implements FxSpotCurrencyUsageQueryPort {
+
+    /* DSLContext для выполнения SQL-запросов через jOOQ. */
+    private final DSLContext dsl;
+
+    public JooqFxSpotCurrencyUsageQueryAdapter(DSLContext dsl) {
+        this.dsl = Objects.requireNonNull(dsl, "dsl must not be null");
+    }
+
+    @Override
+    public boolean existsByCurrencyCode(CurrencyCode currencyCode) {
+        Objects.requireNonNull(currencyCode, "currencyCode must not be null");
+
+        return dsl.fetchExists(
+                dsl.selectOne()
+                        .from(INSTRUMENT_FX_SPOT)
+                        .where(INSTRUMENT_FX_SPOT.BASE_CURRENCY.eq(currencyCode.value())
+                                .or(INSTRUMENT_FX_SPOT.QUOTE_CURRENCY.eq(currencyCode.value())))
+        );
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/query/usage/port/FxSpotCurrencyUsageQueryPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/query/usage/port/FxSpotCurrencyUsageQueryPort.java
@@ -1,0 +1,14 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.usage.port;
+
+import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
+
+/**
+ * Query-port проверки использования валюты в инструментах FOREX_SPOT.
+ */
+public interface FxSpotCurrencyUsageQueryPort {
+
+    /**
+     * Проверить использование валюты хотя бы в одном FX_SPOT инструменте.
+     */
+    boolean existsByCurrencyCode(CurrencyCode currencyCode);
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/query/usage/FxSpotCurrencyUsageQueryWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/query/usage/FxSpotCurrencyUsageQueryWiringConfig.java
@@ -1,0 +1,21 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.query.usage;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.usage.adapter.JooqFxSpotCurrencyUsageQueryAdapter;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.usage.port.FxSpotCurrencyUsageQueryPort;
+import org.jooq.DSLContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring-конфигурация query-port проверки использования валюты в FOREX_SPOT.
+ */
+@Configuration(proxyBeanMethods = false)
+public class FxSpotCurrencyUsageQueryWiringConfig {
+
+    public static final String BEAN_FX_SPOT_CURRENCY_USAGE_QUERY_PORT = "fxSpotCurrencyUsageQueryPort";
+
+    @Bean(BEAN_FX_SPOT_CURRENCY_USAGE_QUERY_PORT)
+    public FxSpotCurrencyUsageQueryPort fxSpotCurrencyUsageQueryPort(DSLContext dsl) {
+        return new JooqFxSpotCurrencyUsageQueryAdapter(dsl);
+    }
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
@@ -164,18 +164,6 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
                 .fetch(record -> toDomain(record, baseCurrencyRef, quoteCurrencyRef));
     }
 
-    @Override
-    public boolean existsByCurrencyCode(CurrencyCode currencyCode) {
-        Objects.requireNonNull(currencyCode, "currencyCode must not be null");
-
-        return dsl.fetchExists(
-                dsl.selectOne()
-                        .from(INSTRUMENT_FX_SPOT)
-                        .where(INSTRUMENT_FX_SPOT.BASE_CURRENCY.eq(currencyCode.value())
-                                .or(INSTRUMENT_FX_SPOT.QUOTE_CURRENCY.eq(currencyCode.value())))
-        );
-    }
-
     /* Проверяет наличие валюты в reference-таблице currency. */
     private void ensureCurrencyExists(CurrencyCode currencyCode) {
         Objects.requireNonNull(currencyCode, "currencyCode must not be null");

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/usage/contributor/fxspot/FxSpotCurrencyUsageContributor.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/application/usage/contributor/fxspot/FxSpotCurrencyUsageContributor.java
@@ -1,8 +1,8 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.application.usage.contributor.fxspot;
 
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.usage.contributor.CurrencyUsageContributor;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.usage.port.FxSpotCurrencyUsageQueryPort;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
-import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;
 
 import java.util.Objects;
 
@@ -11,16 +11,19 @@ import java.util.Objects;
  */
 public final class FxSpotCurrencyUsageContributor implements CurrencyUsageContributor {
 
-    private final FxSpotRepository fxSpotRepository;
+    private final FxSpotCurrencyUsageQueryPort fxSpotCurrencyUsageQueryPort;
 
-    public FxSpotCurrencyUsageContributor(FxSpotRepository fxSpotRepository) {
-        this.fxSpotRepository = Objects.requireNonNull(fxSpotRepository, "fxSpotRepository must not be null");
+    public FxSpotCurrencyUsageContributor(FxSpotCurrencyUsageQueryPort fxSpotCurrencyUsageQueryPort) {
+        this.fxSpotCurrencyUsageQueryPort = Objects.requireNonNull(
+                fxSpotCurrencyUsageQueryPort,
+                "fxSpotCurrencyUsageQueryPort must not be null"
+        );
     }
 
     @Override
     public boolean isUsed(CurrencyCode currencyCode) {
         Objects.requireNonNull(currencyCode, "currencyCode must not be null");
 
-        return fxSpotRepository.existsByCurrencyCode(currencyCode);
+        return fxSpotCurrencyUsageQueryPort.existsByCurrencyCode(currencyCode);
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/usage/contributor/CurrencyUsageContributorWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/application/usage/contributor/CurrencyUsageContributorWiringConfig.java
@@ -1,21 +1,28 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.usage.contributor;
 
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.usage.port.FxSpotCurrencyUsageQueryPort;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.query.usage.FxSpotCurrencyUsageQueryWiringConfig;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.usage.contributor.CurrencyUsageContributor;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.usage.contributor.fxspot.FxSpotCurrencyUsageContributor;
-import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * Wiring-конфигурация {@link CurrencyUsageContributor}.
  */
 @Configuration(proxyBeanMethods = false)
+@Import(FxSpotCurrencyUsageQueryWiringConfig.class)
 public class CurrencyUsageContributorWiringConfig {
 
     public static final String BEAN_FX_SPOT_CURRENCY_USAGE_CONTRIBUTOR = "fxSpotCurrencyUsageContributor";
 
     @Bean(BEAN_FX_SPOT_CURRENCY_USAGE_CONTRIBUTOR)
-    public CurrencyUsageContributor fxSpotCurrencyUsageContributor(FxSpotRepository fxSpotRepository) {
-        return new FxSpotCurrencyUsageContributor(fxSpotRepository);
+    public CurrencyUsageContributor fxSpotCurrencyUsageContributor(
+            @Qualifier(FxSpotCurrencyUsageQueryWiringConfig.BEAN_FX_SPOT_CURRENCY_USAGE_QUERY_PORT)
+            FxSpotCurrencyUsageQueryPort fxSpotCurrencyUsageQueryPort
+    ) {
+        return new FxSpotCurrencyUsageContributor(fxSpotCurrencyUsageQueryPort);
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/repository/FxSpotRepository.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/repository/FxSpotRepository.java
@@ -1,7 +1,6 @@
 package com.alligator.market.domain.instrument.asset.forex.fxspot.repository;
 
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
-import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 
 import java.util.List;
@@ -36,9 +35,4 @@ public interface FxSpotRepository {
      * Вернуть все инструменты.
      */
     List<FxSpot> findAll();
-
-    /**
-     * Проверить, используется ли код валюты хотя бы в одном инструменте.
-     */
-    boolean existsByCurrencyCode(CurrencyCode currencyCode);
 }


### PR DESCRIPTION
### Motivation

- Убрать технический read-only запрос из доменного репозитория, чтобы `FxSpotRepository` отвечал только за lifecycle-операции агрегата.
- Перенести проверку использования валюты в слой application/query через узкий порт для улучшения разделения ответственности и упрощения тестирования.

### Description

- Удалён метод `existsByCurrencyCode(CurrencyCode)` из интерфейса `domain/.../fxspot/repository/FxSpotRepository`.
- Удалена реализация `existsByCurrencyCode(...)` из `JooqFxSpotRepositoryAdapter`, при этом импорт `CurrencyCode` сохранён для `ensureCurrencyExists(...)` и `toCurrency(...)`.
- Добавлен query-port `FxSpotCurrencyUsageQueryPort` с методом `existsByCurrencyCode(CurrencyCode)` в `backend/.../application/query/usage/port`.
- Добавлен jOOQ-адаптер `JooqFxSpotCurrencyUsageQueryAdapter` в `backend/.../application/query/usage/adapter`, реализующий `fetchExists` по таблице `INSTRUMENT_FX_SPOT` с условием `BASE_CURRENCY = value OR QUOTE_CURRENCY = value`.
- Добавлен wiring-конфиг `FxSpotCurrencyUsageQueryWiringConfig` с bean `fxSpotCurrencyUsageQueryPort` для создания адаптера через `DSLContext`.
- Обновлён `FxSpotCurrencyUsageContributor`, заменена зависимость с `FxSpotRepository` на `FxSpotCurrencyUsageQueryPort`, метод `isUsed(...)` теперь вызывает `fxSpotCurrencyUsageQueryPort.existsByCurrencyCode(...)`.
- Обновлён `CurrencyUsageContributorWiringConfig` для импорта нового wiring-конфига и внедрения query-port через `@Qualifier`.

### Testing

- Выполнен проектный поиск `rg -n "existsByCurrencyCode"` и проверено, что в проекте остались только `FxSpotCurrencyUsageQueryPort`, `JooqFxSpotCurrencyUsageQueryAdapter` и `FxSpotCurrencyUsageContributor` (успех).
- Попытка сборки `./mvnw -q -DskipTests compile` не удалась из-за проблем с загрузкой дистрибутива Maven в этой среде (невозможно скачать `apache-maven-3.9.9-bin.zip`), поэтому локальная компиляция не завершена (неуспех).
- Изменения закоммичены в репозиторий (commit `Refactor FX spot currency usage check into query port`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee641a87f4832d837beb6f83ed2199)