### PR TITLE
Упростить FxSpotSameCurrenciesException

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/FxSpot.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/FxSpot.java
@@ -45,7 +45,7 @@ public record FxSpot(
 
         // Валюты не должны совпадать
         if (base.code().equals(quote.code())) {
-            throw new FxSpotSameCurrenciesException(base.code(), quote.code());
+            throw new FxSpotSameCurrenciesException(base.code());
         }
     }
 

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/exception/FxSpotSameCurrenciesException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/exception/FxSpotSameCurrenciesException.java
@@ -11,65 +11,17 @@ import java.util.Objects;
  */
 public final class FxSpotSameCurrenciesException extends BaseDomainException {
 
-    private final CurrencyCode base;
-    private final CurrencyCode quote;
-
     /**
      * Создает исключение.
      *
-     * @param base  код базовой валюты
-     * @param quote код котируемой валюты
+     * @param currencyCode код совпадающей валюты
      */
-    public FxSpotSameCurrenciesException(CurrencyCode base, CurrencyCode quote) {
-        super(DomainErrorCode.FX_SPOT_SAME_CURRENCIES, msg(base, quote));
-        this.base = Objects.requireNonNull(base, "base must not be null");
-        this.quote = Objects.requireNonNull(quote, "quote must not be null");
-    }
-
-    /**
-     * Создает исключение с причиной.
-     *
-     * @param base  код базовой валюты
-     * @param quote код котируемой валюты
-     * @param cause причина ошибки
-     */
-    @SuppressWarnings("unused")
-    public FxSpotSameCurrenciesException(CurrencyCode base, CurrencyCode quote, Throwable cause) {
-        super(DomainErrorCode.FX_SPOT_SAME_CURRENCIES, msg(base, quote), cause);
-        this.base = Objects.requireNonNull(base, "base must not be null");
-        this.quote = Objects.requireNonNull(quote, "quote must not be null");
-    }
-
-    /**
-     * Формирует сообщение об ошибке.
-     *
-     * @param base  код базовой валюты
-     * @param quote код котируемой валюты
-     * @return текст сообщения
-     */
-    private static String msg(CurrencyCode base, CurrencyCode quote) {
-        CurrencyCode b = Objects.requireNonNull(base, "base must not be null");
-        CurrencyCode q = Objects.requireNonNull(quote, "quote must not be null");
-        return "Base and quote currencies must be different (base=" + b.value() + ", quote=" + q.value() + ")";
-    }
-
-    /**
-     * Возвращает код базовой валюты.
-     *
-     * @return код базовой валюты
-     */
-    @SuppressWarnings("unused")
-    public CurrencyCode getBaseCurrency() {
-        return base;
-    }
-
-    /**
-     * Возвращает код котируемой валюты.
-     *
-     * @return код котируемой валюты
-     */
-    @SuppressWarnings("unused")
-    public CurrencyCode getQuoteCurrency() {
-        return quote;
+    public FxSpotSameCurrenciesException(CurrencyCode currencyCode) {
+        super(
+                DomainErrorCode.FX_SPOT_SAME_CURRENCIES,
+                "Base and quote currencies must be different (currency=%s)".formatted(
+                        Objects.requireNonNull(currencyCode, "currencyCode must not be null").value()
+                )
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Снизить сложность `FxSpotSameCurrenciesException` оставив только необходимую информацию для ошибки и упростив создание исключения.
- Упростить вызов в модели `FxSpot` и убрать избыточное хранение полей `base` и `quote` в исключении.

### Description

- Заменён класс `FxSpotSameCurrenciesException` на компактную реализацию, которая продолжает наследоваться от `BaseDomainException` и использует `DomainErrorCode.FX_SPOT_SAME_CURRENCIES` и новый конструктор `FxSpotSameCurrenciesException(CurrencyCode currencyCode)` с сообщением `"Base and quote currencies must be different (currency=%s)"`.
- Удалены поля `base`/`quote`, их геттеры и конструктор с `cause` из класса исключения.
- В `FxSpot` заменён вызов `new FxSpotSameCurrenciesException(base.code(), quote.code())` на `new FxSpotSameCurrenciesException(base.code())`.
- Проверены и удалены неиспользуемые импорты в затронутых файлах.

### Testing

- Выполнялся запуск компиляции модуля через `./mvnw -pl domain -DskipTests compile`, который не завершился из-за попытки загрузки Maven Wrapper дистрибутива в окружении.
- Выполнялся запуск компиляции через `mvn -pl domain -DskipTests compile`, который не завершился из-за ошибки при загрузке зависимостей из Maven Central (`403 Forbidden`).
- Из-за ограничений среды автоматические сборочные тесты/компиляция не прошли, изменения ограничиваются статическими правками кода и обновлением вызовов исключения.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee714b6320832d972bf30d7e562d9b)