### PR TITLE
frontend: improve provider passport list error handling, stable sorting and minor UI cleanup

### DIFF
--- a/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
+++ b/frontend/src/app/features/currency/pages/currency-admin/currency-admin.component.ts
@@ -218,7 +218,6 @@ export class CurrencyAdminComponent implements OnInit {
   }
 
 
-
   /* Утилита: извлекаем текст ошибки из стандартного ответа Spring ProblemDetail. */
   private resolveErrorMessage(err: unknown, fallback: string): string {
     if (!err || typeof err !== 'object') {

--- a/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
+++ b/frontend/src/app/features/provider_passport/pages/passport-list/passport-list.component.ts
@@ -2,13 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { ProviderPassportService } from '../../services/provider-passport.service';
 import { ProviderDto } from '../../models/provider-dto.model';
 
 @Component({
   selector: 'app-provider-passport-list',
   standalone: true,
-  imports: [CommonModule, MatTableModule, MatCardModule],
+  imports: [CommonModule, MatTableModule, MatCardModule, MatSnackBarModule],
   templateUrl: './passport-list.component.html',
   styleUrl: './passport-list.component.scss'
 })
@@ -25,7 +26,10 @@ export class PassportListComponent implements OnInit {
   /* Источник данных для таблицы. */
   dataSource = new MatTableDataSource<ProviderDto>([]);
 
-  constructor(private readonly service: ProviderPassportService) {}
+  constructor(
+    private readonly service: ProviderPassportService,
+    private readonly snack: MatSnackBar
+  ) {}
 
   /* Загрузка списка при открытии страницы. */
   ngOnInit(): void {
@@ -36,11 +40,40 @@ export class PassportListComponent implements OnInit {
   private refresh(): void {
     this.service.list().subscribe({
       next: list => {
-        this.dataSource.data = list;
+        this.dataSource.data = [...list].sort((left, right) =>
+          left.providerCode.localeCompare(right.providerCode, 'en', { sensitivity: 'base' })
+        );
       },
       error: err => {
-        console.error(err);
+        this.snack.open(this.resolveErrorMessage(err, 'Load provider passports failed'), 'Close');
       }
     });
+  }
+
+  /* Извлекаем текст ошибки из стандартного HttpErrorResponse/ProblemDetail. */
+  private resolveErrorMessage(err: unknown, fallback: string): string {
+    if (!err || typeof err !== 'object') {
+      return fallback;
+    }
+
+    const body = (err as { error?: unknown }).error;
+    if (body && typeof body === 'object') {
+      const detail = (body as { detail?: unknown }).detail;
+      if (typeof detail === 'string' && detail.trim().length > 0) {
+        return detail;
+      }
+
+      const title = (body as { title?: unknown }).title;
+      if (typeof title === 'string' && title.trim().length > 0) {
+        return title;
+      }
+    }
+
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+
+    return fallback;
   }
 }

--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -1,3 +1,3 @@
 <div class="center-box">
-  <h1 class="mat-headline-3">AlligatorFX-market</h1>
+  <h1 class="mat-headline-3">Alligator Market</h1>
 </div>


### PR DESCRIPTION
### Motivation
- Устранить явный шум и непредсказуемое поведение в frontend: показать пользователю понятные ошибки вместо `console.error`, зафиксировать порядок таблицы паспортов провайдеров и убрать мелкий визуальный шум на главной странице.

### Description
- В `passport-list` добавлен `MatSnackBar` и заменён `console.error` на пользовательский snackbar с универсальной функцией извлечения сообщения из `ProblemDetail`/`HttpErrorResponse` (`resolveErrorMessage`).
- В `passport-list` реализована стабильная сортировка записей по `providerCode` через `localeCompare` для предсказуемого порядка строк в таблице.
- Исправлен заголовок на главной странице с `AlligatorFX-market` на `Alligator Market` для единообразия UI текста.
- Убрана лишняя пустая строка/визуальный шум в файле `currency-admin` без изменения логики.

### Testing
- Сборка фронтенда выполнена командой `npm run build` и прошла успешно.
- Тесты запущены командой `npm test -- --watch=false --browsers=ChromeHeadless` завершились ошибкой из-за отсутствия бинарника ChromeHeadless в окружении, поэтому unit-тесты не были выполнены здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4884ade2c832db03d985dba936e14)