### PR TITLE
Сделать API-коды ошибок currency локальными (CurrencyApiErrorCodes)

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/advice/CurrencyRestExceptionHandler.java
@@ -8,7 +8,7 @@ import com.alligator.market.backend.instrument.asset.forex.reference.currency.ap
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyInUseException;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNameDuplicateException;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
-import com.alligator.market.domain.common.exception.DomainErrorCode;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.api.error.CurrencyApiErrorCodes;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -40,7 +40,7 @@ public class CurrencyRestExceptionHandler {
                 HttpStatus.CONFLICT,
                 "Currency already exists",
                 ex.getMessage(),
-                DomainErrorCode.CURRENCY_ALREADY_EXISTS.name()
+                CurrencyApiErrorCodes.CURRENCY_ALREADY_EXISTS
         );
     }
 
@@ -54,7 +54,7 @@ public class CurrencyRestExceptionHandler {
                 HttpStatus.CONFLICT,
                 "Currency name duplicate",
                 ex.getMessage(),
-                DomainErrorCode.CURRENCY_NAME_DUPLICATE.name()
+                CurrencyApiErrorCodes.CURRENCY_NAME_DUPLICATE
         );
     }
 
@@ -68,7 +68,7 @@ public class CurrencyRestExceptionHandler {
                 HttpStatus.CONFLICT,
                 "Currency is in use",
                 ex.getMessage(),
-                DomainErrorCode.CURRENCY_IN_USE.name()
+                CurrencyApiErrorCodes.CURRENCY_IN_USE
         );
     }
 
@@ -82,7 +82,7 @@ public class CurrencyRestExceptionHandler {
                 HttpStatus.NOT_FOUND,
                 "Currency not found",
                 ex.getMessage(),
-                DomainErrorCode.CURRENCY_NOT_FOUND.name()
+                CurrencyApiErrorCodes.CURRENCY_NOT_FOUND
         );
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/error/CurrencyApiErrorCodes.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/error/CurrencyApiErrorCodes.java
@@ -1,0 +1,13 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.api.error;
+
+/* Локальные API-коды ошибок currency feature. */
+public final class CurrencyApiErrorCodes {
+
+    public static final String CURRENCY_ALREADY_EXISTS = "CURRENCY_ALREADY_EXISTS";
+    public static final String CURRENCY_NAME_DUPLICATE = "CURRENCY_NAME_DUPLICATE";
+    public static final String CURRENCY_IN_USE = "CURRENCY_IN_USE";
+    public static final String CURRENCY_NOT_FOUND = "CURRENCY_NOT_FOUND";
+
+    private CurrencyApiErrorCodes() {
+    }
+}


### PR DESCRIPTION
### Motivation
- Убрать зависимость currency feature от общего `DomainErrorCode` и сделать API-коды ошибок локальными рядом с API для повышения независимости фичи. 
- Сохранить существующий REST error contract (`title`, `detail`, `errorCode`) при переносе источника значений `errorCode` в локальный класс.

### Description
- Добавлен локальный класс `CurrencyApiErrorCodes` в `backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/api/error` с константами `CURRENCY_ALREADY_EXISTS`, `CURRENCY_NAME_DUPLICATE`, `CURRENCY_IN_USE` и `CURRENCY_NOT_FOUND`.
- В `CurrencyRestExceptionHandler` удалён импорт `com.alligator.market.domain.common.exception.DomainErrorCode` и заменён на `com.alligator.market.backend.instrument.asset.forex.reference.currency.api.error.CurrencyApiErrorCodes`.
- Все места, где ранее использовалось `DomainErrorCode.<X>.name()`, теперь используют соответствующие константы из `CurrencyApiErrorCodes`, при этом типовые application-исключения (`CurrencyAlreadyExistsException`, `CurrencyNameDuplicateException`, `CurrencyInUseException`, `CurrencyNotFoundException`) не изменялись.
- Контракт `ProblemDetail` оставлен без изменений и по-прежнему содержит `title`, `detail`, `errorCode` (теперь `errorCode` берётся из локального класса).

### Testing
- Выполнен поиск ссылок на `DomainErrorCode` в пакете currency с помощью `rg`, результат: совпадений не найдено (проверка успешна).
- Запуск сборки модуля через `./mvnw -pl backend -am -DskipTests compile` завершился неудачно из-за ошибки скачивания Maven дистрибутива в окружении (`Failed to fetch apache-maven-3.9.9-bin.zip`), поэтому полная компиляция не была подтверждена (неудача).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbb8a2e80832da19e16733155ae0b)