### PR TITLE
Добавлены краткие комментарии в JooqCurrencyRepositoryAdapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/persistence/jooq/repository/JooqCurrencyRepositoryAdapter.java
@@ -37,6 +37,7 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
         Objects.requireNonNull(currency, "currency must not be null");
 
         try {
+            // Пытаемся вставить валюту по коду.
             Record createdRecord = dsl.insertInto(CURRENCY)
                     .set(CURRENCY.CODE, currency.code().value())
                     .set(CURRENCY.NAME, currency.name())
@@ -51,11 +52,14 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
                             CURRENCY.FRACTION_DIGITS
                     )
                     .fetchOne();
+            // Если запись не создана — код уже существует.
             if (createdRecord == null) {
                 throw new CurrencyAlreadyExistsException(currency.code());
             }
+            // Возвращаем созданную доменную модель.
             return toDomain(createdRecord);
         } catch (DataIntegrityViolationException ex) {
+            // Отдельно обрабатываем конфликт уникального имени.
             if (DbConstraintErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
                 throw new CurrencyNameDuplicateException(currency.name());
             }
@@ -68,6 +72,7 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
         Objects.requireNonNull(currency, "currency must not be null");
 
         try {
+            // Обновляем валюту по коду и сразу читаем результат.
             Optional<Currency> updatedCurrency = dsl.update(CURRENCY)
                     .set(CURRENCY.NAME, currency.name())
                     .set(CURRENCY.COUNTRY, currency.country())
@@ -80,9 +85,11 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
                             CURRENCY.FRACTION_DIGITS
                     )
                     .fetchOptional(this::toDomain);
+            // Если запись не найдена — сигнализируем об этом.
             return updatedCurrency
                     .orElseThrow(() -> new CurrencyNotFoundException(currency.code()));
         } catch (DataIntegrityViolationException ex) {
+            // Отдельно обрабатываем конфликт уникального имени.
             if (DbConstraintErrors.isViolationOf(ex, UQ_CURRENCY_NAME)) {
                 throw new CurrencyNameDuplicateException(currency.name());
             }
@@ -94,9 +101,11 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
     public void deleteByCode(CurrencyCode code) {
         Objects.requireNonNull(code, "code must not be null");
 
+        // Удаляем валюту по коду.
         int deletedRows = dsl.deleteFrom(CURRENCY)
                 .where(CURRENCY.CODE.eq(code.value()))
                 .execute();
+        // Если удалять было нечего — валюты не существует.
         if (deletedRows == 0) {
             throw new CurrencyNotFoundException(code);
         }
@@ -106,6 +115,7 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
     public Optional<Currency> findByCode(CurrencyCode code) {
         Objects.requireNonNull(code, "code must not be null");
 
+        // Ищем одну валюту по коду.
         return dsl.select(
                         CURRENCY.CODE,
                         CURRENCY.NAME,
@@ -119,6 +129,7 @@ public final class JooqCurrencyRepositoryAdapter implements CurrencyRepository {
 
     @Override
     public List<Currency> findAll() {
+        // Читаем весь справочник валют с детерминированной сортировкой.
         return dsl.select(
                         CURRENCY.CODE,
                         CURRENCY.NAME,


### PR DESCRIPTION
### Motivation
- Упростить быстрое понимание основных шагов работы jOOQ-адаптера валют без изменения логики кода.

### Description
- Добавлены очень краткие русские комментарии к ключевым шагам в методах `create`, `update`, `deleteByCode`, `findByCode` и `findAll`, а также в блоках обработки нарушений уникальных ограничений.

### Testing
- Автоматизированных тестов для изменений не запускалось; изменения состоят только из комментариев и не влияют на поведение, коммит выполнен успешно и рабочее дерево проверено (`git status --short`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0866564c4832daecf605bbfdde788)