### PR TITLE
Refactor provider passport projection wiring packages

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/ProviderFeatureWiringConfig.java
@@ -2,7 +2,7 @@ package com.alligator.market.backend.provider.config;
 
 import com.alligator.market.backend.provider.config.adapter.moex.iss.MoexIssProviderConfig;
 import com.alligator.market.backend.provider.config.application.passport.query.list.PassportListServiceWiringConfig;
-import com.alligator.market.backend.provider.config.readmodel.passport.projection.startup.ProviderPassportProjectionStartupRunnerWiringConfig;
+import com.alligator.market.backend.provider.config.application.passport.projection.startup.ProviderPassportProjectionStartupRunnerWiringConfig;
 import com.alligator.market.backend.provider.config.registry.ProviderRegistryWiringConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/jooq/ProviderPassportProjectionWritePortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/jooq/ProviderPassportProjectionWritePortWiringConfig.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.config.readmodel.passport.projection.jooq;
+package com.alligator.market.backend.provider.config.application.passport.projection.jooq;
 
 import com.alligator.market.backend.provider.application.passport.projection.port.adapter.JooqProviderPassportProjectionWritePortAdapter;
 import com.alligator.market.backend.provider.application.passport.projection.port.ProviderPassportProjectionWritePort;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/service/ProviderPassportProjectionServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/service/ProviderPassportProjectionServiceWiringConfig.java
@@ -1,7 +1,7 @@
-package com.alligator.market.backend.provider.config.readmodel.passport.projection.service;
+package com.alligator.market.backend.provider.config.application.passport.projection.service;
 
 import com.alligator.market.backend.provider.application.passport.projection.port.ProviderPassportProjectionWritePort;
-import com.alligator.market.backend.provider.config.readmodel.passport.projection.jooq.ProviderPassportProjectionWritePortWiringConfig;
+import com.alligator.market.backend.provider.config.application.passport.projection.jooq.ProviderPassportProjectionWritePortWiringConfig;
 import com.alligator.market.backend.provider.config.registry.ProviderRegistryWiringConfig;
 import com.alligator.market.backend.provider.application.passport.projection.ProviderPassportProjectionService;
 import com.alligator.market.domain.provider.registry.ProviderRegistry;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/startup/ProviderPassportProjectionStartupRunnerWiringConfig.java
@@ -1,6 +1,6 @@
-package com.alligator.market.backend.provider.config.readmodel.passport.projection.startup;
+package com.alligator.market.backend.provider.config.application.passport.projection.startup;
 
-import com.alligator.market.backend.provider.config.readmodel.passport.projection.service.ProviderPassportProjectionServiceWiringConfig;
+import com.alligator.market.backend.provider.config.application.passport.projection.service.ProviderPassportProjectionServiceWiringConfig;
 import com.alligator.market.backend.provider.application.passport.projection.ProviderPassportProjectionService;
 import com.alligator.market.backend.provider.application.passport.projection.runner.ProviderPassportProjectionStartupRunner;
 import org.springframework.boot.ApplicationRunner;


### PR DESCRIPTION
### Motivation
- Упростить и выровнять структуру wiring: wiring для application-level проекции паспортов логичнее держать рядом с сервисом проекции, а не в пакете с историческим названием `readmodel`.

### Description
- Перенёс wiring-конфиги проекции паспортов из `provider/config/readmodel/passport/projection/{service,jooq,startup}` в `provider/config/application/passport/projection/{service,jooq,startup}` и обновил пакеты в файлах.
- Обновил импорты в `ProviderFeatureWiringConfig` на новый путь `com.alligator.market.backend.provider.config.application.passport.projection.startup.ProviderPassportProjectionStartupRunnerWiringConfig`.
- Обновил внутренние импорты между перемещёнными wiring-классами, чтобы они ссылались на новые пакеты.

### Testing
- Проверил отсутствие оставшихся ссылок на старый пакет командой `rg 'config\.readmodel\.passport\.projection|readmodel/passport/projection' backend/src/main/java` и не нашёл совпадений.
- Запуск сборки `mvn -pl backend -DskipTests compile` завершился с ошибкой разрешения внешних зависимостей (Maven Central вернул `403 Forbidden` для `org.springframework.boot:spring-boot-starter-parent:4.0.5`), то есть локальные изменения не смогли быть проверены компиляцией из-за внешней проблемы.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47e16c318832d9e9d87467a296857)