### PR TITLE
Рефакторинг: PassportController на стандартный Spring `ResponseEntity`

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java
@@ -1,7 +1,5 @@
 package com.alligator.market.backend.provider.api.passport;
 
-import com.alligator.market.backend.common.web.response.ApiResponse;
-import com.alligator.market.backend.common.web.response.ResponseEntityFactory;
 import com.alligator.market.backend.provider.application.passport.catalog.PassportCatalogService;
 import com.alligator.market.backend.provider.api.passport.dto.PassportResponseDto;
 import com.alligator.market.backend.provider.api.passport.mapper.PassportDtoMapper;
@@ -27,12 +25,12 @@ public class PassportController {
      * Вернуть все паспорта провайдеров.
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PassportResponseDto>>> getAll() {
+    public ResponseEntity<List<PassportResponseDto>> getAll() {
         var passports = service.findAll();
 
         List<PassportResponseDto> list = passports.entrySet().stream()
                 .map(entry -> PassportDtoMapper.toProviderPassportResponseDto(entry.getKey(), entry.getValue()))
                 .toList();
-        return ResponseEntityFactory.ok(list);
+        return ResponseEntity.ok(list);
     }
 }


### PR DESCRIPTION
### Motivation
- Привести `PassportController` к единому контракту HTTP-ответов проекта, отказавшись от кастомного `ApiResponse` в пользу стандартных обёрток Spring.

### Description
- В `backend/src/main/java/com/alligator/market/backend/provider/api/passport/PassportController.java` убраны импорты `ApiResponse` и `ResponseEntityFactory`, изменён возвращаемый тип метода на `ResponseEntity<List<PassportResponseDto>>` и заменён `ResponseEntityFactory.ok(list)` на `ResponseEntity.ok(list)`.

### Testing
- Выполнена попытка сборки проекта командой `./mvnw -q -pl backend -DskipTests compile`, которая не завершилась успешно из‑за невозможности скачать Maven дистрибутив в текущем окружении (скачивание заблокировано).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f344f345e4832daaa8ba0c92e70e9d)