### PR TITLE
Переименование unique-ограничений в миграции market_data_source на префикс uq

### DIFF
--- a/backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_market_data_source.sql
+++ b/backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_market_data_source.sql
@@ -17,8 +17,8 @@ CREATE TABLE market_data_source
             ON DELETE CASCADE,
 
     -- Ограничения уникальности
-    CONSTRAINT uk_market_data_source_instr_provider UNIQUE (instrument_code, provider_code),
-    CONSTRAINT uk_market_data_source_instr_priority UNIQUE (instrument_code, priority),
+    CONSTRAINT uq_market_data_source_instr_provider UNIQUE (instrument_code, provider_code),
+    CONSTRAINT uq_market_data_source_instr_priority UNIQUE (instrument_code, priority),
 
     -- Ограничения доменной валидности
     CONSTRAINT chk_market_data_source_priority CHECK (priority >= 0)


### PR DESCRIPTION
### Motivation
- Устранить рассинхрон между именами ограничений в миграции и ожиданиями адаптеров/тестов, которые используют шаблон `uq_*`, чтобы корректно обрабатывать ошибки целостности.

### Description
- В файле миграции `backend/src/main/resources/db/migration/sourcing/source/V20260407_02__create_market_data_source.sql` переименованы ограничения `uk_market_data_source_instr_provider` → `uq_market_data_source_instr_provider` и `uk_market_data_source_instr_priority` → `uq_market_data_source_instr_priority`.

### Testing
- Выполнены автоматические проверки поиска и просмотра файлов командой `rg -n "uk_market_data_source_instr_provider|uk_market_data_source_instr_priority|uq_market_data_source_instr_provider|uq_market_data_source_instr_priority"` и просмотр изменённого файла с `nl`, которые подтвердили наличие `uq_*` в миграции, и патч был успешно применён и закоммичен.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdee6c64c832d9ca78e394ed4c3c5)