### PR TITLE
Краткие русские комментарии в JooqFxSpotRepositoryAdapter

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/persistence/jooq/repository/JooqFxSpotRepositoryAdapter.java
@@ -46,14 +46,17 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
     public FxSpot create(FxSpot fxSpot) {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
+        // Проверяем, что обе валюты уже заведены в справочнике.
         ensureCurrencyExists(fxSpot.base().code());
         ensureCurrencyExists(fxSpot.quote().code());
 
         try {
+            // Создаём instrument и его FX_SPOT-часть в одной транзакции.
             return dsl.transactionResult(configuration -> {
                 DSLContext tx = configuration.dsl();
                 InstrumentCode instrumentCode = fxSpot.instrumentCode();
 
+                // Регистрируем код инструмента.
                 int insertedRegistryRows = tx.insertInto(INSTRUMENT_REGISTRY)
                         .set(INSTRUMENT_REGISTRY.CODE, instrumentCode.value())
                         .onConflict(INSTRUMENT_REGISTRY.CODE)
@@ -64,6 +67,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
                     throw new FxSpotAlreadyExistsException(instrumentCode);
                 }
 
+                // Сохраняем параметры FX_SPOT.
                 int insertedFxSpotRows = tx.insertInto(INSTRUMENT_FX_SPOT)
                         .set(INSTRUMENT_FX_SPOT.INSTRUMENT_CODE, instrumentCode.value())
                         .set(INSTRUMENT_FX_SPOT.BASE_CURRENCY, fxSpot.base().code().value())
@@ -82,6 +86,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
                     throw new FxSpotAlreadyExistsException(instrumentCode);
                 }
 
+                // Читаем обратно сохранённую сущность.
                 return findByCode(tx, instrumentCode)
                         .orElseThrow(() -> new IllegalStateException(
                                 "Created FX_SPOT instrument was not found after insert"
@@ -97,6 +102,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
         Objects.requireNonNull(fxSpot, "fxSpot must not be null");
 
         try {
+            // Обновляем только изменяемые поля FX_SPOT.
             int updatedRows = dsl.update(INSTRUMENT_FX_SPOT)
                     .set(INSTRUMENT_FX_SPOT.QUOTE_FRACTION_DIGITS, fxSpot.defaultQuoteFractionDigits())
                     .where(INSTRUMENT_FX_SPOT.INSTRUMENT_CODE.eq(fxSpot.instrumentCode().value()))
@@ -106,6 +112,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
                 throw new FxSpotNotFoundException(fxSpot.instrumentCode());
             }
 
+            // Возвращаем актуальное состояние из БД.
             return findByCode(fxSpot.instrumentCode())
                     .orElseThrow(() -> new FxSpotNotFoundException(fxSpot.instrumentCode()));
         } catch (DataAccessException ex) {
@@ -118,9 +125,11 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
         try {
+            // Удаляем связанные записи в корректном порядке внутри транзакции.
             dsl.transaction(configuration -> {
                 DSLContext tx = configuration.dsl();
 
+                // Сначала удаляем запись FX_SPOT.
                 int deletedFxSpotRows = tx.deleteFrom(INSTRUMENT_FX_SPOT)
                         .where(INSTRUMENT_FX_SPOT.INSTRUMENT_CODE.eq(instrumentCode.value()))
                         .execute();
@@ -129,6 +138,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
                     throw new FxSpotNotFoundException(instrumentCode);
                 }
 
+                // Затем удаляем запись из общего реестра инструментов.
                 int deletedRegistryRows = tx.deleteFrom(INSTRUMENT_REGISTRY)
                         .where(INSTRUMENT_REGISTRY.CODE.eq(instrumentCode.value()))
                         .execute();
@@ -157,6 +167,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
         var baseCurrencyRef = CURRENCY.as("base_currency_ref");
         var quoteCurrencyRef = CURRENCY.as("quote_currency_ref");
 
+        // Получаем все FX_SPOT и сразу собираем доменные объекты.
         return dsl.select(fxSpotSelectFields(baseCurrencyRef, quoteCurrencyRef))
                 .from(INSTRUMENT_FX_SPOT)
                 .join(INSTRUMENT_REGISTRY)
@@ -189,6 +200,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
         var baseCurrencyRef = CURRENCY.as("base_currency_ref");
         var quoteCurrencyRef = CURRENCY.as("quote_currency_ref");
 
+        // Ищем один FX_SPOT по коду и маппим в доменную модель.
         return context.select(fxSpotSelectFields(baseCurrencyRef, quoteCurrencyRef))
                 .from(INSTRUMENT_FX_SPOT)
                 .join(INSTRUMENT_REGISTRY)
@@ -231,6 +243,7 @@ public final class JooqFxSpotRepositoryAdapter implements FxSpotRepository {
     ) {
         Objects.requireNonNull(record, "record must not be null");
 
+        // Собираем валюты и параметры инструмента из записи.
         Currency base = toCurrency(record, baseCurrencyRef);
         Currency quote = toCurrency(record, quoteCurrencyRef);
         FxSpotTenor tenor = FxSpotTenor.valueOf(record.get(INSTRUMENT_FX_SPOT.TENOR));


### PR DESCRIPTION
### Motivation
- Добавить очень краткие русскоязычные комментарии над ключевыми шагами в адаптере для быстрого понимания порядка операций без изменения бизнес-логики.

### Description
- Вставлены лаконичные комментарии на русском в методах `create`, `update`, `deleteByCode`, `findAll`, `findByCode` и `toDomain` в `JooqFxSpotRepositoryAdapter`, без изменений функционала.

### Testing
- Выполнены автоматизированные VCS-команды `git status --short` и `git commit -m ...`, которые завершились успешно (файл изменён и закоммичен).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08962ae38832db13a4950be4dc7d0)