### PR TITLE
refactor(provider): add feature-level wiring config

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
+++ b/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
@@ -1,9 +1,10 @@
 package com.alligator.market.backend;
 
+import com.alligator.market.backend.provider.config.ProviderFeatureWiringConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.time.ZoneOffset;
@@ -15,6 +16,7 @@ import java.util.TimeZone;
 @SpringBootApplication
 @EnableScheduling
 @ConfigurationPropertiesScan("com.alligator.market.backend")
+@Import(ProviderFeatureWiringConfig.class)
 public class BackendApplication {
 
     private static final TimeZone TECHNICAL_TIME_ZONE = TimeZone.getTimeZone(ZoneOffset.UTC);

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
@@ -1,0 +1,21 @@
+package com.alligator.market.backend.provider.config;
+
+import com.alligator.market.backend.provider.config.adapter.moex.iss.MoexIssProviderConfig;
+import com.alligator.market.backend.provider.config.passport.service.PassportCatalogServiceWiringConfig;
+import com.alligator.market.backend.provider.config.readmodel.passport.projection.startup.ProviderPassportProjectionStartupRunnerWiringConfig;
+import com.alligator.market.backend.provider.config.registry.ProviderRegistryWiringConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Единая внешняя точка входа в wiring фичи provider.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        ProviderRegistryWiringConfig.class,
+        PassportCatalogServiceWiringConfig.class,
+        ProviderPassportProjectionStartupRunnerWiringConfig.class,
+        MoexIssProviderConfig.class
+})
+public class ProviderFeatureWiringConfig {
+}


### PR DESCRIPTION
### Motivation
- Сделать явную единую точку входа Spring-wiring для фичи `provider`, чтобы внешний backend не импортировал множество внутренних provider-config классов напрямую.
- Уменьшить архитектурную связность между корневым backend-config и внутренней структурой `provider` при сохранении приватности внутренней сборки в `provider/config/**`.

### Description
- Добавлен root wiring-конфиг `backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java`, содержащий только `@Configuration` и `@Import({...})` без бизнес-логики.
- `ProviderFeatureWiringConfig` импортирует существующие внутренние wiring-конфиги: `ProviderRegistryWiringConfig`, `PassportCatalogServiceWiringConfig`, `ProviderPassportProjectionStartupRunnerWiringConfig` и `MoexIssProviderConfig`.
- Обновлён `backend/src/main/java/com/alligator/market/backend/BackendApplication.java`, теперь он импортирует только `ProviderFeatureWiringConfig` через `@Import(ProviderFeatureWiringConfig.class)` вместо множества внутренних provider-config.
- Внутренняя структура `provider/config/**` оставлена самодостаточной и неизменной, имена bean и production-логика сохранены.

### Testing
- Проверен внешний код на наличие прямых импортов внутренних provider-config: использовался `rg` и подтверждено, что вне пакета `com.alligator.market.backend.provider` теперь импортируется только `ProviderFeatureWiringConfig` (успешно).
- Попытка сборки через `mvn -pl backend compile` выполнена, сборка не прошла по проблемам окружения с разрешением parent POM (`org.springframework.boot:spring-boot-starter-parent:4.0.5` вернула HTTP 403), ошибка не связана с изменениями кода.
- Локальная проверка содержимого файлов показала корректную установку `@Import` в `ProviderFeatureWiringConfig` и добавление `@Import(ProviderFeatureWiringConfig.class)` в `BackendApplication` (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09cd2389c832db1068b253912d3d1)