### PR TITLE
Переместить wiring-конфиг ProviderPassportProjectionWritePortWiringConfig рядом с Jooq-адаптером

### DIFF
--- a/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/service/ProviderPassportProjectionServiceWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/service/ProviderPassportProjectionServiceWiringConfig.java
@@ -1,7 +1,7 @@
 package com.alligator.market.backend.provider.config.application.passport.projection.service;
 
 import com.alligator.market.backend.provider.application.passport.projection.port.ProviderPassportProjectionWritePort;
-import com.alligator.market.backend.provider.config.application.passport.projection.jooq.ProviderPassportProjectionWritePortWiringConfig;
+import com.alligator.market.backend.provider.config.persistence.passport.projection.port.adapter.ProviderPassportProjectionWritePortWiringConfig;
 import com.alligator.market.backend.provider.config.registry.ProviderRegistryWiringConfig;
 import com.alligator.market.backend.provider.application.passport.projection.ProviderPassportProjectionService;
 import com.alligator.market.domain.provider.registry.ProviderRegistry;

--- a/backend/src/main/java/com/alligator/market/backend/provider/config/persistence/passport/projection/port/adapter/ProviderPassportProjectionWritePortWiringConfig.java
+++ b/backend/src/main/java/com/alligator/market/backend/provider/config/persistence/passport/projection/port/adapter/ProviderPassportProjectionWritePortWiringConfig.java
@@ -1,4 +1,4 @@
-package com.alligator.market.backend.provider.config.application.passport.projection.jooq;
+package com.alligator.market.backend.provider.config.persistence.passport.projection.port.adapter;
 
 import com.alligator.market.backend.provider.persistence.passport.projection.port.adapter.JooqProviderPassportProjectionWritePortAdapter;
 import com.alligator.market.backend.provider.application.passport.projection.port.ProviderPassportProjectionWritePort;


### PR DESCRIPTION
### Motivation
- Перенести wiring-конфиг `ProviderPassportProjectionWritePortWiringConfig` в пакет рядом с адаптером `JooqProviderPassportProjectionWritePortAdapter` для согласованного расположения кода и улучшения структуры проекта.

### Description
- Перемещён файл `backend/src/main/java/com/alligator/market/backend/provider/config/application/passport/projection/jooq/ProviderPassportProjectionWritePortWiringConfig.java` в `backend/src/main/java/com/alligator/market/backend/provider/config/persistence/passport/projection/port/adapter/ProviderPassportProjectionWritePortWiringConfig.java` и обновлён пакет на `com.alligator.market.backend.provider.config.persistence.passport.projection.port.adapter`.
- Обновлён импорт в `ProviderPassportProjectionServiceWiringConfig` на `com.alligator.market.backend.provider.config.persistence.passport.projection.port.adapter.ProviderPassportProjectionWritePortWiringConfig`.

### Testing
- Попытка компиляции модуля `backend` командой `mvn -pl backend -DskipTests compile` завершилась с ошибкой из-за недоступного внешнего артефакта (`org.springframework.boot:spring-boot-starter-parent:4.0.5`) из Maven Central (HTTP 403), поэтому автоматическая сборка не прошла.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4822fa700832daf046a88ca307f81)