### PR TITLE
fix: перевод FK-ошибки удаления fxspot в FxSpotInUseException

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
@@ -1,8 +1,10 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.persistence.jooq.repository;
 
+import com.alligator.market.backend.common.persistence.constraint.DbConstraintErrors;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotAlreadyExistsException;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotCreateException;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotDeleteException;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotInUseException;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotNotFoundException;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotUpdateException;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
@@ -29,6 +31,9 @@ import static com.alligator.market.backend.infra.jooq.generated.tables.Instrumen
  * jOOQ-адаптер доменного репозитория инструментов FOREX_SPOT.
  */
 public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
+
+    /* Имя FK-ограничения, блокирующего удаление используемого FX_SPOT инструмента. */
+    private static final String FK_SOURCE_PLAN_INSTRUMENT = "fk_instr_source_plan_instrument";
 
     /* DSLContext для выполнения SQL-запросов через jOOQ. */
     private final DSLContext dsl;
@@ -91,9 +96,6 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
     public FxSpot update(FxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
-        ensureCurrencyExists(fxSpot.base().code());
-        ensureCurrencyExists(fxSpot.quote().code());
-
         try {
             int updatedRows = dsl.update(INSTRUMENT_FX_SPOT)
                     .set(INSTRUMENT_FX_SPOT.QUOTE_FRACTION_DIGITS, fxSpot.defaultQuoteFractionDigits())
@@ -136,6 +138,9 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
                 }
             });
         } catch (DataAccessException ex) {
+            if (DbConstraintErrors.isViolationOf(ex, FK_SOURCE_PLAN_INSTRUMENT)) {
+                throw new FxSpotInUseException(instrumentCode);
+            }
             throw new FxSpotDeleteException(instrumentCode, ex);
         }
     }


### PR DESCRIPTION
### Motivation

- Обработать race condition: при параллельном создании `source_plan` удаление `FX_SPOT` может упереться в FK `fk_instr_source_plan_instrument` и должно транслироваться в понятное application-исключение `FxSpotInUseException` на persistence-границе.
- Сохранить границы ответственностей: перевод DB constraint ошибок должен выполняться только в persistence/infrastructure слое с помощью `DbConstraintErrors`.

### Description

- Добавлен импорт `DbConstraintErrors` и локальная константа `FK_SOURCE_PLAN_INSTRUMENT = "fk_instr_source_plan_instrument"` в `JooqFxSpotRepositoryAdapter` рядом с полями класса, чтобы имя ограничения оставалось в persistence-слое.
- В `deleteByCode(...)` добавлена обработка `DataAccessException`: если `DbConstraintErrors.isViolationOf(ex, FK_SOURCE_PLAN_INSTRUMENT)` — бросается `FxSpotInUseException(instrumentCode)`, иначе сохраняется существующий `FxSpotDeleteException` fallback.
- Удалены лишние вызовы `ensureCurrencyExists(...)` в `update(...)`, так как метод изменяет только `quote_fraction_digits` и повторная проверка валют избыточна.
- Логика `create(...)` и поведение `onConflict(...).doNothing()` оставлены без изменений, интерфейс `FxSpotRepository` не менялся.

### Testing

- Запуск `mvn -pl backend test -DskipITs` завершился ошибкой из-за невозможности разрешить parent POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5`) в текущем окружении, поэтому автоматические тесты не были выполнены (dependency resolution failure, 403).
- Запуски `mvn -pl backend -DskipTests compile` и `mvn -pl backend generate-sources -DskipTests` также не удалось выполнить по той же причине.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efca1dd96c832dba0afd11c28dabe4)