### PR TITLE
Адаптация frontend fx-spot к Spring ResponseEntity и ProblemDetail

### DIFF
--- a/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
+++ b/frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts
@@ -133,7 +133,7 @@ export class FxSpotAdminComponent implements OnInit {
         this.locked = false;
       },
       error: err => {
-        const msg = err.error?.message ?? err.message ?? 'Add failed';
+        const msg = this.resolveErrorMessage(err, 'Add failed');
         const ref = this.snack.open(msg, 'Close', { duration: 0 });
         ref.afterDismissed().subscribe(() => {
           this.locked = false;
@@ -179,7 +179,7 @@ export class FxSpotAdminComponent implements OnInit {
         this.locked = false;
       },
       error: err => {
-        const msg = err.error?.message ?? err.message ?? 'Update failed';
+        const msg = this.resolveErrorMessage(err, 'Update failed');
         const ref = this.snack.open(msg, 'Close', { duration: 0 });
         ref.afterDismissed().subscribe(() => {
           this.locked = false;
@@ -213,7 +213,7 @@ export class FxSpotAdminComponent implements OnInit {
         this.refresh();
       },
       error: err => {
-        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close');
+        this.snack.open(this.resolveErrorMessage(err, 'Delete failed'), 'Close');
       }
     });
   }
@@ -228,9 +228,33 @@ export class FxSpotAdminComponent implements OnInit {
         this.dataSource.data = [...list].sort((left, right) => left.symbol.localeCompare(right.symbol));
       },
       error: err => {
-        this.snack.open(err.message ?? 'Load failed', 'Close');
+        this.snack.open(this.resolveErrorMessage(err, 'Load failed'), 'Close');
       }
     });
+  }
+
+  /* Утилита: извлекаем текст ошибки из стандартного ответа Spring ProblemDetail. */
+  private resolveErrorMessage(err: unknown, fallback: string): string {
+    if (!err || typeof err !== 'object') {
+      return fallback;
+    }
+
+    const body = (err as { error?: unknown }).error;
+    if (!body || typeof body !== 'object') {
+      return (err as { message?: string }).message ?? fallback;
+    }
+
+    const detail = (body as { detail?: unknown }).detail;
+    if (typeof detail === 'string' && detail.trim().length > 0) {
+      return detail;
+    }
+
+    const title = (body as { title?: unknown }).title;
+    if (typeof title === 'string' && title.trim().length > 0) {
+      return title;
+    }
+
+    return (err as { message?: string }).message ?? fallback;
   }
 
 }

--- a/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
+++ b/frontend/src/app/features/fx_spot/services/fx-spot.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
-
-import { ApiResponse } from '../../../shared/api/api-response.model';
 import { FxSpotCreateDto } from '../models/fx-spot-create.model';
 import { FxSpotListItemDto } from '../models/fx-spot.model';
 import { FxSpotUpdateDto } from '../models/fx-spot-update.model';
@@ -20,16 +18,12 @@ export class FxSpotService {
 
   /* Получить список всех инструментов FX_SPOT. */
   list(): Observable<FxSpotListItemDto[]> {
-    return this.http
-      .get<ApiResponse<FxSpotListItemDto[]>>(this.baseUrl)
-      .pipe(map(res => res.data ?? []));
+    return this.http.get<FxSpotListItemDto[]>(this.baseUrl).pipe(map(res => res ?? []));
   }
 
   /* Добавить инструмент FX_SPOT, backend вернёт его код. */
   add(dto: FxSpotCreateDto): Observable<string> {
-    return this.http
-      .post<ApiResponse<string>>(this.baseUrl, dto)
-      .pipe(map(res => res.data ?? ''));
+    return this.http.post(this.baseUrl, dto, { responseType: 'text' }).pipe(map(res => res ?? ''));
   }
 
   /* Удалить инструмент FX_SPOT по коду. */


### PR DESCRIPTION
### Motivation
- Бэкенд был переведён на Spring API, где успешные ответы приходят как обычные `ResponseEntity`, а ошибки — в формате `ProblemDetail`, поэтому фронтенду нужно отказаться от envelope-контракта и корректно извлекать сообщения ошибок.

### Description
- Обновлён `FxSpotService`: `list()` теперь запрашивает `FxSpotListItemDto[]`, а `add()` использует `responseType: 'text'` для чтения строкового тела, удалена зависимость от `ApiResponse`.
- В `FxSpotAdminComponent` добавлена утилита `resolveErrorMessage`, которая приоритетно читает `detail`, затем `title`, и затем fallback, и все обработчики ошибок (add/update/delete/load) заменены на использование этой утилиты.
- Изменены файлы `frontend/src/app/features/fx_spot/services/fx-spot.service.ts` и `frontend/src/app/features/fx_spot/pages/fx-spot-admin/fx-spot-admin.component.ts`.

### Testing
- Собрана фронтенд-аппликация командой `cd frontend && npm run build`, сборка прошла успешно.
- Юнит-тесты не запускались; изменения покрыты ручной сборкой и статической компиляцией TypeScript/Angular.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efee162ed4832dac14e0fd85777e58)