### PR TITLE
refactor(provider): move PassportController to provider/api/passport

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.api.passport.controller;
+package com.alligator.market.backend.provider.api.passport;
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;


### PR DESCRIPTION
### Motivation
- Сделать API‑роль фичи очевидной и сосредоточить HTTP‑транспорт в `provider/api/**`, поместив `PassportController` в `provider/api/passport`.

### Description
- Перенесён `PassportController` в пакет `com.alligator.market.backend.provider.api.passport` (файл `backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java`), обновлён `package` и удалена теперь пустая папка `controller`; путь эндпоинта и тело HTTP‑логики не изменялись.

### Testing
- Запуск `mvn -pl backend compile` завершился ошибкой из-за невозможности скачать parent POM из Maven Central (403), что является инфраструктурной проблемой в окружении и не связано с изменениями (FAIL).
- Произведён скан пакетов с помощью `rg -n "package .*provider.*web"` и `rg -n "RestController|RequestMapping|ControllerAdvice"` для `backend/src/main/java/com/alligator/market/backend/provider`, подтверждающий, что API‑классы находятся под `provider/api/**` (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0cd271e98832dbe0e9fb2d8ef4f57)