### PR TITLE
Simplify HandlerNotFoundException

### DIFF
--- a/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
+++ b/domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java
@@ -8,67 +8,12 @@ import java.util.Objects;
 /**
  * Обработчик для инструмента не найден.
  */
-public final class HandlerNotFoundException extends RuntimeException {
+public final class HandlerNotFoundException extends IllegalStateException {
 
-    private final InstrumentCode instrumentCode;
-    private final ProviderCode providerCode;
-
-    /**
-     * Создает исключение.
-     *
-     * @param instrumentCode код инструмента
-     * @param providerCode   код провайдера
-     */
     public HandlerNotFoundException(InstrumentCode instrumentCode, ProviderCode providerCode) {
-        super(msg(instrumentCode, providerCode));
-        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        this.providerCode = Objects.requireNonNull(providerCode, "providerCode must not be null");
-    }
-
-    /**
-     * Создает исключение с причиной.
-     *
-     * @param instrumentCode код инструмента
-     * @param providerCode   код провайдера
-     * @param cause          причина ошибки
-     */
-    @SuppressWarnings("unused")
-    public HandlerNotFoundException(InstrumentCode instrumentCode, ProviderCode providerCode, Throwable cause) {
-        super(msg(instrumentCode, providerCode), cause);
-        this.instrumentCode = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        this.providerCode = Objects.requireNonNull(providerCode, "providerCode must not be null");
-    }
-
-    /**
-     * Формирует сообщение об ошибке.
-     *
-     * @param instrumentCode код инструмента
-     * @param providerCode   код провайдера
-     * @return текст сообщения
-     */
-    private static String msg(InstrumentCode instrumentCode, ProviderCode providerCode) {
-        InstrumentCode ic = Objects.requireNonNull(instrumentCode, "instrumentCode must not be null");
-        ProviderCode pc = Objects.requireNonNull(providerCode, "providerCode must not be null");
-        return "Handler not found (instrumentCode=" + ic.value() + ", providerCode=" + pc.value() + ")";
-    }
-
-    /**
-     * Возвращает код инструмента.
-     *
-     * @return код инструмента
-     */
-    @SuppressWarnings("unused")
-    public InstrumentCode getInstrumentCode() {
-        return instrumentCode;
-    }
-
-    /**
-     * Возвращает код провайдера.
-     *
-     * @return код провайдера
-     */
-    @SuppressWarnings("unused")
-    public ProviderCode getProviderCode() {
-        return providerCode;
+        super("Handler not found (instrumentCode=%s, providerCode=%s)".formatted(
+                Objects.requireNonNull(instrumentCode, "instrumentCode must not be null").value(),
+                Objects.requireNonNull(providerCode, "providerCode must not be null").value()
+        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Упростить реализацию ошибки для единообразия с другими not-found исключениями в проекте и убрать неиспользуемое состояние.

### Description
- Обновлён файл `domain/src/main/java/com/alligator/market/domain/provider/exception/HandlerNotFoundException.java`: класс теперь наследует `IllegalStateException`, удалены поля `InstrumentCode`/`ProviderCode`, лишний конструктор с `cause` и геттеры, оставлен один конструктор, формирующий сообщение с null-проверками.

### Testing
- Попытка собрать модуль `domain` командой `./mvnw -q -pl domain -DskipTests compile` была выполнена, но сборка не стартовала из-за того, что Maven Wrapper не смог скачать дистрибутив (`Failed to fetch ... apache-maven-3.9.9-bin.zip`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3435b5a48832d9cd2406f9fbb8501)