### PR TITLE
refactor(provider): move passport projector to application layer

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/application/passport/projection/ProviderPassportProjector.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/application/passport/projection/ProviderPassportProjector.java
@@ -1,4 +1,4 @@
-package com.alligator.market.domain.provider.readmodel.passport.projection.projector;
+package com.alligator.market.backend.provider.application.passport.projection;
 
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.backend.provider.application.passport.projection.port.out.ProviderPassportProjectionWritePort;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/projector/ProviderPassportProjectorWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/projector/ProviderPassportProjectorWiringConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.config.readmodel.passport.projecti
 
 import com.alligator.market.backend.provider.config.readmodel.passport.projection.jooq.ProviderPassportProjectionWritePortWiringConfig;
 import com.alligator.market.backend.provider.config.registry.ProviderRegistryWiringConfig;
-import com.alligator.market.domain.provider.readmodel.passport.projection.projector.ProviderPassportProjector;
+import com.alligator.market.backend.provider.application.passport.projection.ProviderPassportProjector;
 import com.alligator.market.backend.provider.application.passport.projection.port.out.ProviderPassportProjectionWritePort;
 import com.alligator.market.domain.provider.registry.ProviderRegistry;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/service/ProviderPassportProjectionServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/service/ProviderPassportProjectionServiceWiringConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.config.readmodel.passport.projecti
 
 import com.alligator.market.backend.provider.config.readmodel.passport.projection.projector.ProviderPassportProjectorWiringConfig;
 import com.alligator.market.backend.provider.readmodel.passport.projection.service.ProviderPassportProjectionService;
-import com.alligator.market.domain.provider.readmodel.passport.projection.projector.ProviderPassportProjector;
+import com.alligator.market.backend.provider.application.passport.projection.ProviderPassportProjector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/service/ProviderPassportProjectionService.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/readmodel/passport/projection/service/ProviderPassportProjectionService.java
@@ -1,6 +1,6 @@
 package com.alligator.market.backend.provider.readmodel.passport.projection.service;
 
-import com.alligator.market.domain.provider.readmodel.passport.projection.projector.ProviderPassportProjector;
+import com.alligator.market.backend.provider.application.passport.projection.ProviderPassportProjector;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Objects;


### PR DESCRIPTION
### Motivation
- ProviderPassportProjector — это логика построения application-level проекции из `ProviderRegistry`, а не слой persistence, поэтому её место в application-пакете. 
- Перемещение упрощает архитектурную границу между readmodel/persistence и application/use-case логикой.

### Description
- Файл класса перенесён в пакет `com.alligator.market.backend.provider.application.passport.projection` и обновлён `package`-декларацией, при этом внутренняя логика класса не менялась. 
- Обновлены импорты во вёртках/сервисах: `ProviderPassportProjectionService`, `ProviderPassportProjectorWiringConfig` и `ProviderPassportProjectionServiceWiringConfig` теперь ссылаются на новый пакет проектора. 
- Bean-настройка и имя bean не изменялись, публичные методы и поведение проекции сохранены. 
- Старый файл в пакете readmodel был устранён как часть перемещения.

### Testing
- Запущена проверка отсутствия старых импортов через `rg` и подтверждено, что больше нет ссылок на старое расположение проектора. (успех)
- Попытка компиляции `mvn -pl backend compile` выполнена, но закончилась неудачей из-за доступа к внешним зависимостям Maven Central (HTTP 403), не связанного с внесёнными изменениями. (неудача)
- Локальная инспекция файлов показала, что логика метода `project()` и вызовы `deleteAllExcept` → `upsertAll` не изменены. (успех)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f226aa3cbc832d9e62e54b9946e4bb)