### PR TITLE
Изолировать FX_SPOT ошибки от общего DomainErrorCode

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotApiErrorCode.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotApiErrorCode.java
@@ -1,0 +1,19 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.api.advice;
+
+/**
+ * API-коды ошибок FOREX_SPOT slice.
+ */
+public enum FxSpotApiErrorCode {
+
+    FX_SPOT_ALREADY_EXISTS,
+    FX_SPOT_NOT_FOUND,
+    FX_SPOT_SAME_CURRENCIES,
+    FX_SPOT_IN_USE,
+
+    // Ошибка reference lookup при создании FOREX_SPOT.
+    CURRENCY_NOT_FOUND,
+
+    FX_SPOT_CREATE_FAILED,
+    FX_SPOT_UPDATE_FAILED,
+    FX_SPOT_DELETE_FAILED
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
@@ -13,7 +13,6 @@ import com.alligator.market.backend.instrument.asset.forex.fxspot.application.ex
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotNotFoundException;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.exception.FxSpotUpdateException;
 import com.alligator.market.backend.instrument.asset.forex.reference.currency.application.exception.CurrencyNotFoundException;
-import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.asset.forex.fxspot.exception.FxSpotSameCurrenciesException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
@@ -39,31 +38,31 @@ public class FxSpotRestExceptionHandler {
     @ExceptionHandler(FxSpotAlreadyExistsException.class)
     public ResponseEntity<ApiResponse<Void>> fxSpotAlreadyExists(FxSpotAlreadyExistsException ex) {
         log.warn("FX Spot already exists: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.FX_SPOT_ALREADY_EXISTS.name(), ex.getMessage());
+        return ResponseEntityFactory.conflict(FxSpotApiErrorCode.FX_SPOT_ALREADY_EXISTS.name(), ex.getMessage());
     }
 
     @ExceptionHandler(FxSpotNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> fxSpotNotFound(FxSpotNotFoundException ex) {
         log.warn("FX Spot not found: {}", ex.getMessage());
-        return ResponseEntityFactory.notFound(DomainErrorCode.FX_SPOT_NOT_FOUND.name(), ex.getMessage());
+        return ResponseEntityFactory.notFound(FxSpotApiErrorCode.FX_SPOT_NOT_FOUND.name(), ex.getMessage());
     }
 
     @ExceptionHandler(FxSpotSameCurrenciesException.class)
     public ResponseEntity<ApiResponse<Void>> fxSpotSameCurrencies(FxSpotSameCurrenciesException ex) {
         log.warn("FX Spot same currencies: {}", ex.getMessage());
-        return ResponseEntityFactory.badRequest(DomainErrorCode.FX_SPOT_SAME_CURRENCIES.name(), ex.getMessage());
+        return ResponseEntityFactory.badRequest(FxSpotApiErrorCode.FX_SPOT_SAME_CURRENCIES.name(), ex.getMessage());
     }
 
     @ExceptionHandler(FxSpotInUseException.class)
     public ResponseEntity<ApiResponse<Void>> fxSpotInUse(FxSpotInUseException ex) {
         log.warn("FX Spot is in use: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(DomainErrorCode.FX_SPOT_IN_USE.name(), ex.getMessage());
+        return ResponseEntityFactory.conflict(FxSpotApiErrorCode.FX_SPOT_IN_USE.name(), ex.getMessage());
     }
 
     @ExceptionHandler(CurrencyNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> currencyNotFound(CurrencyNotFoundException ex) {
         log.warn("Currency not found: {}", ex.getMessage());
-        return ResponseEntityFactory.notFound(DomainErrorCode.CURRENCY_NOT_FOUND.name(), ex.getMessage());
+        return ResponseEntityFactory.notFound(FxSpotApiErrorCode.CURRENCY_NOT_FOUND.name(), ex.getMessage());
     }
 
     @ExceptionHandler({
@@ -80,11 +79,11 @@ public class FxSpotRestExceptionHandler {
     /* Подбираем код ошибки для технических application-исключений FX_SPOT. */
     private String resolveTechnicalErrorCode(RuntimeException ex) {
         if (ex instanceof FxSpotCreateException) {
-            return DomainErrorCode.FX_SPOT_CREATE_FAILED.name();
+            return FxSpotApiErrorCode.FX_SPOT_CREATE_FAILED.name();
         }
         if (ex instanceof FxSpotUpdateException) {
-            return DomainErrorCode.FX_SPOT_UPDATE_FAILED.name();
+            return FxSpotApiErrorCode.FX_SPOT_UPDATE_FAILED.name();
         }
-        return DomainErrorCode.FX_SPOT_DELETE_FAILED.name();
+        return FxSpotApiErrorCode.FX_SPOT_DELETE_FAILED.name();
     }
 }

--- a/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
+++ b/domain/src/main/java/com/alligator/market/domain/common/exception/DomainErrorCode.java
@@ -17,16 +17,8 @@ public enum DomainErrorCode {
     CURRENCY_ALREADY_EXISTS(DomainErrorType.CONFLICT),
     CURRENCY_NAME_DUPLICATE(DomainErrorType.CONFLICT),
     CURRENCY_NOT_FOUND(DomainErrorType.NOT_FOUND),
-    CURRENCY_IN_USE(DomainErrorType.CONFLICT),
+    CURRENCY_IN_USE(DomainErrorType.CONFLICT);
 
-    /* FOREX_SPOT инструмент: */
-    FX_SPOT_ALREADY_EXISTS(DomainErrorType.CONFLICT),
-    FX_SPOT_NOT_FOUND(DomainErrorType.NOT_FOUND),
-    FX_SPOT_SAME_CURRENCIES(DomainErrorType.BAD_REQUEST),
-    FX_SPOT_IN_USE(DomainErrorType.CONFLICT),
-    FX_SPOT_CREATE_FAILED(DomainErrorType.TECHNICAL),
-    FX_SPOT_UPDATE_FAILED(DomainErrorType.TECHNICAL),
-    FX_SPOT_DELETE_FAILED(DomainErrorType.TECHNICAL);
 
     /* Тип ошибки доменной логики. */
     private final DomainErrorType type;

--- a/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/exception/FxSpotSameCurrenciesException.java
+++ b/domain/src/main/java/com/alligator/market/domain/instrument/asset/forex/fxspot/exception/FxSpotSameCurrenciesException.java
@@ -1,7 +1,5 @@
 package com.alligator.market.domain.instrument.asset.forex.fxspot.exception;
 
-import com.alligator.market.domain.common.exception.BaseDomainException;
-import com.alligator.market.domain.common.exception.DomainErrorCode;
 import com.alligator.market.domain.instrument.asset.forex.reference.currency.vo.CurrencyCode;
 
 import java.util.Objects;
@@ -9,19 +7,11 @@ import java.util.Objects;
 /**
  * Ошибка: базовая и котируемая валюты совпадают.
  */
-public final class FxSpotSameCurrenciesException extends BaseDomainException {
+public final class FxSpotSameCurrenciesException extends IllegalArgumentException {
 
-    /**
-     * Создает исключение.
-     *
-     * @param currencyCode код совпадающей валюты
-     */
     public FxSpotSameCurrenciesException(CurrencyCode currencyCode) {
-        super(
-                DomainErrorCode.FX_SPOT_SAME_CURRENCIES,
-                "Base and quote currencies must be different (currency=%s)".formatted(
-                        Objects.requireNonNull(currencyCode, "currencyCode must not be null").value()
-                )
-        );
+        super("Base and quote currencies must be different (currency=%s)".formatted(
+                Objects.requireNonNull(currencyCode, "currencyCode must not be null").value()
+        ));
     }
 }


### PR DESCRIPTION
### Motivation

- Доменная логика FX_SPOT не должна зависеть от общего контейнера кодов ошибок и превращать `DomainErrorCode` в свалку slice-специфичных значений.
- API-коды ошибок FX_SPOT должны жить локально в backend fxspot slice, а домен — содержать простые доменные исключения без знания про API-коды.

### Description

- Преобразована `FxSpotSameCurrenciesException` в простое доменное исключение, теперь оно наследует `IllegalArgumentException` и содержит прежнее сообщение на английском (файл `domain/src/main/java/.../FxSpotSameCurrenciesException.java`).
- Добавлен локальный enum `FxSpotApiErrorCode` с FX_SPOT- и `CURRENCY_NOT_FOUND` кодами в `backend/src/main/java/.../FxSpotApiErrorCode.java` для хранения API errorCode значений внутри slice.
- Обновлён `FxSpotRestExceptionHandler`: удалён импорт `DomainErrorCode`, все маппинги ошибок и `resolveTechnicalErrorCode` теперь возвращают `FxSpotApiErrorCode.*.name()` (файл `backend/src/main/java/.../FxSpotRestExceptionHandler.java`).
- Удалены FX_SPOT-специфичные entries из общего `DomainErrorCode` чтобы удалить кросс-зависимость (файл `domain/src/main/java/.../DomainErrorCode.java`).

### Testing

- Выполнен поиск по проекту командой `rg` для всех `DomainErrorCode.FX_SPOT...` и `FX_SPOT_*` значений и подтверждена их замена/перенос в `FxSpotApiErrorCode` (поиск прошёл успешно).
- Проверено, что в пакете domain FX_SPOT больше нет импортов `DomainErrorCode` и `BaseDomainException` (проверка прошла успешно).
- Попытка сборки через `mvn -q -DskipTests compile` была выполнена, но сборка упала из-за проблем с разрешением родительского POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5`) из Maven Central (HTTP 403), поэтому полноценная компиляция в этом окружении не прошла.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efce25debc832d9e7ac7fadc158e5f)