### PR TITLE
Ввести feature-level wiring-конфигурации для sourcing.plan и forex

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
+++ b/backend/src/main/java/com/alligator/market/backend/BackendApplication.java
@@ -1,6 +1,9 @@
 package com.alligator.market.backend;
 
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.FxSpotFeatureWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.CurrencyFeatureWiringConfig;
 import com.alligator.market.backend.provider.config.ProviderFeatureWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.SourcingPlanFeatureWiringConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -16,7 +19,12 @@ import java.util.TimeZone;
 @SpringBootApplication
 @EnableScheduling
 @ConfigurationPropertiesScan("com.alligator.market.backend")
-@Import(ProviderFeatureWiringConfig.class)
+@Import({
+        ProviderFeatureWiringConfig.class,
+        SourcingPlanFeatureWiringConfig.class,
+        FxSpotFeatureWiringConfig.class,
+        CurrencyFeatureWiringConfig.class
+})
 public class BackendApplication {
 
     private static final TimeZone TECHNICAL_TIME_ZONE = TimeZone.getTimeZone(ZoneOffset.UTC);

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/FxSpotFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/fxspot/config/FxSpotFeatureWiringConfig.java
@@ -1,0 +1,25 @@
+package com.alligator.market.backend.instrument.asset.forex.fxspot.config;
+
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.command.create.CreateFxSpotServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.command.delete.DeleteFxSpotServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.command.update.UpdateFxSpotServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.query.list.ListFxSpotsServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.query.reference.currency.FxSpotCurrencyReferenceQueryWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.fxspot.config.application.usage.contributor.FxSpotUsageContributorWiringConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Единая внешняя точка входа в wiring фичи instrument.asset.forex.fxspot.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        CreateFxSpotServiceWiringConfig.class,
+        UpdateFxSpotServiceWiringConfig.class,
+        DeleteFxSpotServiceWiringConfig.class,
+        ListFxSpotsServiceWiringConfig.class,
+        FxSpotCurrencyReferenceQueryWiringConfig.class,
+        FxSpotUsageContributorWiringConfig.class
+})
+public class FxSpotFeatureWiringConfig {
+}

--- a/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/CurrencyFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/instrument/asset/forex/reference/currency/config/CurrencyFeatureWiringConfig.java
@@ -1,0 +1,23 @@
+package com.alligator.market.backend.instrument.asset.forex.reference.currency.config;
+
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.command.create.CreateCurrencyServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.command.delete.DeleteCurrencyServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.command.update.UpdateCurrencyServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.query.list.ListCurrenciesServiceWiringConfig;
+import com.alligator.market.backend.instrument.asset.forex.reference.currency.config.application.usage.contributor.CurrencyUsageContributorWiringConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Единая внешняя точка входа в wiring фичи instrument.asset.forex.reference.currency.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        CreateCurrencyServiceWiringConfig.class,
+        UpdateCurrencyServiceWiringConfig.class,
+        DeleteCurrencyServiceWiringConfig.class,
+        ListCurrenciesServiceWiringConfig.class,
+        CurrencyUsageContributorWiringConfig.class
+})
+public class CurrencyFeatureWiringConfig {
+}

--- a/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/SourcingPlanFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/sourcing/config/plan/SourcingPlanFeatureWiringConfig.java
@@ -1,0 +1,29 @@
+package com.alligator.market.backend.sourcing.config.plan;
+
+import com.alligator.market.backend.sourcing.config.plan.api.mapper.InstrumentSourcePlanApiMapperWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.command.create.CreateInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.command.delete.DeleteInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.command.replace.ReplaceInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.query.existence.SourcePlanExistenceQueryWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.query.get.GetInstrumentSourcePlanServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.query.list.ListInstrumentSourcePlansServiceWiringConfig;
+import com.alligator.market.backend.sourcing.config.plan.application.query.options.adapter.InstrumentSourcePlanOptionsQueryWiringConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Единая внешняя точка входа в wiring фичи sourcing.plan.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import({
+        CreateInstrumentSourcePlanServiceWiringConfig.class,
+        DeleteInstrumentSourcePlanServiceWiringConfig.class,
+        ReplaceInstrumentSourcePlanServiceWiringConfig.class,
+        GetInstrumentSourcePlanServiceWiringConfig.class,
+        ListInstrumentSourcePlansServiceWiringConfig.class,
+        SourcePlanExistenceQueryWiringConfig.class,
+        InstrumentSourcePlanOptionsQueryWiringConfig.class,
+        InstrumentSourcePlanApiMapperWiringConfig.class
+})
+public class SourcingPlanFeatureWiringConfig {
+}


### PR DESCRIPTION
### Motivation
- Упростить и стандартизировать внешнюю точку входа для отдельных фич, чтобы сборка wiring-конфигов была централизована и читабельна.
- Снизить распыление зависимостей внутри фич (команды, запросы, порты, репозитории, mapper) и явным образом обозначить границы фич.

### Description
- Добавлен `SourcingPlanFeatureWiringConfig` как единая внешняя точка входа для фичи `sourcing.plan`, которая импортирует все существующие wiring-конфиги (command/query/mapper и пр.).
- Добавлен `FxSpotFeatureWiringConfig` как единая внешняя точка входа для `instrument.asset.forex.fxspot`, собирающая wiring для create/update/delete/list и reference/usage-конфигы.
- Добавлен `CurrencyFeatureWiringConfig` как единая внешняя точка входа для `instrument.asset.forex.reference.currency`, собирающая wiring для command/query/usage слоёв.
- Обновлён `BackendApplication` с явным импортом всех feature-level entrypoints: `ProviderFeatureWiringConfig`, `SourcingPlanFeatureWiringConfig`, `FxSpotFeatureWiringConfig` и `CurrencyFeatureWiringConfig`.

### Testing
- Попытка сборки (команда `./mvnw -pl backend -DskipTests compile`) была выполнена автоматически и завершилась неудачей из-за ошибки загрузки Maven Wrapper (нельзя скачать `apache-maven-3.9.9-bin.zip` с `repo.maven.apache.org`).
- Поскольку окружение не позволило завершить сборку, автоматические тесты или полноценная компиляция на CI не запускались в этом пулл-реквесте.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c27f63b0832d8e52033bc856b746)