### PR TITLE
refactor(fxspot): перейти на Spring ResponseEntity и ProblemDetail

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/advice/FxSpotRestExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.advice;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.create.controller.CreateFxSpotController;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.delete.controller.DeleteFxSpotController;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.update.controller.UpdateFxSpotController;
@@ -19,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -37,33 +35,58 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class FxSpotRestExceptionHandler {
 
     @ExceptionHandler(FxSpotAlreadyExistsException.class)
-    public ResponseEntity<ApiResponse<Void>> fxSpotAlreadyExists(FxSpotAlreadyExistsException ex) {
+    public ProblemDetail fxSpotAlreadyExists(FxSpotAlreadyExistsException ex) {
         log.warn("FX Spot already exists: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(FxSpotApiErrorCode.FX_SPOT_ALREADY_EXISTS.code(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.CONFLICT,
+                "FX Spot already exists",
+                ex.getMessage(),
+                FxSpotApiErrorCode.FX_SPOT_ALREADY_EXISTS.name()
+        );
     }
 
     @ExceptionHandler(FxSpotNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> fxSpotNotFound(FxSpotNotFoundException ex) {
+    public ProblemDetail fxSpotNotFound(FxSpotNotFoundException ex) {
         log.warn("FX Spot not found: {}", ex.getMessage());
-        return ResponseEntityFactory.notFound(FxSpotApiErrorCode.FX_SPOT_NOT_FOUND.code(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.NOT_FOUND,
+                "FX Spot not found",
+                ex.getMessage(),
+                FxSpotApiErrorCode.FX_SPOT_NOT_FOUND.name()
+        );
     }
 
     @ExceptionHandler(FxSpotSameCurrenciesException.class)
-    public ResponseEntity<ApiResponse<Void>> fxSpotSameCurrencies(FxSpotSameCurrenciesException ex) {
+    public ProblemDetail fxSpotSameCurrencies(FxSpotSameCurrenciesException ex) {
         log.warn("FX Spot same currencies: {}", ex.getMessage());
-        return ResponseEntityFactory.badRequest(FxSpotApiErrorCode.FX_SPOT_SAME_CURRENCIES.code(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "FX Spot same currencies",
+                ex.getMessage(),
+                FxSpotApiErrorCode.FX_SPOT_SAME_CURRENCIES.name()
+        );
     }
 
     @ExceptionHandler(FxSpotInUseException.class)
-    public ResponseEntity<ApiResponse<Void>> fxSpotInUse(FxSpotInUseException ex) {
+    public ProblemDetail fxSpotInUse(FxSpotInUseException ex) {
         log.warn("FX Spot is in use: {}", ex.getMessage());
-        return ResponseEntityFactory.conflict(FxSpotApiErrorCode.FX_SPOT_IN_USE.code(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.CONFLICT,
+                "FX Spot is in use",
+                ex.getMessage(),
+                FxSpotApiErrorCode.FX_SPOT_IN_USE.name()
+        );
     }
 
     @ExceptionHandler(CurrencyNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> currencyNotFound(CurrencyNotFoundException ex) {
+    public ProblemDetail currencyNotFound(CurrencyNotFoundException ex) {
         log.warn("Currency not found: {}", ex.getMessage());
-        return ResponseEntityFactory.notFound(FxSpotApiErrorCode.CURRENCY_NOT_FOUND.code(), ex.getMessage());
+        return buildProblemDetail(
+                HttpStatus.NOT_FOUND,
+                "Currency not found",
+                ex.getMessage(),
+                FxSpotApiErrorCode.CURRENCY_NOT_FOUND.name()
+        );
     }
 
     @ExceptionHandler({
@@ -71,20 +94,52 @@ public class FxSpotRestExceptionHandler {
             FxSpotUpdateException.class,
             FxSpotDeleteException.class
     })
-    public ResponseEntity<ApiResponse<Void>> domainTechnicalError(RuntimeException ex) {
-        log.error("Domain operation failed: {}", ex.getMessage(), ex);
-        String errorCode = resolveTechnicalErrorCode(ex);
-        return ResponseEntityFactory.error(HttpStatus.INTERNAL_SERVER_ERROR, errorCode, ex.getMessage());
+    public ProblemDetail fxSpotTechnicalError(RuntimeException ex) {
+        log.error("FX Spot operation failed: {}", ex.getMessage(), ex);
+
+        FxSpotApiErrorCode errorCode = resolveTechnicalErrorCode(ex);
+        String title = resolveTechnicalErrorTitle(ex);
+
+        return buildProblemDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                title,
+                ex.getMessage(),
+                errorCode.name()
+        );
     }
 
     /* Подбираем код ошибки для технических application-исключений FX_SPOT. */
-    private String resolveTechnicalErrorCode(RuntimeException ex) {
+    private FxSpotApiErrorCode resolveTechnicalErrorCode(RuntimeException ex) {
         if (ex instanceof FxSpotCreateException) {
-            return FxSpotApiErrorCode.FX_SPOT_CREATE_FAILED.code();
+            return FxSpotApiErrorCode.FX_SPOT_CREATE_FAILED;
         }
         if (ex instanceof FxSpotUpdateException) {
-            return FxSpotApiErrorCode.FX_SPOT_UPDATE_FAILED.code();
+            return FxSpotApiErrorCode.FX_SPOT_UPDATE_FAILED;
         }
-        return FxSpotApiErrorCode.FX_SPOT_DELETE_FAILED.code();
+        return FxSpotApiErrorCode.FX_SPOT_DELETE_FAILED;
+    }
+
+    /* Подбираем title для технических application-исключений FX_SPOT. */
+    private String resolveTechnicalErrorTitle(RuntimeException ex) {
+        if (ex instanceof FxSpotCreateException) {
+            return "FX Spot create failed";
+        }
+        if (ex instanceof FxSpotUpdateException) {
+            return "FX Spot update failed";
+        }
+        return "FX Spot delete failed";
+    }
+
+    /* Формируем стандартный ProblemDetail ответ с дополнительным errorCode. */
+    private ProblemDetail buildProblemDetail(
+            HttpStatus status,
+            String title,
+            String detail,
+            String errorCode
+    ) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setTitle(title);
+        problemDetail.setProperty("errorCode", errorCode);
+        return problemDetail;
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/create/controller/CreateFxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/create/controller/CreateFxSpotController.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.create.controller;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.create.dto.CreateFxSpotRequest;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.create.mapper.CreateFxSpotRequestMapper;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.create.CreateFxSpotService;
@@ -28,7 +26,7 @@ public class CreateFxSpotController {
     private final CreateFxSpotService createFxSpotService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<String>> create(@Valid @RequestBody CreateFxSpotRequest request) {
+    public ResponseEntity<String> create(@Valid @RequestBody CreateFxSpotRequest request) {
         FxSpot created = createFxSpotService.create(
                 CreateFxSpotRequestMapper.toCommand(request)
         );
@@ -39,6 +37,6 @@ public class CreateFxSpotController {
                 .buildAndExpand(created.instrumentCode().value())
                 .toUri();
 
-        return ResponseEntityFactory.created(location, created.instrumentCode().value());
+        return ResponseEntity.created(location).body(created.instrumentCode().value());
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/delete/controller/DeleteFxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/delete/controller/DeleteFxSpotController.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.delete.controller;
 
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.delete.DeleteFxSpotService;
 import com.alligator.market.domain.instrument.vo.InstrumentCode;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +22,6 @@ public class DeleteFxSpotController {
     @DeleteMapping("/{instrumentCode}")
     public ResponseEntity<Void> delete(@PathVariable String instrumentCode) {
         deleteFxSpotService.delete(InstrumentCode.of(instrumentCode));
-        return ResponseEntityFactory.noContent();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/update/controller/UpdateFxSpotController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/command/update/controller/UpdateFxSpotController.java
@@ -1,6 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.update.controller;
 
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.update.dto.UpdateFxSpotRequest;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.command.update.mapper.UpdateFxSpotRequestMapper;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.command.update.UpdateFxSpotService;
@@ -27,6 +26,6 @@ public class UpdateFxSpotController {
     public ResponseEntity<Void> update(@PathVariable String instrumentCode,
                                        @Valid @RequestBody UpdateFxSpotRequest request) {
         updateFxSpotService.update(UpdateFxSpotRequestMapper.toCommand(instrumentCode, request));
-        return ResponseEntityFactory.noContent();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/controller/ListFxSpotsController.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/api/query/list/controller/ListFxSpotsController.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.controller;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.dto.FxSpotListItemResponse;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.api.query.list.mapper.FxSpotListItemResponseMapper;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.query.list.ListFxSpotsService;
@@ -26,11 +24,11 @@ public class ListFxSpotsController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<FxSpotListItemResponse>>> getAll() {
+    public ResponseEntity<List<FxSpotListItemResponse>> getAll() {
         List<FxSpotListItemResponse> list = listFxSpotsService.findAll().stream()
                 .map(FxSpotListItemResponseMapper::toResponse)
                 .toList();
 
-        return ResponseEntityFactory.ok(list);
+        return ResponseEntity.ok(list);
     }
 }


### PR DESCRIPTION
### Motivation
- Убрать зависимость fxspot-слайса от `ApiResponse` и `ResponseEntityFactory` и привести API к стандартным Spring-ответам для простоты и совместимости. 
- Ошибки должны отдаваться через стандартный `ProblemDetail` вместо кастомных обёрток, сохраняя существующие коды ошибок и бизнес-логику.

### Description
- В `CreateFxSpotController` заменён тип ответа с `ResponseEntity<ApiResponse<String>>` на `ResponseEntity<String>` и возврат теперь через `ResponseEntity.created(location).body(...)`. (файл: `CreateFxSpotController.java`).
- В `UpdateFxSpotController` и `DeleteFxSpotController` удалён `ResponseEntityFactory` и ответы `204` формируются через `ResponseEntity.noContent().build()`. (файлы: `UpdateFxSpotController.java`, `DeleteFxSpotController.java`).
- В `ListFxSpotsController` заменён тип ответа с `ResponseEntity<ApiResponse<List<...>>>` на `ResponseEntity<List<...>>` и используется `ResponseEntity.ok(list)`. (файл: `ListFxSpotsController.java`).
- Полностью переработан `FxSpotRestExceptionHandler` чтобы возвращать `ProblemDetail` вместо `ResponseEntity<ApiResponse<Void>>`: каждому исключению сопоставлены `HttpStatus`, `title` и `errorCode`, добавлены хелперы `resolveTechnicalErrorCode`, `resolveTechnicalErrorTitle` и `buildProblemDetail` для единообразия ответа. (файл: `FxSpotRestExceptionHandler.java`).

### Testing
- Выполнен поиск в пакете fxspot на остатки `ApiResponse`/`ResponseEntityFactory`/`ResponseEntity<ApiResponse` с помощью `rg "ApiResponse|ResponseEntityFactory|ResponseEntity<ApiResponse" backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot || true`, и совпадений не найдено.
- Попытка сборки `mvn -pl backend compile` была выполнена, но завершилась неудачей в этой среде из-за невозможности скачать родительский POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5`) с Maven Central (HTTP 403), поэтому полная компиляция в текущем окружении не прошла.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efeca103b0832db484c429846a5dc1)