### PR TITLE
Адаптация currency feature к стандартным Spring-ответам (frontend)

### DIFF
--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
@@ -127,7 +127,7 @@ export class CurrencyAdminComponent implements OnInit {
       },
       error: err => {
         // Если ошибка
-        const msg = err.error?.message ?? err.message ?? 'Add failed'; // ловим сообщение ошибки сервера
+        const msg = this.resolveErrorMessage(err, 'Add failed'); // ловим сообщение ошибки сервера
         const ref = this.snack.open(msg, 'Close', { duration: 0 }); // уведомление с ошибкой
         ref.afterDismissed().subscribe(() => {
           this.locked = false;
@@ -171,7 +171,7 @@ export class CurrencyAdminComponent implements OnInit {
         this.locked = false;
       },
       error: err => {
-        const msg = err.error?.message ?? err.message ?? 'Update failed';
+        const msg = this.resolveErrorMessage(err, 'Update failed');
         const ref = this.snack.open(msg, 'Close', { duration: 0 });
         ref.afterDismissed().subscribe(() => {
           this.locked = false;
@@ -197,7 +197,7 @@ export class CurrencyAdminComponent implements OnInit {
         this.refresh();
       },
       error: err => {
-        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close');
+        this.snack.open(this.resolveErrorMessage(err, 'Delete failed'), 'Close');
       }
     });
   }
@@ -212,9 +212,36 @@ export class CurrencyAdminComponent implements OnInit {
         this.dataSource.data = this.sortCurrenciesAlphabetically(list);
       },
       error: err => {
-        this.snack.open(err.message ?? 'Load failed', 'Close');
+        this.snack.open(this.resolveErrorMessage(err, 'Load failed'), 'Close');
       }
     });
+  }
+
+
+
+  /* Утилита: извлекаем текст ошибки из стандартного ответа Spring ProblemDetail. */
+  private resolveErrorMessage(err: unknown, fallback: string): string {
+    if (!err || typeof err !== 'object') {
+      return fallback;
+    }
+
+    const body = (err as { error?: unknown }).error;
+
+    if (!body || typeof body !== 'object') {
+      return (err as { message?: string }).message ?? fallback;
+    }
+
+    const detail = (body as { detail?: unknown }).detail;
+    if (typeof detail === 'string' && detail.trim().length > 0) {
+      return detail;
+    }
+
+    const title = (body as { title?: unknown }).title;
+    if (typeof title === 'string' && title.trim().length > 0) {
+      return title;
+    }
+
+    return (err as { message?: string }).message ?? fallback;
   }
 
   /* Утилита: стабильная сортировка валют по алфавиту (по коду). */

--- a/frontend/src/app/features/currency/services/currency.service.ts
+++ b/frontend/src/app/features/currency/services/currency.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { map, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { CreateCurrencyDto, CurrencyResponseDto } from '../models/currency.model';
-import { ApiResponse } from '../../../shared/api/api-response.model';
 import { UpdateCurrencyDto } from '../models/currency-update.model';
 
 /* Сервис для взаимодействия с API по работе с валютами. */
@@ -17,31 +16,23 @@ export class CurrencyService {
   /* Базовый URL (через proxy уйдёт на Spring). */
   private readonly baseUrl = '/api/v1/currencies';
 
-  /* Получить список всех валют. */
+  /* Получить список всех валют в стандартном Spring-формате ответа. */
   list(): Observable<CurrencyResponseDto[]> {
-    return this.http
-      .get<ApiResponse<CurrencyResponseDto[]>>(this.baseUrl)
-      .pipe(map(res => res.data ?? []));
+    return this.http.get<CurrencyResponseDto[]>(this.baseUrl);
   }
 
-  /* Добавить валюту, backend вернёт её код. */
+  /* Добавить валюту, backend вернёт её код plain string. */
   add(dto: CreateCurrencyDto): Observable<string> {
-    return this.http
-      .post<ApiResponse<string>>(this.baseUrl, dto)
-      .pipe(map(res => res.data ?? ''));
+    return this.http.post(this.baseUrl, dto, { responseType: 'text' });
   }
 
   /* Удалить валюту по коду. */
   delete(code: string): Observable<void> {
-    return this.http
-      .delete<void>(`${this.baseUrl}/${code}`)
-      .pipe(map(() => undefined));
+    return this.http.delete<void>(`${this.baseUrl}/${code}`);
   }
 
   /* Обновить валюту по коду. */
   update(code: string, dto: UpdateCurrencyDto): Observable<void> {
-    return this.http
-      .put<void>(`${this.baseUrl}/${code}`, dto)
-      .pipe(map(() => undefined));
+    return this.http.put<void>(`${this.baseUrl}/${code}`, dto);
   }
 }


### PR DESCRIPTION
### Motivation
- Привести feature `currency` к единому, стандартному контракту ответов Spring вместо кастомного `ApiResponse`-конверта, чтобы упростить взаимодействие и убрать лишнюю обвязку на фронтенде.

### Description
- Обновлён frontend: `CurrencyService` теперь запрашивает список как `CurrencyResponseDto[]` и создание возвращает plain string; изменены файлы `frontend/src/app/features/currency/services/currency.service.ts` и `frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts`.
- Удалён импорт/использование обёртки `ApiResponse` в сервисе `currency` и убран маппинг `res.data` в пользу прямых ответов Spring (`get<T[]>`, `post(..., { responseType: 'text' })`).
- В `currency-admin` добавлена утилита `resolveErrorMessage` для разбора стандартного `ProblemDetail` (ищет `detail`, затем `title`, затем fallback), и обработка ошибок Add/Update/Delete/Load под новый контракт.
- Backend проверки показали, что контроллеры currency уже возвращают стандартные ответы и ошибки через `ProblemDetail`, поэтому изменений в backend не потребовалось.

### Testing
- Собрана фронтенд-часть командой `npm --prefix frontend run build`, сборка прошла успешно.
- Прогнаны проверки на отсутствие использования обёртки в backend командой типа `rg -n "ApiResponse|ResponseEntityFactory" backend/...`, проблем не найдено.
- Прогнаны проверки на отсутствие ожидания `ApiResponse` в currency frontend командой типа `rg -n "ApiResponse|res\.data" frontend/src/app/features/currency`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe9353df4832d9c0b390d9e4db1a6)