### PR TITLE
refactor(provider): move passport query jooq adapter to infrastructure

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/query/ProviderPassportQueryPortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/query/ProviderPassportQueryPortWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.config.readmodel.passport.query;
 
-import com.alligator.market.backend.provider.readmodel.passport.query.port.adapter.jooq.ProviderPassportQueryPortJooqAdapter;
+import com.alligator.market.backend.provider.infrastructure.persistence.passport.readmodel.jooq.ProviderPassportQueryPortJooqAdapter;
 import com.alligator.market.backend.provider.application.passport.catalog.port.out.ProviderPassportQueryPort;
 import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/alligator/market/backend/provider/infrastructure/persistence/passport/readmodel/jooq/ProviderPassportQueryPortJooqAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/infrastructure/persistence/passport/readmodel/jooq/ProviderPassportQueryPortJooqAdapter.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.readmodel.passport.query.port.adapter.jooq;
+package com.alligator.market.backend.provider.infrastructure.persistence.passport.readmodel.jooq;
 
 import com.alligator.market.domain.provider.passport.AccessMethod;
 import com.alligator.market.domain.provider.passport.DeliveryMode;


### PR DESCRIPTION
### Motivation
- Перенести реализацию query-порта, использующую jOOQ и сгенерированные таблицы, в слой инфраструктуры, чтобы соблюсти архитектурный принцип: application владеет портом, infrastructure реализует порт.

### Description
- Перемещён класс `ProviderPassportQueryPortJooqAdapter` в пакет `provider.infrastructure.persistence.passport.readmodel.jooq` и обновлён `package` в файле.
- Конфигурация wiring `ProviderPassportQueryPortWiringConfig` обновлена для импорта и создания адаптера из нового пакета (`new ProviderPassportQueryPortJooqAdapter(dsl)`).
- Вся существующая jOOQ-логика в `findAll()` сохранена без изменений (сортировка, `LinkedHashMap`, маппинг enum/VO, обработка дубликатов и использование сгенерированной таблицы `PROVIDER_PASSPORT`).
- Старый файл из пакета `provider.readmodel.passport.query.port.adapter.jooq` удалён в результате переноса и пакет больше не содержит адаптера.

### Testing
- Попытка сборки `mvn -pl backend compile` завершилась неудачей из-за ограничений окружения при загрузке parent POM из Maven Central (HTTP 403), поэтому полная компиляция не прошла.
- Архитектурные grep-проверки выполнены и не обнаружили ссылок на старый пакет: `rg "readmodel.passport.query.port.adapter.jooq" backend/src/main/java` (нет совпадений).
- Проверка отсутствия использования jOOQ/сгенерированных таблиц в application-слое выполнена командой `rg "org.jooq|infra.jooq.generated" backend/src/main/java/com/alligator/market/backend/provider/application` и не обнаружила совпадений.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f205a71894832d80c3aecb923726e2)