### PR TITLE
Убрать версионирование provider_passport и обновить UPSERT проекции

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/port/adapter/jdbc/ProviderPassportProjectionWritePortJdbcAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/port/adapter/jdbc/ProviderPassportProjectionWritePortJdbcAdapter.java
@@ -23,22 +23,20 @@ public class ProviderPassportProjectionWritePortJdbcAdapter implements ProviderP
             WHERE provider_code <> ALL (?)
             """;
 
-    // upsertAll(Map): вставка/обновление, version растёт только при изменении бизнес-полей.
+    // upsertAll(Map): вставка/обновление только бизнес-полей.
     private static final String SQL_UPSERT = """
             INSERT INTO provider_passport(
               provider_code,
               display_name,
               delivery_mode,
               access_method,
-              bulk_subscription,
-              version
-            ) VALUES (?, ?, ?, ?, ?, 0)
+              bulk_subscription
+            ) VALUES (?, ?, ?, ?, ?)
             ON CONFLICT (provider_code) DO UPDATE SET
               display_name = EXCLUDED.display_name,
               delivery_mode = EXCLUDED.delivery_mode,
               access_method = EXCLUDED.access_method,
-              bulk_subscription = EXCLUDED.bulk_subscription,
-              version = provider_passport.version + 1
+              bulk_subscription = EXCLUDED.bulk_subscription
             WHERE
               provider_passport.display_name IS DISTINCT FROM EXCLUDED.display_name
               OR provider_passport.delivery_mode IS DISTINCT FROM EXCLUDED.delivery_mode

--- a/backend/src/main/resources/db/migration/provider/passport/V20260301_01__create_provider_passport.sql
+++ b/backend/src/main/resources/db/migration/provider/passport/V20260301_01__create_provider_passport.sql
@@ -14,9 +14,6 @@ CREATE TABLE provider_passport
     access_method     VARCHAR(20)  NOT NULL,
     bulk_subscription BOOLEAN      NOT NULL,
 
-    -- Версионирование
-    version           BIGINT       NOT NULL DEFAULT 0,
-
     -- Уникальность натурального ключа
     CONSTRAINT uq_provider_code UNIQUE (provider_code),
 
@@ -30,9 +27,5 @@ CREATE TABLE provider_passport
     CONSTRAINT chk_provider_delivery_mode_allowed
         CHECK (delivery_mode IN ('PULL', 'PUSH')),
     CONSTRAINT chk_provider_access_method_allowed
-        CHECK (access_method IN ('API_POLL', 'WEBSOCKET', 'FIX_PROTOCOL')),
-
-    -- Техническая защита версии
-    CONSTRAINT chk_provider_passport_version_non_negative
-        CHECK (version >= 0)
+        CHECK (access_method IN ('API_POLL', 'WEBSOCKET', 'FIX_PROTOCOL'))
 );


### PR DESCRIPTION
### Motivation
- Убрать ненужное поле `version` в read-model `provider_passport`, чтобы схема соответствовала текущей модели данных без optimistic locking.
- Обеспечить корректную работу проекции паспортов после удаления версии, чтобы адаптер не пытался вставлять/инкрементировать несуществующее поле.

### Description
- Удалена колонка `version` и соответствующее `CHECK`-ограничение из миграции `backend/src/main/resources/db/migration/provider/passport/V20260301_01__create_provider_passport.sql`.
- Обновлён JDBC UPSERT в `ProviderPassportProjectionWritePortJdbcAdapter` так, чтобы запрос вставлял/обновлял только бизнес-поля и больше не использовал поле `version` (`backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/port/adapter/jdbc/ProviderPassportProjectionWritePortJdbcAdapter.java`).
- Сохранён `WHERE ... IS DISTINCT FROM ...` для того, чтобы обновления выполнялись только при реальных изменениях бизнес-полей.

### Testing
- Попытка скомпилировать бэкенд командой `./mvnw -pl backend -DskipTests compile` была выполнена, но сборка не завершилась из-за невозможности скачать Maven дистрибутив (`wget: Failed to fetch ... apache-maven-3.9.9-bin.zip`).
- Автоматические тесты или сборка модуля в этом окружении не были успешно выполнены, поэтому поведение в CI/локально следует проверить дополнительно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe02f6258832d8a538b4dfb4fe548)