### PR TITLE
refactor(provider): move passport projection jooq adapter to infrastructure

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/jooq/ProviderPassportProjectionWritePortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/jooq/ProviderPassportProjectionWritePortWiringConfig.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.config.readmodel.passport.projection.jooq;
 
-import com.alligator.market.backend.provider.readmodel.passport.projection.port.adapter.jooq.ProviderPassportProjectionWritePortJooqAdapter;
+import com.alligator.market.backend.provider.infrastructure.persistence.passport.readmodel.jooq.ProviderPassportProjectionWritePortJooqAdapter;
 import com.alligator.market.backend.provider.application.passport.projection.port.out.ProviderPassportProjectionWritePort;
 import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/alligator/market/backend/provider/infrastructure/persistence/passport/readmodel/jooq/ProviderPassportProjectionWritePortJooqAdapter.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/infrastructure/persistence/passport/readmodel/jooq/ProviderPassportProjectionWritePortJooqAdapter.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.readmodel.passport.projection.port.adapter.jooq;
+package com.alligator.market.backend.provider.infrastructure.persistence.passport.readmodel.jooq;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.backend.provider.application.passport.projection.port.out.ProviderPassportProjectionWritePort;


### PR DESCRIPTION
### Motivation
- Выделить jOOQ-реализацию write-порта проекции паспортов провайдера в слой инфраструктуры, соблюдая архитектурное правило: jOOQ только в `infrastructure/persistence` и application не зависит от infrastructure.
- Согласовать расположение persistence-адаптеров для фичи `provider` с уже перенесённым query adapter.

### Description
- Перенёс класс `ProviderPassportProjectionWritePortJooqAdapter` в пакет `com.alligator.market.backend.provider.infrastructure.persistence.passport.readmodel.jooq` и обновил `package`-декларацию без изменения внутренней логики.
- Адаптер продолжает реализовывать порт `com.alligator.market.backend.provider.application.passport.projection.port.out.ProviderPassportProjectionWritePort` и сохраняет всю jOOQ-логику (включая `deleteAllExcept`, `upsertAll`, `ON CONFLICT`, `IS DISTINCT FROM`, батч-исполнение и использование сгенерированной jOOQ-таблицы).
- Обновил импорт в `ProviderPassportProjectionWritePortWiringConfig` так, чтобы бин создавался из нового `infrastructure`-пакета и при этом метод возвращает интерфейс `ProviderPassportProjectionWritePort` из application-слоя.

### Testing
- Запуск `mvn -pl backend compile` завершился с ошибкой в этом окружении из-за `403 Forbidden` при разрешении `org.springframework.boot:spring-boot-starter-parent:4.0.5` из Maven Central, поэтому полная сборка не прошла.
- Проверки поиска: `grep -R "readmodel.passport.projection.port.adapter.jooq" backend/src/main/java` не нашёл старых импортов, а `grep -R "org.jooq\|infra.jooq.generated" backend/src/main/java/com/alligator/market/backend/provider/application` не нашёл утечек jOOQ в application-слое, обе проверки успешны.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21d7efa0c832dae3d5eb0a9e175ce)