### PR TITLE
refactor(fxspot): финальная полировка command/response имен в slice

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
@@ -54,7 +54,6 @@ public class FxSpotRestExceptionHandler {
         return ResponseEntityFactory.badRequest(DomainErrorCode.FX_SPOT_SAME_CURRENCIES.name(), ex.getMessage());
     }
 
-
     @ExceptionHandler(FxSpotInUseException.class)
     public ResponseEntity<ApiResponse<Void>> fxSpotInUse(FxSpotInUseException ex) {
         log.warn("FX Spot is in use: {}", ex.getMessage());
@@ -78,7 +77,7 @@ public class FxSpotRestExceptionHandler {
         return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, errorCode, ex.getMessage());
     }
 
-    /* Подбираем код ошибки для технических доменных исключений. */
+    /* Подбираем код ошибки для технических application-исключений FX_SPOT. */
     private String resolveTechnicalErrorCode(RuntimeException ex) {
         if (ex instanceof FxSpotCreateException) {
             return DomainErrorCode.FX_SPOT_CREATE_FAILED.name();

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/create/mapper/CreateFxSpotRequestMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/create/mapper/CreateFxSpotRequestMapper.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.create.mapper;
 
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.create.dto.CreateFxSpotRequest;
-import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.create.dto.CreateFxSpotCommand;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.create.CreateFxSpotCommand;
 
 import java.util.Objects;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/update/mapper/UpdateFxSpotRequestMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/update/mapper/UpdateFxSpotRequestMapper.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.update.mapper;
 
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.update.dto.UpdateFxSpotRequest;
-import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.update.dto.UpdateFxSpotCommand;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.update.UpdateFxSpotCommand;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 
 import java.util.Objects;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/controller/ListFxSpotsController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/controller/ListFxSpotsController.java
@@ -2,8 +2,8 @@ package com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.lis
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
-import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.dto.FxSpotListResponse;
-import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.mapper.FxSpotListResponseMapper;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.dto.FxSpotListItemResponse;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.mapper.FxSpotListItemResponseMapper;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.list.ListFxSpotsService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,9 +26,9 @@ public class ListFxSpotsController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<FxSpotListResponse>>> getAll() {
-        List<FxSpotListResponse> list = listFxSpotsService.findAll().stream()
-                .map(FxSpotListResponseMapper::toResponse)
+    public ResponseEntity<ApiResponse<List<FxSpotListItemResponse>>> getAll() {
+        List<FxSpotListItemResponse> list = listFxSpotsService.findAll().stream()
+                .map(FxSpotListItemResponseMapper::toResponse)
                 .toList();
 
         return ResponseEntityFactory.ok(list);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/dto/FxSpotListItemResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/dto/FxSpotListItemResponse.java
@@ -5,7 +5,7 @@ import com.alligator.market.domain.instrument.asset.forex.fxspot.classification.
 /**
  * API-ответ для списка инструментов FOREX_SPOT.
  */
-public record FxSpotListResponse(
+public record FxSpotListItemResponse(
         String instrumentCode,
         String symbol,
         String asset,

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/mapper/FxSpotListItemResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/mapper/FxSpotListItemResponseMapper.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.mapper;
 
-import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.dto.FxSpotListResponse;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.dto.FxSpotListItemResponse;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 
 import java.util.Objects;
@@ -8,16 +8,16 @@ import java.util.Objects;
 /**
  * Маппер доменной модели FOREX_SPOT в API-ответ списка.
  */
-public final class FxSpotListResponseMapper {
+public final class FxSpotListItemResponseMapper {
 
-    private FxSpotListResponseMapper() {
+    private FxSpotListItemResponseMapper() {
         throw new UnsupportedOperationException("Utility class");
     }
 
-    public static FxSpotListResponse toResponse(FxSpot fxSpot) {
+    public static FxSpotListItemResponse toResponse(FxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
-        return new FxSpotListResponse(
+        return new FxSpotListItemResponse(
                 fxSpot.instrumentCode().value(),
                 fxSpot.instrumentSymbol().value(),
                 fxSpot.asset().name(),

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/create/CreateFxSpotCommand.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/create/CreateFxSpotCommand.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.create.dto;
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.create;
 
 import com.alligator.market.domain.instrument.asset.forex.fxspot.classification.FxSpotTenor;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/create/CreateFxSpotService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/create/CreateFxSpotService.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.create;
 
-import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.create.dto.CreateFxSpotCommand;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/update/UpdateFxSpotCommand.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/update/UpdateFxSpotCommand.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.update.dto;
+package com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.update;
 
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/update/UpdateFxSpotService.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/application/command/update/UpdateFxSpotService.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.update;
 
-import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.update.dto.UpdateFxSpotCommand;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotNotFoundException;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.FxSpot;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.repository.FxSpotRepository;


### PR DESCRIPTION
### Motivation
- Упорядочить контракты слоя application: убрать вложенные `dto`-пакеты для команд и привести имена API-ответов к явному «item» варианту для ясности и консистентности. 
- Исправить описательный комментарий в обработчике ошибок и убрать лишний пустой ряд для аккуратности кода.

### Description
- Перемещены записи-команды `CreateFxSpotCommand` и `UpdateFxSpotCommand` из пакетов `application/command/*/dto` в корневые пакеты `application/command/create` и `application/command/update` без изменения их содержимого или контрактов. 
- Обновлены импорты в `CreateFxSpotService`, `CreateFxSpotRequestMapper`, `UpdateFxSpotService` и `UpdateFxSpotRequestMapper` для новых путей к командам. 
- В `FxSpotRestExceptionHandler` обновлён комментарий на `/* Подбираем код ошибки для технических application-исключений FX_SPOT. */` и удалена лишняя пустая строка перед обработчиком `FxSpotInUseException`. 
- Переименован API-ответ списка: `FxSpotListResponse` → `FxSpotListItemResponse`, маппер `FxSpotListResponseMapper` → `FxSpotListItemResponseMapper`, и соответствующим образом обновлён `ListFxSpotsController`. 

### Testing
- Выполнен поиск и проверка отсутствия старых пакетов команд с помощью `find` и `rg`, подтверждён успешный рефакторинг (старых `application/command/*/dto` в FX_SPOT нет). 
- Проверены правки импортов и использования новых имён через `rg`/`git diff` и просмотр файлов, изменения согласованы и не оставили старых ссылок. 
- Попытка сборки `mvn -pl backend -am -DskipTests compile` была выполнена, но завершилась неуспехом из-за ограничения окружения при разрешении parent POM (`403 Forbidden` при доступе к Maven Central), поэтому локальная компиляция в CI-контейнере не подтверждена.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7ba6eae4832dbfba4a8f92dffe52)