### PR TITLE
Remove JPA/Hibernate traces; use PostgreSQL driver for DB constraint detection

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,12 +28,6 @@
             <artifactId>market-domain</artifactId>
         </dependency>
 
-        <!-- JPA и работа с БД -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-
         <!-- Runtime-интеграция jOOQ со Spring Boot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrors.java
+++ b/backend/src/main/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrors.java
@@ -1,6 +1,7 @@
 package com.alligator.market.backend.common.persistence.constraint;
 
-import org.hibernate.exception.ConstraintViolationException;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -63,17 +64,18 @@ public final class DbConstraintErrors {
         // 2) Обходим cause-цепочку исключения
         for (Throwable t = ex; t != null && visited.add(t); t = t.getCause()) {
 
-            // 3.1) "Идеальный" вариант – Hibernate смог поймать и обернуть исключение в ConstraintViolationException.
-            //      Тогда извлекаем имя ConstraintViolationException и сравниваем с needle.
-            if (t instanceof ConstraintViolationException cve) {
-                final String name = cve.getConstraintName();
+            // 3.1) Предпочтительный вариант для PostgreSQL+jOOQ:
+            //      драйвер пробрасывает PSQLException, где имя ограничения доступно структурно.
+            if (t instanceof PSQLException psqlEx) {
+                final ServerErrorMessage serverErrorMessage = psqlEx.getServerErrorMessage();
+                final String name = serverErrorMessage == null ? null : serverErrorMessage.getConstraint();
                 if (name != null && name.strip().equalsIgnoreCase(needle)) {
                     return true;
-                    // Сразу же выходим, так как это "идеальный" вариант
+                    // Сразу же выходим, так как это приоритетный структурный вариант
                 }
             }
 
-            // 3.2) "Fallback" вариант – некоторые драйверы/диалекты/обёртки не пробрасывают имя ограничения
+            // 3.2) Fallback-вариант – некоторые драйверы/диалекты/обёртки не пробрасывают имя ограничения
             //      в getConstraintName(), но включают его в текст сообщения. Тогда ищем needle в сообщениях причин.
             if (!matchedByMessage && containsIgnoreCase(t.getMessage(), needle)) {
                 matchedByMessage = true; // <-- Фиксируем, что вариант "fallback" сработал.

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,7 +8,6 @@ spring.application.name=backend
 # ===============================
 app.time.business-zone-id=Europe/Moscow
 spring.jackson.time-zone=UTC
-spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 
 # ===============================
 # DATABASE CONNECTION
@@ -22,13 +21,6 @@ spring.datasource.password=1234
 # SQL INIT
 # ===============================
 spring.sql.init.mode=never
-
-# ===============================
-# JPA / HIBERNATE
-# ===============================
-spring.jpa.open-in-view=false
-spring.jpa.generate-ddl=false
-spring.jpa.hibernate.ddl-auto=validate
 
 # ===============================
 # LOGGING CONFIGURATION

--- a/backend/src/test/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrorsTest.java
+++ b/backend/src/test/java/com/alligator/market/backend/common/persistence/constraint/DbConstraintErrorsTest.java
@@ -1,10 +1,9 @@
 package com.alligator.market.backend.common.persistence.constraint;
 
-import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
-import java.sql.SQLException;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -19,16 +18,16 @@ class DbConstraintErrorsTest {
 
     /**
      * Должен вернуть true так как это “идеальный” вариант алгоритма:
-     * в cause-цепочке есть Hibernate {@link ConstraintViolationException},
-     * и имя ограничения доступно через {@link ConstraintViolationException#getConstraintName()}.
+     * в cause-цепочке есть PostgreSQL {@link PSQLException},
+     * и имя ограничения доступно через {@link ServerErrorMessage#getConstraint()}.
      */
     @Test
-    void shouldDetectByHibernateConstraintName() {
-        SQLException sqlEx = new SQLException("duplicate key");
-        ConstraintViolationException cve =
-                new ConstraintViolationException("violated", sqlEx, "uq_some_column");
-
-        RuntimeException ex = new RuntimeException("wrap", cve);
+    void shouldDetectByPostgresConstraintName() {
+        PSQLException psqlEx = new PSQLException(
+                new ServerErrorMessage("ERROR: duplicate key value violates unique constraint \"uq_some_column\""),
+                true
+        );
+        RuntimeException ex = new RuntimeException("wrap", psqlEx);
 
         assertTrue(DbConstraintErrors.isViolationOf(ex, "UQ_SOME_COLUMN")); // <-- Заглавными буквами для проверки, что регистр не влияет
     }
@@ -46,7 +45,7 @@ class DbConstraintErrorsTest {
     }
 
     /**
-     * Должен вернуть false так как имя ограничения не встречается ни в {@link ConstraintViolationException#getConstraintName()},
+     * Должен вернуть false так как имя ограничения не встречается ни в {@link ServerErrorMessage#getConstraint()},
      * ни в сообщениях исключений в cause-цепочке.
      */
     @Test


### PR DESCRIPTION
### Motivation
- Убрать остаточные зависимости и настройки JPA/Hibernate из backend, чтобы модуль полностью использовал jOOQ.
- Сделать обработку ошибок нарушений ограничений БД более нативной для PostgreSQL+jOOQ, используя структурные поля драйвера вместо Hibernate-специфичных исключений.

### Description
- Удалён `spring-boot-starter-data-jpa` из `backend/pom.xml` и оставлен jOOQ-стек (`spring-boot-starter-jooq`).
- Удалены JPA/Hibernate-свойства из `backend/src/main/resources/application.properties` (`spring.jpa.*` и связанные настройки времени через Hibernate).
- Переписан `DbConstraintErrors.isViolationOf(...)` в `backend/src/main/java/.../DbConstraintErrors.java` для распознавания имени ограничения через `PSQLException` / `ServerErrorMessage#getConstraint` и сохранён fallback на поиск по тексту сообщения.
- Обновлены unit-тесты `DbConstraintErrorsTest` под новую реализацию, заменив имитацию `ConstraintViolationException` на `PSQLException`/`ServerErrorMessage`.

### Testing
- Выполнен поисковый запрос `rg` по коду на следы JPA/Hibernate и `spring.jpa`, совпадений после правок не найдено (успешно).
- Попытка запустить `mvn -pl backend -Dtest=DbConstraintErrorsTest test` завершилась неуспешно из-за невозможности загрузить parent POM из Maven Central (HTTP 403) в этом окружении, поэтому unit-тесты не были выполнены локально.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f488ab3ff8832da481c9c7ad0180bd)