### PR TITLE
refactor(provider): move passport projection startup runner to infrastructure

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/readmodel/passport/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.config.readmodel.passport.projecti
 
 import com.alligator.market.backend.provider.config.readmodel.passport.projection.service.ProviderPassportProjectionServiceWiringConfig;
 import com.alligator.market.backend.provider.readmodel.passport.projection.service.ProviderPassportProjectionService;
-import com.alligator.market.backend.provider.readmodel.passport.projection.startup.ProviderPassportProjectionStartupRunner;
+import com.alligator.market.backend.provider.infrastructure.startup.passport.projection.ProviderPassportProjectionStartupRunner;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/alligator/market/backend/provider/infrastructure/startup/passport/projection/ProviderPassportProjectionStartupRunner.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/infrastructure/startup/passport/projection/ProviderPassportProjectionStartupRunner.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.readmodel.passport.projection.startup;
+package com.alligator.market.backend.provider.infrastructure.startup.passport.projection;
 
 import com.alligator.market.backend.provider.readmodel.passport.projection.service.ProviderPassportProjectionService;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
### Motivation
- Runner `ProviderPassportProjectionStartupRunner` является Spring startup-adapter и логически принадлежит к инфраструктурному слою, а не к readmodel.
- Нужно отделить механизм запуска (infrastructure) от application/readmodel логики, сохранив явную сборку через config.

### Description
- Перенёс класс `ProviderPassportProjectionStartupRunner` в пакет `com.alligator.market.backend.provider.infrastructure.startup.passport.projection` и обновил `package` в файле.
- Обновил импорт в wiring-конфиге: `ProviderPassportProjectionStartupRunnerWiringConfig` теперь импортирует раннер из нового package и по-прежнему создаёт его через `new ProviderPassportProjectionStartupRunner(service)` с тем же именем бина.
- Сохранено поведение раннера без изменений: реализует `ApplicationRunner`, метод `run(ApplicationArguments)`, вызывает `service.project()`, оставлены логи и fail-fast `throw ex`, а также валидация конструктора.
- Удалена старая (пустая) директория `provider/readmodel/passport/projection/startup` после переноса.

### Testing
- Запуск `mvn -pl backend compile` выполнен в окружении и завершился с ошибкой из-за запрета доступа к Maven Central (`403 Forbidden`) при загрузке parent POM, поэтому сборка не была полностью проверена.
- `grep -R "readmodel.passport.projection.startup.ProviderPassportProjectionStartupRunner" backend/src/main/java` не нашёл старых импортов перемещённого класса.
- `grep -R "ApplicationRunner\|ApplicationArguments" backend/src/main/java/com/alligator/market/backend/provider/application` не нашёл нарушений в application-слое.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31c56b3d4832da1bfe2e43a7e74a6)