### PR TITLE
Убрать колонку `version` из миграции таблицы currency

### DIFF
--- a/backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260303_02__create_currency.sql
+++ b/backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260303_02__create_currency.sql
@@ -12,9 +12,6 @@ CREATE TABLE currency
     country           VARCHAR(100) NOT NULL,
     fraction_digits   INTEGER      NOT NULL DEFAULT 2,
 
-    -- Версионирование
-    version           BIGINT       NOT NULL DEFAULT 0,
-
     -- Ограничения уникальности
     CONSTRAINT uq_currency_code UNIQUE (code),
     CONSTRAINT uq_currency_name UNIQUE (name),
@@ -27,7 +24,5 @@ CREATE TABLE currency
     CONSTRAINT chk_currency_country_not_blank
         CHECK (length(btrim(country)) > 0),
     CONSTRAINT chk_currency_fraction_digits
-        CHECK (fraction_digits BETWEEN 0 AND 10),
-    CONSTRAINT chk_currency_version_non_negative
-        CHECK (version >= 0)
+        CHECK (fraction_digits BETWEEN 0 AND 10)
 );

--- a/backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260416_01__drop_currency_version.sql
+++ b/backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260416_01__drop_currency_version.sql
@@ -1,3 +1,0 @@
--- Удаляем version у reference data валют: optimistic locking для currency не используется.
-ALTER TABLE currency
-    DROP COLUMN version;


### PR DESCRIPTION
### Motivation

- Упростить миграции: убрать ненужное поле `version` из базовой миграции таблицы `currency`, чтобы не создавать затем отдельную миграцию для удаления колонки. 
- Оптимистическая блокировка для reference-таблиц не используется, поэтому колонка избыточна и усложняет историю миграций. 

### Description

- Удалён блок `version BIGINT NOT NULL DEFAULT 0` и связанная с ним проверка из `backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260303_02__create_currency.sql`. 
- Удалён файл-миграция `backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency/V20260416_01__drop_currency_version.sql` как теперь избыточный. 
- Проверены ключевые репозитории и адаптеры (jOOQ-адаптеры для `currency` и FX spot), которые читают/записывают только поля `code`, `name`, `country`, `fraction_digits`, поэтому изменение не затрагивает текущую логику Persistance/Service. 

### Testing

- Выполнен поиск по коду командой `rg -n "version" backend/src/main/resources/db/migration/instrument/asset/forex/reference/currency` и подтверждено отсутствие ссылок на `version` в папке миграций. (успешно) 
- Выполнен поиск по сервисному коду командой `rg` для валютных и fxspot-модулей и подтверждено, что код использует только `code/name/country/fraction_digits` (успешно). 
- Попытка запустить таргетированные тесты `./mvnw -pl backend -Dtest='*Currency*' test` завершилась неудачей из-за невозможности скачать зависимости в окружении (`wget` к Maven Central не удался). (неуспешно)
- Статическая проверка файлов адаптеров jOOQ подтвердила отсутствие обращений к колонке `version` (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe0acafb0832db2d06a288fdc0d60)