### PR TITLE
refactor: generalize DB constraint error utility (DbErrors → DbConstraintErrors)

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrors.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrors.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.common.persistence.jpa.constraint;
+package com.alligator.market.backend.common.persistence.constraint;
 
 import org.hibernate.exception.ConstraintViolationException;
 
@@ -8,7 +8,10 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Утилита для распознавания нарушения конкретного ограничения БД по имени этого ограничения.
+ * Утилита для распознавания нарушения именованного ограничения БД.
+ *
+ * <p>Используется на persistence-границе для перевода низкоуровневых DB errors
+ * в application/domain-specific exceptions.</p>
  *
  * <p>Пример: Предположим, что в БД есть таблица, в которой задано ограничение (UNIQUE) на уникальность
  * значений в одной из колонок. В данном приложении, согласно лучшим практикам, каждому ограничению назначается
@@ -23,12 +26,12 @@ import java.util.Set;
  *
  * <p>Ограничения: Метод опирается на наличие осмысленно заданного уникального имени ограничения.</p>
  */
-public final class DbErrors {
+public final class DbConstraintErrors {
 
     /**
      * Приватный конструктор: запрещаем создание экземпляров, так как класс является утилитой.
      */
-    private DbErrors() {
+    private DbConstraintErrors() {
         throw new UnsupportedOperationException("Utility class instantiation is not allowed");
     }
 

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.instrument.asset.forex.reference.currency.persistence.jooq.repository;
 
-import com.alligator.market.backend.common.persistence.jpa.constraint.DbErrors;
+import com.alligator.market.backend.common.persistence.constraint.DbConstraintErrors;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyAlreadyExistsException;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNameDuplicateException;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
@@ -56,7 +56,7 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
             }
             return toDomain(createdRecord);
         } catch (DataIntegrityViolationException ex) {
-            if (DbErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
+            if (DbConstraintErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
                 throw new CurrencyNameDuplicateException(currency.name());
             }
             throw ex;
@@ -83,7 +83,7 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
             return updatedCurrency
                     .orElseThrow(() -> new CurrencyNotFoundException(currency.code()));
         } catch (DataIntegrityViolationException ex) {
-            if (DbErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
+            if (DbConstraintErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
                 throw new CurrencyNameDuplicateException(currency.name());
             }
             throw ex;

--- a/backend/src/test/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrorsTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrorsTest.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.common.persistence.jpa.constraint;
+package com.alligator.market.backend.common.persistence.constraint;
 
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Tag;
@@ -6,14 +6,16 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Тесты класса {@link DbErrors} для проверки распознавания нарушений ограничений БД.
+ * Тесты класса {@link DbConstraintErrors} для проверки распознавания нарушений ограничений БД.
  */
 @Tag("dev")
-class DbErrorsTest {
+class DbConstraintErrorsTest {
 
     /**
      * Должен вернуть true так как это “идеальный” вариант алгоритма:
@@ -28,7 +30,7 @@ class DbErrorsTest {
 
         RuntimeException ex = new RuntimeException("wrap", cve);
 
-        assertTrue(DbErrors.isViolationOf(ex, "UQ_SOME_COLUMN")); // <-- Заглавными буквами для проверки, что регистр не влияет
+        assertTrue(DbConstraintErrors.isViolationOf(ex, "UQ_SOME_COLUMN")); // <-- Заглавными буквами для проверки, что регистр не влияет
     }
 
     /**
@@ -40,7 +42,7 @@ class DbErrorsTest {
         RuntimeException root = new RuntimeException("violates constraint uq_some_column");
         RuntimeException ex = new RuntimeException("wrap", root);
 
-        assertTrue(DbErrors.isViolationOf(ex, "uq_some_column"));
+        assertTrue(DbConstraintErrors.isViolationOf(ex, "uq_some_column"));
     }
 
     /**
@@ -50,16 +52,42 @@ class DbErrorsTest {
     @Test
     void shouldReturnFalseWhenNotMatched() {
         RuntimeException ex = new RuntimeException("some error");
-        assertFalse(DbErrors.isViolationOf(ex, "uq_some_column"));
+        assertFalse(DbConstraintErrors.isViolationOf(ex, "uq_some_column"));
     }
 
     /**
-     * Должен корректно завершаться при циклической cause-цепочке (защита от зацикливания) и вернуть false,
-     * если совпадение не найдено.
+     * Должен вернуть true, если совпадение по сообщению найдено только в другом регистре.
+     */
+    @Test
+    void shouldCompareConstraintNameCaseInsensitiveInMessages() {
+        RuntimeException ex = new RuntimeException("violates constraint UQ_SOME_COLUMN");
+
+        assertTrue(DbConstraintErrors.isViolationOf(ex, "uq_some_column"));
+    }
+
+    @Test
+    void shouldThrowWhenExceptionIsNull() {
+        assertThrows(NullPointerException.class, () -> DbConstraintErrors.isViolationOf(null, "uq_some_column"));
+    }
+
+    @Test
+    void shouldThrowWhenConstraintNameIsNull() {
+        RuntimeException ex = new RuntimeException("error");
+        assertThrows(NullPointerException.class, () -> DbConstraintErrors.isViolationOf(ex, null));
+    }
+
+    @Test
+    void shouldThrowWhenConstraintNameIsBlank() {
+        RuntimeException ex = new RuntimeException("error");
+        assertThrows(IllegalArgumentException.class, () -> DbConstraintErrors.isViolationOf(ex, "   "));
+    }
+
+    /**
+     * Должен корректно завершаться при циклической cause-цепочке (защита от зацикливания).
      */
     @SuppressWarnings("UnnecessaryInitCause")
     @Test
-    void shouldNotHangOnCyclicCauseChain() {
+    void shouldHandleCyclicCauseChainSafely() {
         RuntimeException a = new RuntimeException("a");
         RuntimeException b = new RuntimeException("b");
 
@@ -67,6 +95,7 @@ class DbErrorsTest {
         a.initCause(b);
         b.initCause(a);
 
-        assertFalse(DbErrors.isViolationOf(a, "uq_some_column"));
+        assertDoesNotThrow(() -> DbConstraintErrors.isViolationOf(a, "uq_some_column"));
+        assertFalse(DbConstraintErrors.isViolationOf(a, "uq_some_column"));
     }
 }


### PR DESCRIPTION
### Motivation

- Обобщить утилиту распознавания нарушений DB-constraints, чтобы её можно было использовать за пределами JPA-части инфраструктуры. 
- Сохранить принцип: обработка именованных DB constraint’ов выполняется на persistence-границе, а application services не знают имён constraint’ов. 

### Description

- Переименован и перемещён класс `DbErrors` в `DbConstraintErrors` с новым package `com.alligator.market.backend.common.persistence.constraint` и улучшенным JavaDoc, при этом поведение `isViolationOf(...)` не изменялось. 
- Обновлены все вызовы/импорты: адаптер `JooqCurrencyRepositoryAdapter` теперь использует `DbConstraintErrors.isViolationOf(...)`, а константа `UQ_CURRENCY_NAME` остаётся приватной и локальной в адаптере. 
- Тестовый класс переименован и расширен в `backend/src/test/java/.../DbConstraintErrorsTest.java` с дополнительными проверками: null/blank валидация, case-insensitive сравнение, message-fallback, и безопасная обработка циклической cause-chain. 
- Не вносились изменения в application-слой для currency-фичи и не добавлялись предварительные проверки (`existsByName(...)`) в репозитории или сервисы. 

### Testing

- Попытка запустить `./mvnw -pl backend test -DskipITs` завершилась неудачей из-за невозможности скачать Maven в окружении, поэтому автоматические сборка/тесты не завершились. 
- Аналогичная попытка `mvn -pl backend test -DskipITs` не прошла из-за недоступности родительского POM в Maven Central (HTTP 403). 
- Выполнены локальные проверки кода: обновлённые тесты присутствуют, старый файл `DbErrors.java` и старые импорты не обнаружены, и `JooqCurrencyRepositoryAdapter` использует `DbConstraintErrors` при обработке `DataIntegrityViolationException` (проверено поиском по коду). 
- Unit-тесты для утилиты были обновлены/расширены в кодовой базе и готовы для выполнения в рабочей среде CI, когда внешние зависимости будут доступны.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc346a904832db86594ad006c9b76)