### PR TITLE
refactor(currency): обработка дубликата по `code` через ON CONFLICT

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
@@ -23,7 +23,6 @@ import static com.alligator.market.backend.infra.jooq.generated.tables.Currency.
 public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
 
     /* Имена UQ ограничений (должны совпадать с фактическими именами в DDL/схеме). */
-    private static final String UQ_CURRENCY_CODE = "uq_currency_code";
     private static final String UQ_CURRENCY_NAME = "uq_currency_name";
 
     /* DSLContext для выполнения SQL-запросов через jOOQ. */
@@ -43,6 +42,8 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
                     .set(CURRENCY.NAME, currency.name())
                     .set(CURRENCY.COUNTRY, currency.country())
                     .set(CURRENCY.FRACTION_DIGITS, currency.fractionDigits())
+                    .onConflict(CURRENCY.CODE)
+                    .doNothing()
                     .returning(
                             CURRENCY.CODE,
                             CURRENCY.NAME,
@@ -51,13 +52,10 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
                     )
                     .fetchOne();
             if (createdRecord == null) {
-                throw new IllegalStateException("Currency insert returned no row");
+                throw new CurrencyAlreadyExistsException(currency.code());
             }
             return toDomain(createdRecord);
         } catch (DataIntegrityViolationException ex) {
-            if (DbErrors.isViolationOf(ex, UQ_CURRENCY_CODE)) {
-                throw new CurrencyAlreadyExistsException(currency.code());
-            }
             if (DbErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
                 throw new CurrencyNameDuplicateException(currency.name());
             }


### PR DESCRIPTION
### Motivation

- Сделать обработку дублей при создании валюты более практичной и согласованной со стилем `fxspot`, обработав конфликт по `code` на уровне SQL вместо исключения из DB-ошибки. 
- Сохранить надёжную обработку конфликта по имени через `DbErrors`, потому что это отдельный уникальный constraint и его удобнее ловить по факту DB-violation.

### Description

- Удалена константа `UQ_CURRENCY_CODE` из `JooqCurrencyRepositoryAdapter` и оставлена `UQ_CURRENCY_NAME`.
- В `create(Currency currency)` добавлено использование `onConflict(CURRENCY.CODE).doNothing()` и последующая проверка результата `fetchOne()`; при `null` теперь бросается `CurrencyAlreadyExistsException` вместо определения по `DbErrors`.
- В `catch (DataIntegrityViolationException)` метода `create` оставлена только проверка `DbErrors.isViolationOf(ex, UQ_CURRENCY_NAME)` с выбросом `CurrencyNameDuplicateException`.
- Логика `update(Currency currency)` не менялась и по-прежнему обрабатывает `uq_currency_name` через `DbErrors`, а отсутствие строки — через `CurrencyNotFoundException`.

### Testing

- Выполнен поиск по коду: подтверждено отсутствие `UQ_CURRENCY_CODE` в адаптере с помощью `rg` (успешно).
- Проверено, что `DbErrors` продолжает использоваться для `UQ_CURRENCY_NAME` с помощью `rg` (успешно).
- Попытка компиляции с `./mvnw -pl backend -DskipTests compile` была выполнена, но завершилась ошибкой окружения (не удалось скачать Maven дистрибутив), поэтому автоматическая компиляция не прошла в этой среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8265fe60832d83b14bd428dfe4d5)