### PR TITLE
fix: убрать обращения к VERSION в проекции provider_passport

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/port/adapter/jooq/ProviderPassportProjectionWritePortJooqAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/port/adapter/jooq/ProviderPassportProjectionWritePortJooqAdapter.java
@@ -5,10 +5,7 @@ import com.alligator.market.domain.provider.readmodel.passport.projection.port.P
 import com.alligator.market.domain.provider.vo.ProviderCode;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
-import org.jooq.Field;
 import org.jooq.Query;
-import org.jooq.TableField;
-import org.jooq.impl.DSL;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -72,17 +69,12 @@ public class ProviderPassportProjectionWritePortJooqAdapter implements ProviderP
                     .set(PROVIDER_PASSPORT.DELIVERY_MODE, passport.deliveryMode().name())
                     .set(PROVIDER_PASSPORT.ACCESS_METHOD, passport.accessMethod().name())
                     .set(PROVIDER_PASSPORT.BULK_SUBSCRIPTION, passport.bulkSubscription())
-                    .set(PROVIDER_PASSPORT.VERSION, numericLiteral(PROVIDER_PASSPORT.VERSION, 0))
                     .onConflict(PROVIDER_PASSPORT.PROVIDER_CODE)
                     .doUpdate()
                     .set(PROVIDER_PASSPORT.DISPLAY_NAME, excluded(PROVIDER_PASSPORT.DISPLAY_NAME))
                     .set(PROVIDER_PASSPORT.DELIVERY_MODE, excluded(PROVIDER_PASSPORT.DELIVERY_MODE))
                     .set(PROVIDER_PASSPORT.ACCESS_METHOD, excluded(PROVIDER_PASSPORT.ACCESS_METHOD))
                     .set(PROVIDER_PASSPORT.BULK_SUBSCRIPTION, excluded(PROVIDER_PASSPORT.BULK_SUBSCRIPTION))
-                    .set(
-                            PROVIDER_PASSPORT.VERSION,
-                            PROVIDER_PASSPORT.VERSION.plus(numericLiteral(PROVIDER_PASSPORT.VERSION, 1))
-                    )
                     .where(businessFieldsChanged);
 
             queries.add(query);
@@ -129,10 +121,5 @@ public class ProviderPassportProjectionWritePortJooqAdapter implements ProviderP
             entries.add(entry);
         }
         return entries;
-    }
-
-    /* Типобезопасный numeric literal под тип VERSION-поля таблицы. */
-    private static <N extends Number> Field<N> numericLiteral(TableField<?, N> field, Number value) {
-        return DSL.val(value).cast(field.getDataType());
     }
 }


### PR DESCRIPTION
### Motivation
- В коде `ProviderPassportProjectionWritePortJooqAdapter` оставались обращения к `PROVIDER_PASSPORT.VERSION`, тогда как DDL таблицы `provider_passport` не содержит колонки `version`, из‑за чего компилятор выдавал `cannot find symbol` для поля `VERSION` в сгенерированном jOOQ-классе.

### Description
- Убраны установки поля `VERSION` из `insert ... on conflict do update` в методе `upsertAll` класса `ProviderPassportProjectionWritePortJooqAdapter`.
- Удалён вспомогательный метод `numericLiteral` и ненужные импорты, которые использовались только для работы с `VERSION`.
- Выравнено поведение upsert под текущую схему `provider_passport` (без колонки `version`).

### Testing
- Выполнен поиск в кодовой базе через `rg -n "ProviderPassportProjectionWritePortJooqAdapter|VERSION|provider_passport"`, поиск отобразил изменённые места и миграцию таблицы (успешно).
- Попытка сборки `mvn -pl backend -DskipTests compile` не завершилась успешно из‑за ошибки резолва parent POM (Maven Central вернул `403 Forbidden`), поэтому компиляция проекта в этой среде проверить не удалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0832587b0832db9150beb84680c3e)