### PR TITLE
fix: map source plan instrument fk violation

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepository.java
@@ -1,11 +1,14 @@
 package com.alligator.market.backend.sourcing.plan.persistence.jooq.repository;
 
+import com.alligator.market.backend.common.persistence.constraint.DbConstraintErrors;
+import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentCodeNotFoundException;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import com.alligator.market.domain.provider.vo.ProviderCode;
 import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
 import com.alligator.market.domain.sourcing.plan.repository.InstrumentSourcePlanRepository;
 import com.alligator.market.domain.sourcing.source.MarketDataSource;
 import org.jooq.DSLContext;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.*;
 
@@ -16,6 +19,9 @@ import static com.alligator.market.backend.infra.jooq.generated.tables.SourcePla
  * jOOQ-адаптер репозитория планов источников.
  */
 public final class JooqInstrumentSourcePlanRepository implements InstrumentSourcePlanRepository {
+
+    /* Имя FK-ограничения source_plan -> instrument_registry по коду инструмента. */
+    private static final String FK_SOURCE_PLAN_INSTRUMENT = "fk_instr_source_plan_instrument";
 
     /* DSLContext для выполнения SQL через jOOQ. */
     private final DSLContext dsl;
@@ -94,25 +100,33 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
     public boolean createIfAbsent(InstrumentSourcePlan plan) {
         Objects.requireNonNull(plan, "plan must not be null");
 
-        return dsl.transactionResult(configuration -> {
-            DSLContext tx = configuration.dsl();
+        try {
+            return dsl.transactionResult(configuration -> {
+                DSLContext tx = configuration.dsl();
 
-            int insertedPlans = tx.insertInto(SOURCE_PLAN)
-                    .set(SOURCE_PLAN.INSTRUMENT_CODE, plan.instrumentCode().value())
-                    .onConflict(SOURCE_PLAN.INSTRUMENT_CODE)
-                    .doNothing()
-                    .execute();
+                int insertedPlans = tx.insertInto(SOURCE_PLAN)
+                        .set(SOURCE_PLAN.INSTRUMENT_CODE, plan.instrumentCode().value())
+                        .onConflict(SOURCE_PLAN.INSTRUMENT_CODE)
+                        .doNothing()
+                        .execute();
 
-            if (insertedPlans == 0) {
-                return false;
+                if (insertedPlans == 0) {
+                    return false;
+                }
+
+                for (MarketDataSource source : plan.sources()) {
+                    insertSource(tx, plan.instrumentCode(), source);
+                }
+
+                return true;
+            });
+        } catch (DataIntegrityViolationException ex) {
+            if (DbConstraintErrors.isViolationOf(ex, FK_SOURCE_PLAN_INSTRUMENT)) {
+                throw new InstrumentCodeNotFoundException(plan.instrumentCode());
             }
 
-            for (MarketDataSource source : plan.sources()) {
-                insertSource(tx, plan.instrumentCode(), source);
-            }
-
-            return true;
-        });
+            throw ex;
+        }
     }
 
 

--- a/backend/src/test/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepositoryTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepositoryTest.java
@@ -1,0 +1,89 @@
+package com.alligator.market.backend.sourcing.plan.persistence.jooq.repository;
+
+import com.alligator.market.backend.sourcing.plan.application.exception.InstrumentCodeNotFoundException;
+import com.alligator.market.domain.instrument.vo.InstrumentCode;
+import com.alligator.market.domain.provider.vo.ProviderCode;
+import com.alligator.market.domain.sourcing.plan.InstrumentSourcePlan;
+import com.alligator.market.domain.sourcing.source.MarketDataSource;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Тесты jOOQ-адаптера репозитория плана источников.
+ */
+@Tag("dev")
+class JooqInstrumentSourcePlanRepositoryTest {
+
+    @Test
+    void shouldMapInstrumentFkViolationToInstrumentCodeNotFoundException() {
+        /* Мокаем DSLContext как persistence-границу. */
+        DSLContext dsl = mock(DSLContext.class);
+
+        /* FK violation с именем целевого constraint в cause-цепочке. */
+        DataIntegrityViolationException violation = new DataIntegrityViolationException(
+                "insert failed",
+                new IllegalStateException("violates constraint fk_instr_source_plan_instrument")
+        );
+
+        given(dsl.transactionResult(any())).willThrow(violation);
+
+        JooqInstrumentSourcePlanRepository repository = new JooqInstrumentSourcePlanRepository(dsl);
+        InstrumentSourcePlan plan = sourcePlan("EUR_USD");
+
+        assertThrows(InstrumentCodeNotFoundException.class, () -> repository.createIfAbsent(plan));
+    }
+
+    @Test
+    void shouldRethrowUnknownDataIntegrityViolation() {
+        /* Мокаем DSLContext как persistence-границу. */
+        DSLContext dsl = mock(DSLContext.class);
+
+        /* Нарушение другого ограничения не должно маппиться в application-исключение. */
+        DataIntegrityViolationException violation = new DataIntegrityViolationException(
+                "insert failed",
+                new IllegalStateException("violates constraint uq_market_data_source_instr_provider")
+        );
+
+        given(dsl.transactionResult(any())).willThrow(violation);
+
+        JooqInstrumentSourcePlanRepository repository = new JooqInstrumentSourcePlanRepository(dsl);
+        InstrumentSourcePlan plan = sourcePlan("EUR_USD");
+
+        DataIntegrityViolationException actual =
+                assertThrows(DataIntegrityViolationException.class, () -> repository.createIfAbsent(plan));
+
+        assertSame(violation, actual);
+    }
+
+    @Test
+    void shouldReturnFalseWhenPlanAlreadyExists() {
+        /* Проверяем сохранение контракта createIfAbsent при отсутствии вставки. */
+        DSLContext dsl = mock(DSLContext.class);
+        given(dsl.transactionResult(any())).willReturn(false);
+
+        JooqInstrumentSourcePlanRepository repository = new JooqInstrumentSourcePlanRepository(dsl);
+
+        boolean created = repository.createIfAbsent(sourcePlan("EUR_USD"));
+
+        assertFalse(created);
+    }
+
+    /* Создает валидный aggregate для тестовых сценариев. */
+    private InstrumentSourcePlan sourcePlan(String instrumentCode) {
+        return new InstrumentSourcePlan(
+                new InstrumentCode(instrumentCode),
+                List.of(new MarketDataSource(new ProviderCode("MOEX"), true, 0))
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Обработать ситуацию race condition при вставке `SourcePlan`, когда между pre-check в application service и INSERT параллельная операция удаляет `instrument_registry` и БД возвращает FK-ошибку; цель — переводить эту техническую DB-ошибку в понятное application-исключение. 
- Сохранить границы слоёв: имена DB-constraint остаются в persistence-адаптере и не протекают в service/validator.

### Description
- Добавлен constant `FK_SOURCE_PLAN_INSTRUMENT = "fk_instr_source_plan_instrument"` в `JooqInstrumentSourcePlanRepository` рядом с persistence-кодом. 
- В `JooqInstrumentSourcePlanRepository` добавлены импорты `DbConstraintErrors` и `DataIntegrityViolationException` и `InstrumentCodeNotFoundException`. 
- Метод `createIfAbsent(InstrumentSourcePlan)` обёрнут в `try/catch` и при `DataIntegrityViolationException` выполняется проверка `DbConstraintErrors.isViolationOf(ex, FK_SOURCE_PLAN_INSTRUMENT)` с трансляцией в `InstrumentCodeNotFoundException`; при прочих нарушениях исключение пробрасывается дальше. 
- Сохранено поведение `onConflict(SOURCE_PLAN.INSTRUMENT_CODE).doNothing()` и контракт: если `insertedPlans == 0` — вернуть `false`; `deleteIfExistsByInstrumentCode(...)` не изменён. 
- Добавлен unit-тест `backend/src/test/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepositoryTest.java` с тремя тестами: перевод FK-ошибки в `InstrumentCodeNotFoundException`, повторная проброска прочих `DataIntegrityViolationException` и проверка поведения при уже существующем плане.

### Testing
- Добавлены модульные тесты `JooqInstrumentSourcePlanRepositoryTest` с моками (`DSLContext`) и сценариями: FK-нарушение → `InstrumentCodeNotFoundException`, неизвестное нарушение → проброс `DataIntegrityViolationException`, already-exists → возвращается `false` (файлы: `backend/src/test/.../JooqInstrumentSourcePlanRepositoryTest.java`).
- Попытка запустить тесты командой `mvn -pl backend -Dtest=JooqInstrumentSourcePlanRepositoryTest -DexcludedGroups= test` завершилась неуспехом в этом окружении из‑за ошибки резолва parent POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5` вернул `403 Forbidden`), поэтому тесты не выполнялись здесь.
- Локальные проверки ограничились созданием и компиляцией изменённых классов в рабочем дереве; проект в данном CI-окружении не смог выполнить полный `mvn` из-за внешней зависимости.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efce0f1d20832d8d5c3bf547dd9419)