### PR TITLE
Привести структуру provider/api/passport/query к виду с `list` поддиректорией

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/query/list/controller/PassportListController.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/query/list/controller/PassportListController.java
@@ -1,8 +1,8 @@
-package com.alligator.market.backend.provider.api.passport.query.controller;
+package com.alligator.market.backend.provider.api.passport.query.list.controller;
 
 import com.alligator.market.backend.provider.application.passport.catalog.PassportCatalogService;
-import com.alligator.market.backend.provider.api.passport.query.dto.PassportListItemResponse;
-import com.alligator.market.backend.provider.api.passport.query.mapper.PassportListItemResponseMapper;
+import com.alligator.market.backend.provider.api.passport.query.list.dto.PassportListItemResponse;
+import com.alligator.market.backend.provider.api.passport.query.list.mapper.PassportListItemResponseMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,7 +29,7 @@ public class PassportListController {
         var passports = service.findAll();
 
         List<PassportListItemResponse> list = passports.entrySet().stream()
-                .map(entry -> PassportListItemResponseMapper.toProviderPassportResponseDto(entry.getKey(), entry.getValue()))
+                .map(entry -> PassportListItemResponseMapper.toResponse(entry.getKey(), entry.getValue()))
                 .toList();
         return ResponseEntity.ok(list);
     }

--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/query/list/dto/PassportListItemResponse.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/query/list/dto/PassportListItemResponse.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.api.passport.query.dto;
+package com.alligator.market.backend.provider.api.passport.query.list.dto;
 
 /**
  * DTO для передачи паспорта провайдера (out).

--- a/backend/src/main/java/com/alligator/market/backend/provider/api/passport/query/list/mapper/PassportListItemResponseMapper.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/passport/query/list/mapper/PassportListItemResponseMapper.java
@@ -1,6 +1,6 @@
-package com.alligator.market.backend.provider.api.passport.query.mapper;
+package com.alligator.market.backend.provider.api.passport.query.list.mapper;
 
-import com.alligator.market.backend.provider.api.passport.query.dto.PassportListItemResponse;
+import com.alligator.market.backend.provider.api.passport.query.list.dto.PassportListItemResponse;
 import com.alligator.market.domain.provider.passport.ProviderPassport;
 import com.alligator.market.domain.provider.vo.ProviderCode;
 
@@ -21,7 +21,7 @@ public final class PassportListItemResponseMapper {
     /**
      * Модель --> DTO ответа.
      */
-    public static PassportListItemResponse toProviderPassportResponseDto(ProviderCode providerCode,
+    public static PassportListItemResponse toResponse(ProviderCode providerCode,
                                                                          ProviderPassport providerPassport) {
         Objects.requireNonNull(providerCode, "providerCode must not be null");
         Objects.requireNonNull(providerPassport, "providerPassport must not be null");


### PR DESCRIPTION
### Motivation
- Привести пакет `provider/api/passport/query` к единому виду с другими query-модулями (например `fxspot` и `currency`) для согласованной организации контроллеров/DTO/мапперов.

### Description
- Перемещены классы в `backend/src/main/java/com/alligator/market/backend/provider/api/passport/query/list/{controller,dto,mapper}` и обновлены декларации пакетов и импорты для новых путей.
- Переименован метод маппера `toProviderPassportResponseDto(...)` в `toResponse(...)` и вызовы обновлены в контроллере `PassportListController`.
- Никакая бизнес-логика не изменилаcь: DTO-поля и формируемый ответ остались прежними.

### Testing
- Выполнена попытка сборки: `mvn -pl backend -DskipTests compile`, сборка не прошла в этой среде из‑за невозможности разрешить родительский POM `org.springframework.boot:spring-boot-starter-parent:4.0.5` (HTTP 403 при загрузке из Maven Central), поэтому компиляция не завершилась.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46c0aff6c832d86001905bc7e1470)