### PR TITLE
refactor(provider): перенести ProviderPassportQueryPort в application layer

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/PassportCatalogServiceImpl.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/PassportCatalogServiceImpl.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.application.passport.catalog;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;
-import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
+import com.alligator.market.backend.provider.application.passport.catalog.port.out.ProviderPassportQueryPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/port/out/ProviderPassportQueryPort.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/port/out/ProviderPassportQueryPort.java
@@ -1,4 +1,4 @@
-package com.alligator.market.domain.provider.readmodel.passport.query.port;
+package com.alligator.market.backend.provider.application.passport.catalog.port.out;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/catalog/PassportCatalogServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/catalog/PassportCatalogServiceWiringConfig.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.provider.config.application.passport.catalo
 import com.alligator.market.backend.provider.application.passport.catalog.PassportCatalogService;
 import com.alligator.market.backend.provider.application.passport.catalog.PassportCatalogServiceImpl;
 import com.alligator.market.backend.provider.config.readmodel.passport.query.ProviderPassportQueryPortWiringConfig;
-import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
+import com.alligator.market.backend.provider.application.passport.catalog.port.out.ProviderPassportQueryPort;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/query/ProviderPassportQueryPortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/query/ProviderPassportQueryPortWiringConfig.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.config.readmodel.passport.query;
 
 import com.alligator.market.backend.provider.readmodel.passport.query.port.adapter.jooq.ProviderPassportQueryPortJooqAdapter;
-import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
+import com.alligator.market.backend.provider.application.passport.catalog.port.out.ProviderPassportQueryPort;
 import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/query/port/adapter/jooq/ProviderPassportQueryPortJooqAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/query/port/adapter/jooq/ProviderPassportQueryPortJooqAdapter.java
@@ -3,7 +3,7 @@ package com.alligator.market.backend.provider.readmodel.passport.query.port.adap
 import com.alligator.market.domain.provider.passport.AccessMethod;
 import com.alligator.market.domain.provider.passport.DeliveryMode;
 import com.alligator.market.domain.provider.passport.ProviderPassport;
-import com.alligator.market.domain.provider.readmodel.passport.query.port.ProviderPassportQueryPort;
+import com.alligator.market.backend.provider.application.passport.catalog.port.out.ProviderPassportQueryPort;
 import com.alligator.market.domain.provider.vo.ProviderCode;
 import org.jooq.DSLContext;
 import org.jooq.Record5;


### PR DESCRIPTION
### Motivation
- Убрать нарушение границ слоёв: application сейчас зависел от readmodel, нужно перевести outbound-port в application, чтобы зависимость стала: application -> port, infrastructure -> implements port.

### Description
- Перемещён интерфейс `ProviderPassportQueryPort` в `backend/src/main/java/com/alligator/market/backend/provider/application/passport/catalog/port/out/ProviderPassportQueryPort.java` и обновлён `package`.
- Обновлены импорты в `PassportCatalogServiceImpl` и `PassportCatalogServiceWiringConfig` на новый пакет `com.alligator.market.backend.provider.application.passport.catalog.port.out`.
- Адаптер `ProviderPassportQueryPortJooqAdapter` и wiring `ProviderPassportQueryPortWiringConfig` теперь реализуют/возвращают порт из application-пакета без изменения сигнатуры `findAll()` и без изменения логики адаптера.
- Старый файл интерфейса в `domain/.../readmodel/passport/query/port` был удалён/перемещён и больше не используется в backend-коде.

### Testing
- Выполнена команда `mvn -pl backend compile`, сборка не завершилась из-за проблем с резолвом внешних зависимостей (Maven Central вернул HTTP 403).
- Выполнена проверка поиска по коду (`rg`/`grep`) на наличие старых импортов `readmodel.passport.query.port.ProviderPassportQueryPort`, которая не нашла совпадений, подтверждая корректное обновление ссылок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d1daaa38832dab11149d822cd4e0)