### PR TITLE
Убрал предупреждения о всегда-константных аргументах в ProviderApiExceptionHandler

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/api/advice/ProviderApiExceptionHandler.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/api/advice/ProviderApiExceptionHandler.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice(assignableTypes = PassportListController.class)
 public class ProviderApiExceptionHandler {
+    private static final HttpStatus HANDLER_NOT_FOUND_STATUS = HttpStatus.NOT_FOUND;
+    private static final String HANDLER_NOT_FOUND_TITLE = "Provider handler not found";
 
     /**
      * Хендлер для инструмента не найден --> 404.
@@ -25,17 +27,15 @@ public class ProviderApiExceptionHandler {
     public ProblemDetail handleHandlerNotFound(HandlerNotFoundException ex) {
         log.warn("Provider handler not found: {}", ex.getMessage());
         return buildProblemDetail(
-                HttpStatus.NOT_FOUND,
-                "Provider handler not found",
                 ex.getMessage(),
                 ProviderApiErrorCode.PROVIDER_HANDLER_NOT_FOUND.code()
         );
     }
 
     /* Общий builder ProblemDetail для единообразного контракта ошибок provider feature. */
-    private ProblemDetail buildProblemDetail(HttpStatus status, String title, String detail, String errorCode) {
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
-        problemDetail.setTitle(title);
+    private ProblemDetail buildProblemDetail(String detail, String errorCode) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HANDLER_NOT_FOUND_STATUS, detail);
+        problemDetail.setTitle(HANDLER_NOT_FOUND_TITLE);
         problemDetail.setProperty("errorCode", errorCode);
         return problemDetail;
     }


### PR DESCRIPTION
### Motivation
- В текущем `ProviderApiExceptionHandler` метод `buildProblemDetail` принимал параметры `status` и `title`, которые в этом классе всегда были `HttpStatus.NOT_FOUND` и `"Provider handler not found"`, из‑за чего статический анализатор выдавал предупреждение о всегда-константных аргументах. 

### Description
- Вынес константы `HANDLER_NOT_FOUND_STATUS` и `HANDLER_NOT_FOUND_TITLE` и упростил сигнатуру `buildProblemDetail` до `buildProblemDetail(String detail, String errorCode)` в `backend/src/main/java/com/alligator/market/backend/provider/api/advice/ProviderApiExceptionHandler.java`, сохранив прежнее поведение ответа (404 и тот же заголовок/`errorCode`).

### Testing
- Запуск сборки модуля попыткой `./mvnw -pl backend -DskipTests compile` был выполнен в окружении, но завершился неудачно из‑за невозможности скачать Maven дистрибутив (`Failed to fetch ... apache-maven-3.9.9-bin.zip`), поэтому автоматическая компиляция не прошла в этой среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47aa8a250832da7e5af7ad0916d7f)