### PR TITLE
Добавить краткие русские комментарии в JooqInstrumentSourcePlanRepository

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepository.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/plan/persistence/jooq/repository/JooqInstrumentSourcePlanRepository.java
@@ -16,7 +16,8 @@ import static com.alligator.market.backend.infra.jooq.generated.tables.MarketDat
 import static com.alligator.market.backend.infra.jooq.generated.tables.SourcePlan.SOURCE_PLAN;
 
 /**
- * jOOQ-адаптер репозитория планов источников.
+ * jOOQ-реализация репозитория планов источников.
+ * Суффикс Adapter не добавлен намеренно: роль адаптера уже явно видна из пакета persistence/jooq.
  */
 public final class JooqInstrumentSourcePlanRepository implements InstrumentSourcePlanRepository {
 
@@ -34,6 +35,7 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
     public Optional<InstrumentSourcePlan> findByInstrumentCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
+        // 1) Читаем все источники инструмента из БД в порядке приоритета.
         List<MarketDataSource> sources = dsl
                 .select(
                         MARKET_DATA_SOURCE.PROVIDER_CODE,
@@ -49,15 +51,18 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
                         record.get(MARKET_DATA_SOURCE.PRIORITY)
                 ));
 
+        // 2) Если источников нет — плана тоже нет.
         if (sources.isEmpty()) {
             return Optional.empty();
         }
 
+        // 3) Собираем доменный план и возвращаем его.
         return Optional.of(new InstrumentSourcePlan(instrumentCode, sources));
     }
 
     @Override
     public List<InstrumentSourcePlan> findAll() {
+        // 1) Группируем источники по коду инструмента.
         Map<InstrumentCode, List<MarketDataSource>> groupedSources = new LinkedHashMap<>();
 
         dsl.select(
@@ -87,12 +92,14 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
                             .add(source);
                 });
 
+        // 2) Преобразуем каждую группу в доменный план.
         List<InstrumentSourcePlan> plans = new ArrayList<>(groupedSources.size());
 
         for (Map.Entry<InstrumentCode, List<MarketDataSource>> entry : groupedSources.entrySet()) {
             plans.add(new InstrumentSourcePlan(entry.getKey(), entry.getValue()));
         }
 
+        // 3) Возвращаем неизменяемый список.
         return List.copyOf(plans);
     }
 
@@ -101,6 +108,7 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
         Objects.requireNonNull(plan, "plan must not be null");
 
         try {
+            // 1) В транзакции пробуем создать запись плана.
             return dsl.transactionResult(configuration -> {
                 DSLContext tx = configuration.dsl();
 
@@ -111,16 +119,20 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
                         .execute();
 
                 if (insertedPlans == 0) {
+                    // План уже существует.
                     return false;
                 }
 
+                // 2) План создан — добавляем его источники.
                 for (MarketDataSource source : plan.sources()) {
                     insertSource(tx, plan.instrumentCode(), source);
                 }
 
+                // 3) Успешное создание.
                 return true;
             });
         } catch (DataIntegrityViolationException ex) {
+            // FK-ошибка => такого инструмента нет в реестре.
             if (DbConstraintErrors.isViolationOf(ex, FK_SOURCE_PLAN_INSTRUMENT)) {
                 throw new InstrumentCodeNotFoundException(plan.instrumentCode());
             }
@@ -137,6 +149,7 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
         return dsl.transactionResult(configuration -> {
             DSLContext tx = configuration.dsl();
 
+            // 1) Проверяем, что план есть, и блокируем его до конца транзакции.
             boolean planExists = tx.selectOne()
                     .from(SOURCE_PLAN)
                     .where(SOURCE_PLAN.INSTRUMENT_CODE.eq(plan.instrumentCode().value()))
@@ -148,10 +161,12 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
                 return false;
             }
 
+            // 2) Удаляем старые источники.
             tx.deleteFrom(MARKET_DATA_SOURCE)
                     .where(MARKET_DATA_SOURCE.INSTRUMENT_CODE.eq(plan.instrumentCode().value()))
                     .execute();
 
+            // 3) Вставляем новый набор источников.
             for (MarketDataSource source : plan.sources()) {
                 insertSource(tx, plan.instrumentCode(), source);
             }
@@ -164,6 +179,7 @@ public final class JooqInstrumentSourcePlanRepository implements InstrumentSourc
     public boolean deleteIfExistsByInstrumentCode(InstrumentCode instrumentCode) {
         Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
 
+        // Удаляем план; связанные источники удаляются по каскаду в БД.
         int deletedRows = dsl.deleteFrom(SOURCE_PLAN)
                 .where(SOURCE_PLAN.INSTRUMENT_CODE.eq(instrumentCode.value()))
                 .execute();


### PR DESCRIPTION
### Motivation
- Повысить читаемость и быстроту понимания логики jOOQ-реализации репозитория планов источников без изменения поведения кода. 
- Уточнить нейминг класса и объяснить, почему не добавлен суффикс `Adapter` прямо в JavaDoc для устранения неоднозначности. 

### Description
- Обновлён JavaDoc класса с пояснением: `JooqInstrumentSourcePlanRepository` названа без `Adapter`, потому что роль адаптера видна по пакету `persistence/jooq`. 
- В методе `findByInstrumentCode` добавлены краткие пошаговые комментарии о чтении источников, проверке пустоты и сборке доменного плана. 
- В методе `findAll` добавлены комментарии о группировке строк по инструменту, преобразовании в доменные планы и возврате неизменяемого списка. 
- В методах `createIfAbsent`, `replaceIfExists` и `deleteIfExistsByInstrumentCode` добавлены короткие комментарии, поясняющие основные транзакционные шаги, удаление/вставку источников и обработку FK-ошибки. 

### Testing
- Выполнена автоматизированная попытка сборки модуля с командой `./mvnw -pl backend -DskipTests compile`, которая завершилась неуспехом из-за ошибки скачивания Maven-дистрибутива (`wget` к `repo.maven.apache.org`). 
- Других автоматизированных тестов или сборок в среде не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08befed94832da5f50928153c7ead)