### PR TITLE
refactor(provider): move passport catalog use case to application layer

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.api.passport;
 
 import com.alligator.market.backend.common.web.response.ApiResponse;
 import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
-import com.alligator.market.backend.provider.passport.service.PassportCatalogService;
+import com.alligator.market.backend.provider.application.passport.catalog.PassportCatalogService;
 import com.alligator.market.backend.provider.api.passport.dto.PassportResponseDto;
 import com.alligator.market.backend.provider.api.passport.mapper.PassportDtoMapper;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/PassportCatalogService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/PassportCatalogService.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.passport.service;
+package com.alligator.market.backend.provider.application.passport.catalog;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;

--- a/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/PassportCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/PassportCatalogServiceImpl.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.passport.service;
+package com.alligator.market.backend.provider.application.passport.catalog;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.config;
 
 import com.alligator.market.backend.provider.config.adapter.moex.iss.MoexIssProviderConfig;
-import com.alligator.market.backend.provider.config.passport.service.PassportCatalogServiceWiringConfig;
+import com.alligator.market.backend.provider.config.application.passport.catalog.PassportCatalogServiceWiringConfig;
 import com.alligator.market.backend.provider.config.readmodel.passport.projection.startup.ProviderPassportProjectionStartupRunnerWiringConfig;
 import com.alligator.market.backend.provider.config.registry.ProviderRegistryWiringConfig;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/catalog/PassportCatalogServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/catalog/PassportCatalogServiceWiringConfig.java
@@ -1,7 +1,7 @@
-package com.alligator.market.backend.provider.config.passport.service;
+package com.alligator.market.backend.provider.config.application.passport.catalog;
 
-import com.alligator.market.backend.provider.passport.service.PassportCatalogService;
-import com.alligator.market.backend.provider.passport.service.PassportCatalogServiceImpl;
+import com.alligator.market.backend.provider.application.passport.catalog.PassportCatalogService;
+import com.alligator.market.backend.provider.application.passport.catalog.PassportCatalogServiceImpl;
 import com.alligator.market.backend.provider.config.readmodel.passport.query.ProviderPassportQueryPortWiringConfig;
 import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
 import org.springframework.beans.factory.annotation.Qualifier;


### PR DESCRIPTION
### Motivation
- Сделать явным application-слой для use case каталога паспортов провайдеров, так как `passport` в текущем дереве не является архитектурной ролью и содержит сценарий приложения. 
- Отделить orchestration use case от API и persistence слоёв, чтобы соблюсти архитектурные границы и облегчить дальнейшее развитие фичи.

### Description
- Перемещён интерфейс и реализация use case из `backend/src/main/java/com/alligator/market/backend/provider/passport/service` в `backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog` и обновлены package-декларации на `com.alligator.market.backend.provider.application.passport.catalog`.
- Перенесена wiring-конфигурация в `backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/catalog/PassportCatalogServiceWiringConfig.java` и обновлены её импорты на новый пакет application-сервиса.
- Обновлён `PassportController` так, чтобы он зависел от `provider.application.passport.catalog.PassportCatalogService` вместо старого API/persistence-пакета, при этом endpoint и JSON-ответ не изменялись.
- Обновлён `ProviderFeatureWiringConfig` для импорта новой wiring-конфигурации и удалены старые пустые/перемещённые пакеты в рамках реорганизации.

### Testing
- Выполнена попытка сборки `mvn -pl backend compile`, которая не прошла в этом окружении из-за ошибки резолвинга внешнего артефакта (`org.springframework.boot:spring-boot-starter-parent:4.0.5`) с Maven Central (HTTP 403), поэтому проект не был полностью собран здесь.
- Выполнены проверки поиска пакетов: `rg "package .*provider\.passport" backend/src/main/java/com/alligator/market/backend/provider` — совпадений не найдено, что подтверждает обновление package-деклараций.
- Выполнены проверки отсутствия инфраструктурных/HTTP-зависимостей в application-слое: `rg "org\.jooq|JdbcTemplate|RestController|RequestMapping" backend/src/main/java/com/alligator/market/backend/provider/application` — совпадений не найдено.
- Логика сервиса не менялась и продолжает использовать `ProviderPassportQueryPort` для чтения read-model; поведение API не изменено по контракту.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ca77e024832d8c290ffe06a8a9bb)