### PR TITLE
Добавить maxBatchSize в ProviderPolicy и перейти на явную инициализацию

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/adapter/moex/iss/MoexIssProvider.java
@@ -9,6 +9,7 @@ import com.alligator.market.domain.provider.passport.DeliveryMode;
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.policy.ProviderPolicy;
 
+import java.time.Duration;
 import java.util.Set;
 
 /**
@@ -28,7 +29,10 @@ public final class MoexIssProvider extends AbstractMarketDataProvider<MoexIssPro
             false
     );
 
-    private static final ProviderPolicy POLICY = ProviderPolicy.ofSeconds(1);
+    private static final ProviderPolicy POLICY = new ProviderPolicy(
+            Duration.ofSeconds(1),
+            100
+    );
 
     /**
      * Конструктор адаптера MOEX ISS.

--- a/domain/src/main/java/com/alligator/market/domain/provider/policy/ProviderPolicy.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/policy/ProviderPolicy.java
@@ -7,13 +7,17 @@ import java.util.Objects;
  * Политика провайдера: иммутабельные параметры, которые использует бизнес-логика.
  *
  * @param minUpdateInterval Минимальный интервал обновления/запроса котировок
+ * @param maxBatchSize      Максимальный размер батча на один запрос (параметр для дальнейшего масштабирования)
  */
 public record ProviderPolicy(
-        Duration minUpdateInterval
-        // TODO: добавить еще один параметр и уйти от поведения когда ProviderPolicy подразумевает только minUpdateInterval
+        Duration minUpdateInterval,
+        int maxBatchSize
 ) {
     /* Минимально допустимый интервал (ограничение). */
     private static final Duration MIN_ALLOWED = Duration.ofSeconds(1);
+
+    /* Минимально допустимый размер батча (ограничение). */
+    private static final int MIN_BATCH_SIZE = 1;
 
     public ProviderPolicy {
         Objects.requireNonNull(minUpdateInterval, "minUpdateInterval must not be null");
@@ -22,10 +26,10 @@ public record ProviderPolicy(
         if (minUpdateInterval.compareTo(MIN_ALLOWED) < 0) {
             throw new IllegalArgumentException("minUpdateInterval must be >= PT1S");
         }
-    }
 
-    /* Удобная фабрика, если значения приходят в секундах. */
-    public static ProviderPolicy ofSeconds(long seconds) {
-        return new ProviderPolicy(Duration.ofSeconds(seconds));
+        // Размер батча должен быть положительным
+        if (maxBatchSize < MIN_BATCH_SIZE) {
+            throw new IllegalArgumentException("maxBatchSize must be >= 1");
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Сделать `ProviderPolicy` расширяемым для будущих параметров (ввести дополнительный параметр для масштабирования батч-логики). 
- Устранить использование `ProviderPolicy` как класса с одним параметром и фабрики `ofSeconds`, чтобы policy всегда заполнялся явно. 

### Description
- Расширен `ProviderPolicy` записью `int maxBatchSize` и добавлен соответствующий JavaDoc параметра. 
- Добавлена валидация: `maxBatchSize` должен быть `>= 1`, а `minUpdateInterval` остаётся с ограничением `>= PT1S`. 
- Удалена фабрика `ofSeconds(...)` и canonical-конструктор теперь проверяет оба поля. 
- Обновлён `MoexIssProvider` для явной инициализации `POLICY` через `new ProviderPolicy(Duration.ofSeconds(1), 100)` и добавлен импорт `Duration`. 

### Testing
- Попытка собрать проект командой `./mvnw -q -DskipTests compile` выполнена и завершилась неудачей из-за проблемы окружения: `wget` не смог скачать Maven-дистрибутив с `repo.maven.apache.org` (сборка не выполнена).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33c8a42fc832d97bcd0e4988e0fbc)