### PR TITLE
frontend: unify source plan error handling

### DIFF
--- a/frontend/src/app/features/source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.ts
+++ b/frontend/src/app/features/source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.ts
@@ -129,8 +129,8 @@ export class InstrumentSourcePlanAdminComponent implements OnInit {
       next: plans => {
         this.dataSource.data = plans;
       },
-      error: () => {
-        this.snack.open('Load source plans failed', 'Close');
+      error: err => {
+        this.snack.open(this.resolveErrorMessage(err, 'Load source plans failed'), 'Close');
       }
     });
   }
@@ -142,8 +142,8 @@ export class InstrumentSourcePlanAdminComponent implements OnInit {
         this.instruments = options.instruments;
         this.providers = options.providers;
       },
-      error: () => {
-        this.snack.open('Load options failed', 'Close');
+      error: err => {
+        this.snack.open(this.resolveErrorMessage(err, 'Load options failed'), 'Close');
       }
     });
   }
@@ -184,7 +184,7 @@ export class InstrumentSourcePlanAdminComponent implements OnInit {
         }
       },
       error: err => {
-        this.snack.open(err.error?.message ?? err.message ?? 'Load plan failed', 'Close');
+        this.snack.open(this.resolveErrorMessage(err, 'Load plan failed'), 'Close');
       }
     });
   }
@@ -208,11 +208,7 @@ export class InstrumentSourcePlanAdminComponent implements OnInit {
         this.locked = false;
       },
       error: err => {
-        const msg = err.error?.message ?? err.message ?? 'Create failed';
-        const ref = this.snack.open(msg, 'Close', { duration: 0 });
-        ref.afterDismissed().subscribe(() => {
-          this.locked = false;
-        });
+        this.unlockAfterError(err, 'Create failed');
       }
     });
   }
@@ -234,11 +230,7 @@ export class InstrumentSourcePlanAdminComponent implements OnInit {
         this.locked = false;
       },
       error: err => {
-        const msg = err.error?.message ?? err.message ?? 'Replace failed';
-        const ref = this.snack.open(msg, 'Close', { duration: 0 });
-        ref.afterDismissed().subscribe(() => {
-          this.locked = false;
-        });
+        this.unlockAfterError(err, 'Replace failed');
       }
     });
   }
@@ -309,8 +301,48 @@ export class InstrumentSourcePlanAdminComponent implements OnInit {
         }
       },
       error: err => {
-        this.snack.open(err.error?.message ?? err.message ?? 'Delete failed', 'Close');
+        this.snack.open(this.resolveErrorMessage(err, 'Delete failed'), 'Close');
       }
     });
+  }
+
+  /* Единая обработка ошибки с разблокировкой действий после закрытия уведомления. */
+  private unlockAfterError(err: unknown, fallback: string): void {
+    const ref = this.snack.open(this.resolveErrorMessage(err, fallback), 'Close', { duration: 0 });
+    ref.afterDismissed().subscribe(() => {
+      this.locked = false;
+    });
+  }
+
+  /* Единая утилита извлечения текста ошибки из ProblemDetail и стандартного HttpErrorResponse. */
+  private resolveErrorMessage(err: unknown, fallback: string): string {
+    if (!err || typeof err !== 'object') {
+      return fallback;
+    }
+
+    const body = (err as { error?: unknown }).error;
+    if (body && typeof body === 'object') {
+      const detail = (body as { detail?: unknown }).detail;
+      if (typeof detail === 'string' && detail.trim().length > 0) {
+        return detail;
+      }
+
+      const title = (body as { title?: unknown }).title;
+      if (typeof title === 'string' && title.trim().length > 0) {
+        return title;
+      }
+
+      const message = (body as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim().length > 0) {
+        return message;
+      }
+    }
+
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+
+    return fallback;
   }
 }


### PR DESCRIPTION
### Motivation
- Сделать обработку ошибок на странице администрирования `instrument-source-plan` единообразной и информативной вместо разбросанных `err.error?.message` веток.
- Упростить повторяющуюся логику разблокировки UI после ошибок и уменьшить дублирование кода.

### Description
- Заменил локальные ad-hoc ветки ошибки в `frontend/src/app/features/source_plan/pages/instrument-source-plan-admin/instrument-source-plan-admin.component.ts` на вызовы единой утилиты `resolveErrorMessage` для `refreshList`, `loadOptions`, `onLoadPlan` и `deletePlan`.
- Вынес повторяющуюся логику показа snackbar и разблокировки в хелпер `unlockAfterError` и применил его в `onCreate` и `onSave` вместо ручного кода разблокировки.
- Добавил реализацию `resolveErrorMessage`, которая извлекает понятный текст из `ProblemDetail` (`detail`, `title`) и из распространённых полей `message` с заданным `fallback`.
- Упрощена и выровнена семантика сообщений об ошибках по всем основным операциям страницы (`list`, `options`, `load`, `create`, `replace`, `delete`).

### Testing
- Запущена сборка: `cd frontend && npm run build` — прошла успешно.
- Запущены unit/browser-тесты: `cd frontend && npm run test -- --watch=false --browsers=ChromeHeadless` — не прошли в этой среде из-за отсутствия бинарника ChromeHeadless (`No binary for ChromeHeadless browser on your platform.`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48653b2ac832d96e451c9490105ec)