### PR TITLE
refactor(provider): перенести HTTP/API provider в provider/api

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/controller/PassportController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/controller/PassportController.java
@@ -1,10 +1,10 @@
-package com.alligator.market.backend.provider.passport.web;
+package com.alligator.market.backend.provider.api.passport.controller;
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.provider.passport.service.PassportCatalogService;
-import com.alligator.market.backend.provider.passport.web.dto.out.PassportResponseDto;
-import com.alligator.market.backend.provider.passport.web.dto.mapper.PassportDtoMapper;
+import com.alligator.market.backend.provider.api.passport.dto.PassportResponseDto;
+import com.alligator.market.backend.provider.api.passport.mapper.PassportDtoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/dto/PassportResponseDto.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/dto/PassportResponseDto.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.passport.web.dto.out;
+package com.alligator.market.backend.provider.api.passport.dto;
 
 /**
  * DTO для передачи паспорта провайдера (out).

--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/mapper/PassportDtoMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/mapper/PassportDtoMapper.java
@@ -1,6 +1,6 @@
-package com.alligator.market.backend.provider.passport.web.dto.mapper;
+package com.alligator.market.backend.provider.api.passport.mapper;
 
-import com.alligator.market.backend.provider.passport.web.dto.out.PassportResponseDto;
+import com.alligator.market.backend.provider.api.passport.dto.PassportResponseDto;
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;
 


### PR DESCRIPTION
### Motivation
- Сделать явным API-слой фичи provider и собрать все HTTP-контроллеры, DTO и mapper'ы под `backend/src/main/java/com/alligator/market/backend/provider/api/**`.

### Description
- Перемещены классы HTTP API: `PassportController` -> `provider/api/passport/controller`, `PassportResponseDto` -> `provider/api/passport/dto`, `PassportDtoMapper` -> `provider/api/passport/mapper`, обновлены пакеты и импорты.
- Поведение и URL эндпоинта не изменились (по-прежнему `GET /api/v1/providers`).

### Testing
- Попытка компиляции модуля backend выполнена командой `./mvnw -pl backend -DskipTests compile`, но она не прошла в этом окружении из‑за ошибки скачивания Maven (`Failed to fetch ... apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c90407f0832da0b66886f65e8301)