### PR TITLE
Introduce Provider and Sourcing feature wiring configs and register them in application

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
+++ b/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
@@ -1,9 +1,11 @@
 package com.alligator.market.backend;
 
+import com.alligator.market.backend.provider.config.ProviderFeatureWiringConfig;
+import com.alligator.market.backend.sourcing.config.SourcingFeatureWiringConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.time.ZoneOffset;
@@ -15,6 +17,7 @@ import java.util.TimeZone;
 @SpringBootApplication
 @EnableScheduling
 @ConfigurationPropertiesScan("com.alligator.market.backend")
+@Import({ProviderFeatureWiringConfig.class, SourcingFeatureWiringConfig.class})
 public class BackendApplication {
 
     private static final TimeZone TECHNICAL_TIME_ZONE = TimeZone.getTimeZone(ZoneOffset.UTC);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/FxSpotUsageContributorWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/application/usage/contributor/FxSpotUsageContributorWiringConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.instrument.asset.forex.fxspot.config.applic
 
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.FxSpotUsageContributor;
 import com.alligator.market.backend.instrument.asset.forex.fxspot.application.usage.contributor.sourcing.SourcePlanFxSpotUsageContributor;
-import com.alligator.market.backend.sourcing.config.plan.application.query.existence.SourcePlanExistenceQueryWiringConfig;
+import com.alligator.market.backend.sourcing.config.SourcingFeatureWiringConfig;
 import com.alligator.market.backend.sourcing.plan.application.query.existence.port.SourcePlanExistenceQueryPort;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -13,14 +13,14 @@ import org.springframework.context.annotation.Import;
  * Wiring-конфигурация {@link FxSpotUsageContributor}.
  */
 @Configuration(proxyBeanMethods = false)
-@Import(SourcePlanExistenceQueryWiringConfig.class)
+@Import(SourcingFeatureWiringConfig.class)
 public class FxSpotUsageContributorWiringConfig {
 
     public static final String BEAN_SOURCE_PLAN_FX_SPOT_USAGE_CONTRIBUTOR = "sourcePlanFxSpotUsageContributor";
 
     @Bean(BEAN_SOURCE_PLAN_FX_SPOT_USAGE_CONTRIBUTOR)
     public FxSpotUsageContributor sourcePlanFxSpotUsageContributor(
-            @Qualifier(SourcePlanExistenceQueryWiringConfig.BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT)
+            @Qualifier(SourcingFeatureWiringConfig.BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT)
             SourcePlanExistenceQueryPort sourcePlanExistenceQueryPort
     ) {
         return new SourcePlanFxSpotUsageContributor(sourcePlanExistenceQueryPort);

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
@@ -1,0 +1,21 @@
+package com.alligator.market.backend.provider.config;
+
+import com.alligator.market.backend.provider.config.adapter.moex.iss.MoexIssProviderConfig;
+import com.alligator.market.backend.provider.config.passport.service.PassportCatalogServiceWiringConfig;
+import com.alligator.market.backend.provider.config.readmodel.passport.projection.startup.ProviderPassportProjectionStartupRunnerWiringConfig;
+import com.alligator.market.backend.provider.config.registry.ProviderRegistryWiringConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Единая внешняя точка входа в wiring фичи provider.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        ProviderRegistryWiringConfig.class,
+        PassportCatalogServiceWiringConfig.class,
+        ProviderPassportProjectionStartupRunnerWiringConfig.class,
+        MoexIssProviderConfig.class
+})
+public class ProviderFeatureWiringConfig {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/SourcingFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/SourcingFeatureWiringConfig.java
@@ -1,0 +1,30 @@
+package com.alligator.market.backend.sourcing.config;
+
+import com.alligator.market.backend.sourcing.config.plan.api.mapper.InstrumentSourcePlanApiMapperWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.command.create.CreateInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.command.delete.DeleteInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.command.replace.ReplaceInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.query.existence.SourcePlanExistenceQueryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.query.get.GetInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.query.list.ListInstrumentSourcePlansServiceWiringConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Единая внешняя точка входа в wiring фичи sourcing.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        InstrumentSourcePlanApiMapperWiringConfig.class,
+        GetInstrumentSourcePlanServiceWiringConfig.class,
+        ListInstrumentSourcePlansServiceWiringConfig.class,
+        CreateInstrumentSourcePlanServiceWiringConfig.class,
+        ReplaceInstrumentSourcePlanServiceWiringConfig.class,
+        DeleteInstrumentSourcePlanServiceWiringConfig.class,
+        SourcePlanExistenceQueryWiringConfig.class
+})
+public class SourcingFeatureWiringConfig {
+
+    public static final String BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT =
+            SourcePlanExistenceQueryWiringConfig.BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT;
+}


### PR DESCRIPTION
### Motivation
- Consolidate and expose wiring configuration for the `provider` and `sourcing` features through single entry-point configs to simplify imports and bean wiring.
- Replace multiple scattered wiring imports with feature-level wiring to make cross-feature dependencies easier to manage.

### Description
- Added `SourcingFeatureWiringConfig` as a central wiring configuration that `@Import`s all sourcing-related wiring configs and re-exports the `BEAN_SOURCE_PLAN_EXISTENCE_QUERY_PORT` constant.
- Added `ProviderFeatureWiringConfig` as a central wiring configuration that `@Import`s provider-related wiring configs including MOEX, registry and passport wiring.
- Updated `BackendApplication` to `@Import` the new `ProviderFeatureWiringConfig` and `SourcingFeatureWiringConfig` so feature wiring is registered on application startup.
- Updated `FxSpotUsageContributorWiringConfig` to import `SourcingFeatureWiringConfig` and to use its qualifier constant for the `SourcePlanExistenceQueryPort` bean.

### Testing
- Ran a full project build with `./gradlew build` and the execution of unit tests, and the build and tests completed successfully.
- Verified application context starts with the new wiring configs by running the application startup in a local environment, which initialized without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09cd2389c832db1068b253912d3d1)